### PR TITLE
Release new versions: patrol-v0.6.8, patrol_cli-v0.6.9

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.8
+
+- Fix handling permission prompts now working in some edge cases (#383)
+
 ## 0.6.7+1
 
 - Fix package score on pub.dev (#375)

--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -2,7 +2,7 @@ name: patrol
 description: >
   Simple yet powerful Flutter-native UI testing framework eliminating
   limitations of flutter_test, integration_test, and flutter_driver.
-version: 0.6.7+1
+version: 0.6.8
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.9
+
+- Fix handling permission prompts now working in some edge cases (#383)
+
 ## 0.6.8
 
 - Improve update prompt (#377)

--- a/packages/patrol_cli/lib/src/common/constants.dart
+++ b/packages/patrol_cli/lib/src/common/constants.dart
@@ -1,7 +1,7 @@
 import 'package:path/path.dart' as path;
 
 /// Version of Patrol CLI. Must be kept in sync with pubspec.yaml.
-const version = '0.6.8';
+const version = '0.6.9';
 
 const patrolPackage = 'patrol';
 const patrolCliPackage = 'patrol_cli';

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: patrol_cli
 description: >
   Command-line tool for Patrol, a powerful Flutter-native UI testing framework.
-version: 0.6.8
+version: 0.6.9
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues


### PR DESCRIPTION
- patrol: bump version to 0.6.8
- patrol_cli: bump version to 0.6.9
