### PR TITLE
rename `MAESTRO_ARTIFACT_PATH` to `MAESTRO_CACHE`

### DIFF
--- a/packages/maestro_cli/README.md
+++ b/packages/maestro_cli/README.md
@@ -40,7 +40,7 @@ directories to PATH:
 
 On first run, `maestro` will download artifacts it needs to the _artifact path_.
 By default it is `$HOME/.maestro`, but you can change it by setting
-`MAESTRO_ARTIFACT_PATH` environment variable.
+`MAESTRO_CACHE` environment variable.
 
 To learn about commands, run:
 

--- a/packages/maestro_cli/lib/src/common/paths.dart
+++ b/packages/maestro_cli/lib/src/common/paths.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:maestro_cli/src/common/common.dart';
 import 'package:path/path.dart' as path;
 
-const maestroArtifactPathEnv = 'MAESTRO_ARTIFACT_PATH';
+const maestroArtifactPathEnv = 'MAESTRO_CACHE';
 
 String get serverArtifact => 'server-$version';
 String get instrumentationArtifact => 'instrumentation-$version';


### PR DESCRIPTION
So it matches other common tools, like [mason](https://github.com/felangel/mason/issues/402).