### PR TITLE
Don't suppress a11y services when `AutomatorServer` is running on Android

### DIFF
--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/MaestroAutomator.kt
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/MaestroAutomator.kt
@@ -1,5 +1,6 @@
 package pl.leancode.automatorserver
 
+import android.app.UiAutomation
 import android.os.SystemClock
 import android.widget.EditText
 import androidx.test.platform.app.InstrumentationRegistry
@@ -53,6 +54,8 @@ class MaestroAutomator {
         configurator.waitForSelectorTimeout = 5000
         configurator.waitForIdleTimeout = 5000
         configurator.keyInjectionDelay = 50
+
+        Configurator.getInstance().uiAutomationFlags = UiAutomation.FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES
 
         Logger.i("Android UiAutomator configuration:")
         Logger.i("\twaitForSelectorTimeout: ${configurator.waitForSelectorTimeout} ms")


### PR DESCRIPTION
This is basically #218, but #218 was more about debugging and research, and it's faster to create a new PR with the fix.

