### PR TITLE
fix/maestrofinder text

### DIFF
--- a/packages/maestro_test/lib/src/custom_finders/maestro_finder.dart
+++ b/packages/maestro_test/lib/src/custom_finders/maestro_finder.dart
@@ -120,12 +120,32 @@ class MaestroFinder extends MatchFinder {
     await tester.performPump(andSettle);
   }
 
-  /// If this [MaestroFinder] matches a [Text] widget, then this method returns
-  /// its data.
+  /// If the first widget resolved by this [MaestroFinder] matches a [Text]
+  /// widget, then this method returns its data. Otherwise it throws an
+  /// exception.
   ///
-  /// Otherwise it throws an error.
+  /// If you want to make sure that the Text widget is visible, first use
+  /// [visible] method:
+  ///
+  /// ```dart
+  /// expect(await $(Key('Sign in Button')).visible.text, 'Sign in');
+  /// ```
   String? get text {
-    return (finder.hitTestable().evaluate().first.widget as Text).data;
+    final elements = finder.evaluate();
+    if (elements.isEmpty) {
+      throw MaestroFinderFoundNothingException(finder: this);
+    }
+
+    final firstWidget = elements.first.widget;
+
+    if (firstWidget is! Text) {
+      throw Exception(
+        'The first ${firstWidget.runtimeType} widget resolved by this finder '
+        'is not a Text widget',
+      );
+    }
+
+    return firstWidget.data;
   }
 
   /// Shorthand for [MaestroFinder.resolve].

--- a/packages/maestro_test/test/custom_selectors_test.dart
+++ b/packages/maestro_test/test/custom_selectors_test.dart
@@ -209,7 +209,7 @@ void main() {
     });
 
     maestroTest(
-      'finds only hit testable',
+      'visible() throws exception when widget is not hit testable',
       ($) async {
         await pumpWithOverlays($);
 
@@ -223,6 +223,30 @@ void main() {
       findTimeout: const Duration(milliseconds: 300),
     );
   });
+
+  maestroTest('text returns the nearest visible Text widget (1)', ($) async {
+    await smallPump($);
+
+    expect($(#helloText), findsOneWidget);
+    expect($(#helloText).text, 'Hello');
+  });
+
+  maestroTest('text returns the nearest visible Text widget (2)', ($) async {
+    await pumpWithOverlays($);
+
+    expect($(#visibleText), findsOneWidget);
+    expect($(#hiddenText), findsOneWidget);
+
+    expect($(#visibleText).text, 'visible boi');
+    expect(
+      () => $(#hiddenBoi).text,
+      throwsA(isA<MaestroFinderFoundNothingException>()),
+    );
+    expect(
+      () => $(#hiddenBoiButWrongKey).text,
+      throwsA(isA<MaestroFinderFoundNothingException>()),
+    );
+  });
 }
 
 Future<void> smallPump(MaestroTester $) async {
@@ -231,7 +255,7 @@ Future<void> smallPump(MaestroTester $) async {
       home: Row(
         children: const [
           Icon(Icons.front_hand),
-          Text('Hello'),
+          Text('Hello', key: Key('helloText')),
         ],
       ),
     ),
@@ -280,9 +304,7 @@ Future<void> pumpWithOverlays(MaestroTester $) async {
       home: Scaffold(
         body: Stack(
           children: [
-            const Center(
-              child: Text('hidden boi'),
-            ),
+            const Center(child: Text('hidden boi', key: Key('hiddenText'))),
             Center(
               child: Container(
                 width: 150,
@@ -290,6 +312,7 @@ Future<void> pumpWithOverlays(MaestroTester $) async {
                 color: Colors.blue,
               ),
             ),
+            const Text('visible boi', key: Key('visibleText')),
           ],
         ),
       ),


### PR DESCRIPTION
- make `MaestroFinder.text` only find visible texts
- make `MaestroFinder.text` method more pleasant to use
