### PR TITLE
Implement `tapOnNotificationByIndex` and `tapOnNotificationBySelector` on iOS

### DIFF
--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/PatrolAutomator.kt
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/PatrolAutomator.kt
@@ -250,8 +250,6 @@ class PatrolAutomator private constructor() {
     fun getNotifications(): List<Contracts.Notification> {
         Logger.d("getNotifications()")
 
-        openNotifications()
-
         val notificationContainers = mutableListOf<UiObject2>()
         val identifiers = listOf(
             "android:id/status_bar_latest_event_content", // notification not bundled

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/Contracts.java
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/Contracts.java
@@ -17033,7 +17033,7 @@ public final class Contracts {
       "\t\022&\n\010children\030\t \003(\0132\024.patrol.NativeWidge" +
       "t\"]\n\014Notification\022\024\n\007appName\030\001 \001(\tH\000\210\001\001\022" +
       "\r\n\005title\030\002 \001(\t\022\017\n\007content\030\003 \001(\t\022\013\n\003raw\030\004" +
-      " \001(\tB\n\n\010_appName2\240\r\n\017NativeAutomator\022+\n\t" +
+      " \001(\tB\n\n\010_appName2\334\r\n\017NativeAutomator\022+\n\t" +
       "pressHome\022\r.patrol.Empty\032\r.patrol.Empty\"" +
       "\000\022+\n\tpressBack\022\r.patrol.Empty\032\r.patrol.E" +
       "mpty\"\000\0221\n\017pressRecentApps\022\r.patrol.Empty" +
@@ -17067,17 +17067,18 @@ public final class Contracts {
       "patrol.Empty\"\000\0223\n\021openNotifications\022\r.pa" +
       "trol.Empty\032\r.patrol.Empty\"\000\0224\n\022closeNoti" +
       "fications\022\r.patrol.Empty\032\r.patrol.Empty\"" +
-      "\000\022W\n\020getNotifications\022\037.patrol.GetNotifi" +
-      "cationsRequest\032 .patrol.GetNotifications" +
-      "Response\"\000\022F\n\021tapOnNotification\022 .patrol" +
-      ".TapOnNotificationRequest\032\r.patrol.Empty" +
-      "\"\000\022J\n\026handlePermissionDialog\022\037.patrol.Ha" +
-      "ndlePermissionRequest\032\r.patrol.Empty\"\000\022J" +
-      "\n\023setLocationAccuracy\022\".patrol.SetLocati" +
-      "onAccuracyRequest\032\r.patrol.Empty\"\000\022\'\n\005de" +
-      "bug\022\r.patrol.Empty\032\r.patrol.Empty\"\000B\'\n%p" +
-      "l.leancode.automatorserver.contractsb\006pr" +
-      "oto3"
+      "\000\022:\n\030closeHeadsUpNotification\022\r.patrol.E" +
+      "mpty\032\r.patrol.Empty\"\000\022W\n\020getNotification" +
+      "s\022\037.patrol.GetNotificationsRequest\032 .pat" +
+      "rol.GetNotificationsResponse\"\000\022F\n\021tapOnN" +
+      "otification\022 .patrol.TapOnNotificationRe" +
+      "quest\032\r.patrol.Empty\"\000\022J\n\026handlePermissi" +
+      "onDialog\022\037.patrol.HandlePermissionReques" +
+      "t\032\r.patrol.Empty\"\000\022J\n\023setLocationAccurac" +
+      "y\022\".patrol.SetLocationAccuracyRequest\032\r." +
+      "patrol.Empty\"\000\022\'\n\005debug\022\r.patrol.Empty\032\r" +
+      ".patrol.Empty\"\000B\'\n%pl.leancode.automator" +
+      "server.contractsb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/Contracts.java
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/Contracts.java
@@ -7753,17 +7753,17 @@ public final class Contracts {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>.patrol.Selector Selector = 1;</code>
+     * <code>.patrol.Selector selector = 1;</code>
      * @return Whether the selector field is set.
      */
     boolean hasSelector();
     /**
-     * <code>.patrol.Selector Selector = 1;</code>
+     * <code>.patrol.Selector selector = 1;</code>
      * @return The selector.
      */
     pl.leancode.automatorserver.contracts.Contracts.Selector getSelector();
     /**
-     * <code>.patrol.Selector Selector = 1;</code>
+     * <code>.patrol.Selector selector = 1;</code>
      */
     pl.leancode.automatorserver.contracts.Contracts.SelectorOrBuilder getSelectorOrBuilder();
 
@@ -7881,7 +7881,7 @@ public final class Contracts {
     public static final int SELECTOR_FIELD_NUMBER = 1;
     private pl.leancode.automatorserver.contracts.Contracts.Selector selector_;
     /**
-     * <code>.patrol.Selector Selector = 1;</code>
+     * <code>.patrol.Selector selector = 1;</code>
      * @return Whether the selector field is set.
      */
     @java.lang.Override
@@ -7889,7 +7889,7 @@ public final class Contracts {
       return selector_ != null;
     }
     /**
-     * <code>.patrol.Selector Selector = 1;</code>
+     * <code>.patrol.Selector selector = 1;</code>
      * @return The selector.
      */
     @java.lang.Override
@@ -7897,7 +7897,7 @@ public final class Contracts {
       return selector_ == null ? pl.leancode.automatorserver.contracts.Contracts.Selector.getDefaultInstance() : selector_;
     }
     /**
-     * <code>.patrol.Selector Selector = 1;</code>
+     * <code>.patrol.Selector selector = 1;</code>
      */
     @java.lang.Override
     public pl.leancode.automatorserver.contracts.Contracts.SelectorOrBuilder getSelectorOrBuilder() {
@@ -8278,14 +8278,14 @@ public final class Contracts {
       private com.google.protobuf.SingleFieldBuilderV3<
           pl.leancode.automatorserver.contracts.Contracts.Selector, pl.leancode.automatorserver.contracts.Contracts.Selector.Builder, pl.leancode.automatorserver.contracts.Contracts.SelectorOrBuilder> selectorBuilder_;
       /**
-       * <code>.patrol.Selector Selector = 1;</code>
+       * <code>.patrol.Selector selector = 1;</code>
        * @return Whether the selector field is set.
        */
       public boolean hasSelector() {
         return selectorBuilder_ != null || selector_ != null;
       }
       /**
-       * <code>.patrol.Selector Selector = 1;</code>
+       * <code>.patrol.Selector selector = 1;</code>
        * @return The selector.
        */
       public pl.leancode.automatorserver.contracts.Contracts.Selector getSelector() {
@@ -8296,7 +8296,7 @@ public final class Contracts {
         }
       }
       /**
-       * <code>.patrol.Selector Selector = 1;</code>
+       * <code>.patrol.Selector selector = 1;</code>
        */
       public Builder setSelector(pl.leancode.automatorserver.contracts.Contracts.Selector value) {
         if (selectorBuilder_ == null) {
@@ -8312,7 +8312,7 @@ public final class Contracts {
         return this;
       }
       /**
-       * <code>.patrol.Selector Selector = 1;</code>
+       * <code>.patrol.Selector selector = 1;</code>
        */
       public Builder setSelector(
           pl.leancode.automatorserver.contracts.Contracts.Selector.Builder builderForValue) {
@@ -8326,7 +8326,7 @@ public final class Contracts {
         return this;
       }
       /**
-       * <code>.patrol.Selector Selector = 1;</code>
+       * <code>.patrol.Selector selector = 1;</code>
        */
       public Builder mergeSelector(pl.leancode.automatorserver.contracts.Contracts.Selector value) {
         if (selectorBuilder_ == null) {
@@ -8344,7 +8344,7 @@ public final class Contracts {
         return this;
       }
       /**
-       * <code>.patrol.Selector Selector = 1;</code>
+       * <code>.patrol.Selector selector = 1;</code>
        */
       public Builder clearSelector() {
         if (selectorBuilder_ == null) {
@@ -8358,7 +8358,7 @@ public final class Contracts {
         return this;
       }
       /**
-       * <code>.patrol.Selector Selector = 1;</code>
+       * <code>.patrol.Selector selector = 1;</code>
        */
       public pl.leancode.automatorserver.contracts.Contracts.Selector.Builder getSelectorBuilder() {
         
@@ -8366,7 +8366,7 @@ public final class Contracts {
         return getSelectorFieldBuilder().getBuilder();
       }
       /**
-       * <code>.patrol.Selector Selector = 1;</code>
+       * <code>.patrol.Selector selector = 1;</code>
        */
       public pl.leancode.automatorserver.contracts.Contracts.SelectorOrBuilder getSelectorOrBuilder() {
         if (selectorBuilder_ != null) {
@@ -8377,7 +8377,7 @@ public final class Contracts {
         }
       }
       /**
-       * <code>.patrol.Selector Selector = 1;</code>
+       * <code>.patrol.Selector selector = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           pl.leancode.automatorserver.contracts.Contracts.Selector, pl.leancode.automatorserver.contracts.Contracts.Selector.Builder, pl.leancode.automatorserver.contracts.Contracts.SelectorOrBuilder> 
@@ -16998,7 +16998,7 @@ public final class Contracts {
       "ol.NativeWidget\"\031\n\027GetNotificationsReque" +
       "st\"G\n\030GetNotificationsResponse\022+\n\rnotifi" +
       "cations\030\001 \003(\0132\024.patrol.Notification\"?\n\nT" +
-      "apRequest\022\"\n\010Selector\030\001 \001(\0132\020.patrol.Sel" +
+      "apRequest\022\"\n\010selector\030\001 \001(\0132\020.patrol.Sel" +
       "ector\022\r\n\005appId\030\002 \001(\t\"p\n\020EnterTextRequest" +
       "\022\014\n\004data\030\001 \001(\t\022\r\n\005appId\030\002 \001(\t\022\017\n\005index\030\003" +
       " \001(\rH\000\022$\n\010selector\030\004 \001(\0132\020.patrol.Select" +
@@ -17041,29 +17041,29 @@ public final class Contracts {
       "ps\022\r.patrol.Empty\032\r.patrol.Empty\"\000\0222\n\007op" +
       "enApp\022\026.patrol.OpenAppRequest\032\r.patrol.E" +
       "mpty\"\000\022F\n\021openQuickSettings\022 .patrol.Ope" +
-      "nQuickSettingsRequest\032\r.patrol.Empty\"\000\022B" +
-      "\n\022enableAirplaneMode\022\033.patrol.AirplaneMo" +
-      "deRequest\032\r.patrol.Empty\"\000\022C\n\023disableAir" +
-      "planeMode\022\033.patrol.AirplaneModeRequest\032\r" +
-      ".patrol.Empty\"\000\0222\n\nenableWiFi\022\023.patrol.W" +
-      "iFiRequest\032\r.patrol.Empty\"\000\0223\n\013disableWi" +
-      "Fi\022\023.patrol.WiFiRequest\032\r.patrol.Empty\"\000" +
-      "\022:\n\016enableCellular\022\027.patrol.CellularRequ" +
-      "est\032\r.patrol.Empty\"\000\022;\n\017disableCellular\022" +
-      "\027.patrol.CellularRequest\032\r.patrol.Empty\"" +
-      "\000\022<\n\017enableBluetooth\022\030.patrol.BluetoothR" +
-      "equest\032\r.patrol.Empty\"\000\022=\n\020disableBlueto" +
-      "oth\022\030.patrol.BluetoothRequest\032\r.patrol.E" +
-      "mpty\"\000\022:\n\016enableDarkMode\022\027.patrol.DarkMo" +
-      "deRequest\032\r.patrol.Empty\"\000\022;\n\017disableDar" +
-      "kMode\022\027.patrol.DarkModeRequest\032\r.patrol." +
-      "Empty\"\000\022W\n\020getNativeWidgets\022\037.patrol.Get" +
-      "NativeWidgetsRequest\032 .patrol.GetNativeW" +
-      "idgetsResponse\"\000\022*\n\003tap\022\022.patrol.TapRequ" +
-      "est\032\r.patrol.Empty\"\000\0220\n\tdoubleTap\022\022.patr" +
-      "ol.TapRequest\032\r.patrol.Empty\"\000\0226\n\tenterT" +
-      "ext\022\030.patrol.EnterTextRequest\032\r.patrol.E" +
-      "mpty\"\000\022.\n\005swipe\022\024.patrol.SwipeRequest\032\r." +
+      "nQuickSettingsRequest\032\r.patrol.Empty\"\000\022W" +
+      "\n\020getNativeWidgets\022\037.patrol.GetNativeWid" +
+      "getsRequest\032 .patrol.GetNativeWidgetsRes" +
+      "ponse\"\000\022*\n\003tap\022\022.patrol.TapRequest\032\r.pat" +
+      "rol.Empty\"\000\0220\n\tdoubleTap\022\022.patrol.TapReq" +
+      "uest\032\r.patrol.Empty\"\000\0226\n\tenterText\022\030.pat" +
+      "rol.EnterTextRequest\032\r.patrol.Empty\"\000\022.\n" +
+      "\005swipe\022\024.patrol.SwipeRequest\032\r.patrol.Em" +
+      "pty\"\000\022B\n\022enableAirplaneMode\022\033.patrol.Air" +
+      "planeModeRequest\032\r.patrol.Empty\"\000\022C\n\023dis" +
+      "ableAirplaneMode\022\033.patrol.AirplaneModeRe" +
+      "quest\032\r.patrol.Empty\"\000\0222\n\nenableWiFi\022\023.p" +
+      "atrol.WiFiRequest\032\r.patrol.Empty\"\000\0223\n\013di" +
+      "sableWiFi\022\023.patrol.WiFiRequest\032\r.patrol." +
+      "Empty\"\000\022:\n\016enableCellular\022\027.patrol.Cellu" +
+      "larRequest\032\r.patrol.Empty\"\000\022;\n\017disableCe" +
+      "llular\022\027.patrol.CellularRequest\032\r.patrol" +
+      ".Empty\"\000\022<\n\017enableBluetooth\022\030.patrol.Blu" +
+      "etoothRequest\032\r.patrol.Empty\"\000\022=\n\020disabl" +
+      "eBluetooth\022\030.patrol.BluetoothRequest\032\r.p" +
+      "atrol.Empty\"\000\022:\n\016enableDarkMode\022\027.patrol" +
+      ".DarkModeRequest\032\r.patrol.Empty\"\000\022;\n\017dis" +
+      "ableDarkMode\022\027.patrol.DarkModeRequest\032\r." +
       "patrol.Empty\"\000\0223\n\021openNotifications\022\r.pa" +
       "trol.Empty\032\r.patrol.Empty\"\000\0224\n\022closeNoti" +
       "fications\022\r.patrol.Empty\032\r.patrol.Empty\"" +

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/Contracts.java
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/Contracts.java
@@ -15850,6 +15850,18 @@ public final class Contracts {
      */
     com.google.protobuf.ByteString
         getContentBytes();
+
+    /**
+     * <code>string raw = 4;</code>
+     * @return The raw.
+     */
+    java.lang.String getRaw();
+    /**
+     * <code>string raw = 4;</code>
+     * @return The bytes for raw.
+     */
+    com.google.protobuf.ByteString
+        getRawBytes();
   }
   /**
    * <pre>
@@ -15871,6 +15883,7 @@ public final class Contracts {
       appName_ = "";
       title_ = "";
       content_ = "";
+      raw_ = "";
     }
 
     @java.lang.Override
@@ -15920,6 +15933,12 @@ public final class Contracts {
               java.lang.String s = input.readStringRequireUtf8();
 
               content_ = s;
+              break;
+            }
+            case 34: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              raw_ = s;
               break;
             }
             default: {
@@ -16079,6 +16098,44 @@ public final class Contracts {
       }
     }
 
+    public static final int RAW_FIELD_NUMBER = 4;
+    private volatile java.lang.Object raw_;
+    /**
+     * <code>string raw = 4;</code>
+     * @return The raw.
+     */
+    @java.lang.Override
+    public java.lang.String getRaw() {
+      java.lang.Object ref = raw_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        raw_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string raw = 4;</code>
+     * @return The bytes for raw.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getRawBytes() {
+      java.lang.Object ref = raw_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        raw_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -16102,6 +16159,9 @@ public final class Contracts {
       if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(content_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, content_);
       }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(raw_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, raw_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -16119,6 +16179,9 @@ public final class Contracts {
       }
       if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(content_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, content_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(raw_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, raw_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -16144,6 +16207,8 @@ public final class Contracts {
           .equals(other.getTitle())) return false;
       if (!getContent()
           .equals(other.getContent())) return false;
+      if (!getRaw()
+          .equals(other.getRaw())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -16163,6 +16228,8 @@ public final class Contracts {
       hash = (53 * hash) + getTitle().hashCode();
       hash = (37 * hash) + CONTENT_FIELD_NUMBER;
       hash = (53 * hash) + getContent().hashCode();
+      hash = (37 * hash) + RAW_FIELD_NUMBER;
+      hash = (53 * hash) + getRaw().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -16306,6 +16373,8 @@ public final class Contracts {
 
         content_ = "";
 
+        raw_ = "";
+
         return this;
       }
 
@@ -16340,6 +16409,7 @@ public final class Contracts {
         result.appName_ = appName_;
         result.title_ = title_;
         result.content_ = content_;
+        result.raw_ = raw_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -16400,6 +16470,10 @@ public final class Contracts {
         }
         if (!other.getContent().isEmpty()) {
           content_ = other.content_;
+          onChanged();
+        }
+        if (!other.getRaw().isEmpty()) {
+          raw_ = other.raw_;
           onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -16666,6 +16740,82 @@ public final class Contracts {
         onChanged();
         return this;
       }
+
+      private java.lang.Object raw_ = "";
+      /**
+       * <code>string raw = 4;</code>
+       * @return The raw.
+       */
+      public java.lang.String getRaw() {
+        java.lang.Object ref = raw_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          raw_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string raw = 4;</code>
+       * @return The bytes for raw.
+       */
+      public com.google.protobuf.ByteString
+          getRawBytes() {
+        java.lang.Object ref = raw_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          raw_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string raw = 4;</code>
+       * @param value The raw to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRaw(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        raw_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string raw = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearRaw() {
+        
+        raw_ = getDefaultInstance().getRaw();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string raw = 4;</code>
+       * @param value The bytes for raw to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRawBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        raw_ = value;
+        onChanged();
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -16881,52 +17031,53 @@ public final class Contracts {
       "abled\030\005 \001(\010\022\022\n\nchildCount\030\006 \001(\005\022\024\n\014resou" +
       "rceName\030\007 \001(\t\022\032\n\022applicationPackage\030\010 \001(" +
       "\t\022&\n\010children\030\t \003(\0132\024.patrol.NativeWidge" +
-      "t\"P\n\014Notification\022\024\n\007appName\030\001 \001(\tH\000\210\001\001\022" +
-      "\r\n\005title\030\002 \001(\t\022\017\n\007content\030\003 \001(\tB\n\n\010_appN" +
-      "ame2\240\r\n\017NativeAutomator\022+\n\tpressHome\022\r.p" +
-      "atrol.Empty\032\r.patrol.Empty\"\000\022+\n\tpressBac" +
-      "k\022\r.patrol.Empty\032\r.patrol.Empty\"\000\0221\n\017pre" +
-      "ssRecentApps\022\r.patrol.Empty\032\r.patrol.Emp" +
-      "ty\"\000\0227\n\025doublePressRecentApps\022\r.patrol.E" +
-      "mpty\032\r.patrol.Empty\"\000\0222\n\007openApp\022\026.patro" +
-      "l.OpenAppRequest\032\r.patrol.Empty\"\000\0223\n\021ope" +
-      "nNotifications\022\r.patrol.Empty\032\r.patrol.E" +
-      "mpty\"\000\0224\n\022closeNotifications\022\r.patrol.Em" +
-      "pty\032\r.patrol.Empty\"\000\022F\n\021openQuickSetting" +
-      "s\022 .patrol.OpenQuickSettingsRequest\032\r.pa" +
-      "trol.Empty\"\000\022B\n\022enableAirplaneMode\022\033.pat" +
-      "rol.AirplaneModeRequest\032\r.patrol.Empty\"\000" +
-      "\022C\n\023disableAirplaneMode\022\033.patrol.Airplan" +
-      "eModeRequest\032\r.patrol.Empty\"\000\0222\n\nenableW" +
-      "iFi\022\023.patrol.WiFiRequest\032\r.patrol.Empty\"" +
-      "\000\0223\n\013disableWiFi\022\023.patrol.WiFiRequest\032\r." +
-      "patrol.Empty\"\000\022:\n\016enableCellular\022\027.patro" +
-      "l.CellularRequest\032\r.patrol.Empty\"\000\022;\n\017di" +
-      "sableCellular\022\027.patrol.CellularRequest\032\r" +
-      ".patrol.Empty\"\000\022<\n\017enableBluetooth\022\030.pat" +
-      "rol.BluetoothRequest\032\r.patrol.Empty\"\000\022=\n" +
-      "\020disableBluetooth\022\030.patrol.BluetoothRequ" +
-      "est\032\r.patrol.Empty\"\000\022:\n\016enableDarkMode\022\027" +
-      ".patrol.DarkModeRequest\032\r.patrol.Empty\"\000" +
-      "\022;\n\017disableDarkMode\022\027.patrol.DarkModeReq" +
-      "uest\032\r.patrol.Empty\"\000\022W\n\020getNativeWidget" +
-      "s\022\037.patrol.GetNativeWidgetsRequest\032 .pat" +
-      "rol.GetNativeWidgetsResponse\"\000\022W\n\020getNot" +
-      "ifications\022\037.patrol.GetNotificationsRequ" +
-      "est\032 .patrol.GetNotificationsResponse\"\000\022" +
-      "*\n\003tap\022\022.patrol.TapRequest\032\r.patrol.Empt" +
-      "y\"\000\0220\n\tdoubleTap\022\022.patrol.TapRequest\032\r.p" +
-      "atrol.Empty\"\000\0226\n\tenterText\022\030.patrol.Ente" +
-      "rTextRequest\032\r.patrol.Empty\"\000\022.\n\005swipe\022\024" +
-      ".patrol.SwipeRequest\032\r.patrol.Empty\"\000\022J\n" +
-      "\026handlePermissionDialog\022\037.patrol.HandleP" +
-      "ermissionRequest\032\r.patrol.Empty\"\000\022J\n\023set" +
-      "LocationAccuracy\022\".patrol.SetLocationAcc" +
-      "uracyRequest\032\r.patrol.Empty\"\000\022F\n\021tapOnNo" +
-      "tification\022 .patrol.TapOnNotificationReq" +
-      "uest\032\r.patrol.Empty\"\000\022\'\n\005debug\022\r.patrol." +
-      "Empty\032\r.patrol.Empty\"\000B\'\n%pl.leancode.au" +
-      "tomatorserver.contractsb\006proto3"
+      "t\"]\n\014Notification\022\024\n\007appName\030\001 \001(\tH\000\210\001\001\022" +
+      "\r\n\005title\030\002 \001(\t\022\017\n\007content\030\003 \001(\t\022\013\n\003raw\030\004" +
+      " \001(\tB\n\n\010_appName2\240\r\n\017NativeAutomator\022+\n\t" +
+      "pressHome\022\r.patrol.Empty\032\r.patrol.Empty\"" +
+      "\000\022+\n\tpressBack\022\r.patrol.Empty\032\r.patrol.E" +
+      "mpty\"\000\0221\n\017pressRecentApps\022\r.patrol.Empty" +
+      "\032\r.patrol.Empty\"\000\0227\n\025doublePressRecentAp" +
+      "ps\022\r.patrol.Empty\032\r.patrol.Empty\"\000\0222\n\007op" +
+      "enApp\022\026.patrol.OpenAppRequest\032\r.patrol.E" +
+      "mpty\"\000\022F\n\021openQuickSettings\022 .patrol.Ope" +
+      "nQuickSettingsRequest\032\r.patrol.Empty\"\000\022B" +
+      "\n\022enableAirplaneMode\022\033.patrol.AirplaneMo" +
+      "deRequest\032\r.patrol.Empty\"\000\022C\n\023disableAir" +
+      "planeMode\022\033.patrol.AirplaneModeRequest\032\r" +
+      ".patrol.Empty\"\000\0222\n\nenableWiFi\022\023.patrol.W" +
+      "iFiRequest\032\r.patrol.Empty\"\000\0223\n\013disableWi" +
+      "Fi\022\023.patrol.WiFiRequest\032\r.patrol.Empty\"\000" +
+      "\022:\n\016enableCellular\022\027.patrol.CellularRequ" +
+      "est\032\r.patrol.Empty\"\000\022;\n\017disableCellular\022" +
+      "\027.patrol.CellularRequest\032\r.patrol.Empty\"" +
+      "\000\022<\n\017enableBluetooth\022\030.patrol.BluetoothR" +
+      "equest\032\r.patrol.Empty\"\000\022=\n\020disableBlueto" +
+      "oth\022\030.patrol.BluetoothRequest\032\r.patrol.E" +
+      "mpty\"\000\022:\n\016enableDarkMode\022\027.patrol.DarkMo" +
+      "deRequest\032\r.patrol.Empty\"\000\022;\n\017disableDar" +
+      "kMode\022\027.patrol.DarkModeRequest\032\r.patrol." +
+      "Empty\"\000\022W\n\020getNativeWidgets\022\037.patrol.Get" +
+      "NativeWidgetsRequest\032 .patrol.GetNativeW" +
+      "idgetsResponse\"\000\022*\n\003tap\022\022.patrol.TapRequ" +
+      "est\032\r.patrol.Empty\"\000\0220\n\tdoubleTap\022\022.patr" +
+      "ol.TapRequest\032\r.patrol.Empty\"\000\0226\n\tenterT" +
+      "ext\022\030.patrol.EnterTextRequest\032\r.patrol.E" +
+      "mpty\"\000\022.\n\005swipe\022\024.patrol.SwipeRequest\032\r." +
+      "patrol.Empty\"\000\0223\n\021openNotifications\022\r.pa" +
+      "trol.Empty\032\r.patrol.Empty\"\000\0224\n\022closeNoti" +
+      "fications\022\r.patrol.Empty\032\r.patrol.Empty\"" +
+      "\000\022W\n\020getNotifications\022\037.patrol.GetNotifi" +
+      "cationsRequest\032 .patrol.GetNotifications" +
+      "Response\"\000\022F\n\021tapOnNotification\022 .patrol" +
+      ".TapOnNotificationRequest\032\r.patrol.Empty" +
+      "\"\000\022J\n\026handlePermissionDialog\022\037.patrol.Ha" +
+      "ndlePermissionRequest\032\r.patrol.Empty\"\000\022J" +
+      "\n\023setLocationAccuracy\022\".patrol.SetLocati" +
+      "onAccuracyRequest\032\r.patrol.Empty\"\000\022\'\n\005de" +
+      "bug\022\r.patrol.Empty\032\r.patrol.Empty\"\000B\'\n%p" +
+      "l.leancode.automatorserver.contractsb\006pr" +
+      "oto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -17057,7 +17208,7 @@ public final class Contracts {
     internal_static_patrol_Notification_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_patrol_Notification_descriptor,
-        new java.lang.String[] { "AppName", "Title", "Content", "AppName", });
+        new java.lang.String[] { "AppName", "Title", "Content", "Raw", "AppName", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/ContractsGrpcKt.kt
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/ContractsGrpcKt.kt
@@ -131,6 +131,10 @@ public object NativeAutomatorGrpcKt {
     @JvmStatic
     get() = NativeAutomatorGrpc.getCloseNotificationsMethod()
 
+  public val closeHeadsUpNotificationMethod: MethodDescriptor<Contracts.Empty, Contracts.Empty>
+    @JvmStatic
+    get() = NativeAutomatorGrpc.getCloseHeadsUpNotificationMethod()
+
   public val getNotificationsMethod:
       MethodDescriptor<Contracts.GetNotificationsRequest, Contracts.GetNotificationsResponse>
     @JvmStatic
@@ -661,6 +665,27 @@ public object NativeAutomatorGrpcKt {
      *
      * @return The single response from the server.
      */
+    public suspend fun closeHeadsUpNotification(request: Contracts.Empty, headers: Metadata =
+        Metadata()): Contracts.Empty = unaryRpc(
+      channel,
+      NativeAutomatorGrpc.getCloseHeadsUpNotificationMethod(),
+      request,
+      callOptions,
+      headers
+    )
+
+    /**
+     * Executes this RPC and returns the response message, suspending until the RPC completes
+     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
+     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
+     * with the corresponding exception as a cause.
+     *
+     * @param request The request message to send to the server.
+     *
+     * @param headers Metadata to attach to the request.  Most users will not need this.
+     *
+     * @return The single response from the server.
+     */
     public suspend fun getNotifications(request: Contracts.GetNotificationsRequest,
         headers: Metadata = Metadata()): Contracts.GetNotificationsResponse = unaryRpc(
       channel,
@@ -1094,6 +1119,21 @@ public object NativeAutomatorGrpcKt {
         StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.closeNotifications is unimplemented"))
 
     /**
+     * Returns the response to an RPC for patrol.NativeAutomator.closeHeadsUpNotification.
+     *
+     * If this method fails with a [StatusException], the RPC will fail with the corresponding
+     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
+     * will fail
+     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
+     * fail with `Status.UNKNOWN` with the exception as a cause.
+     *
+     * @param request The request from the client.
+     */
+    public open suspend fun closeHeadsUpNotification(request: Contracts.Empty): Contracts.Empty =
+        throw
+        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.closeHeadsUpNotification is unimplemented"))
+
+    /**
      * Returns the response to an RPC for patrol.NativeAutomator.getNotifications.
      *
      * If this method fails with a [StatusException], the RPC will fail with the corresponding
@@ -1283,6 +1323,11 @@ public object NativeAutomatorGrpcKt {
       context = this.context,
       descriptor = NativeAutomatorGrpc.getCloseNotificationsMethod(),
       implementation = ::closeNotifications
+    ))
+      .addMethod(unaryServerMethodDefinition(
+      context = this.context,
+      descriptor = NativeAutomatorGrpc.getCloseHeadsUpNotificationMethod(),
+      implementation = ::closeHeadsUpNotification
     ))
       .addMethod(unaryServerMethodDefinition(
       context = this.context,

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/ContractsGrpcKt.kt
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/ContractsGrpcKt.kt
@@ -55,14 +55,6 @@ public object NativeAutomatorGrpcKt {
     @JvmStatic
     get() = NativeAutomatorGrpc.getOpenAppMethod()
 
-  public val openNotificationsMethod: MethodDescriptor<Contracts.Empty, Contracts.Empty>
-    @JvmStatic
-    get() = NativeAutomatorGrpc.getOpenNotificationsMethod()
-
-  public val closeNotificationsMethod: MethodDescriptor<Contracts.Empty, Contracts.Empty>
-    @JvmStatic
-    get() = NativeAutomatorGrpc.getCloseNotificationsMethod()
-
   public val openQuickSettingsMethod:
       MethodDescriptor<Contracts.OpenQuickSettingsRequest, Contracts.Empty>
     @JvmStatic
@@ -115,11 +107,6 @@ public object NativeAutomatorGrpcKt {
     @JvmStatic
     get() = NativeAutomatorGrpc.getGetNativeWidgetsMethod()
 
-  public val getNotificationsMethod:
-      MethodDescriptor<Contracts.GetNotificationsRequest, Contracts.GetNotificationsResponse>
-    @JvmStatic
-    get() = NativeAutomatorGrpc.getGetNotificationsMethod()
-
   public val tapMethod: MethodDescriptor<Contracts.TapRequest, Contracts.Empty>
     @JvmStatic
     get() = NativeAutomatorGrpc.getTapMethod()
@@ -136,6 +123,24 @@ public object NativeAutomatorGrpcKt {
     @JvmStatic
     get() = NativeAutomatorGrpc.getSwipeMethod()
 
+  public val openNotificationsMethod: MethodDescriptor<Contracts.Empty, Contracts.Empty>
+    @JvmStatic
+    get() = NativeAutomatorGrpc.getOpenNotificationsMethod()
+
+  public val closeNotificationsMethod: MethodDescriptor<Contracts.Empty, Contracts.Empty>
+    @JvmStatic
+    get() = NativeAutomatorGrpc.getCloseNotificationsMethod()
+
+  public val getNotificationsMethod:
+      MethodDescriptor<Contracts.GetNotificationsRequest, Contracts.GetNotificationsResponse>
+    @JvmStatic
+    get() = NativeAutomatorGrpc.getGetNotificationsMethod()
+
+  public val tapOnNotificationMethod:
+      MethodDescriptor<Contracts.TapOnNotificationRequest, Contracts.Empty>
+    @JvmStatic
+    get() = NativeAutomatorGrpc.getTapOnNotificationMethod()
+
   public val handlePermissionDialogMethod:
       MethodDescriptor<Contracts.HandlePermissionRequest, Contracts.Empty>
     @JvmStatic
@@ -145,11 +150,6 @@ public object NativeAutomatorGrpcKt {
       MethodDescriptor<Contracts.SetLocationAccuracyRequest, Contracts.Empty>
     @JvmStatic
     get() = NativeAutomatorGrpc.getSetLocationAccuracyMethod()
-
-  public val tapOnNotificationMethod:
-      MethodDescriptor<Contracts.TapOnNotificationRequest, Contracts.Empty>
-    @JvmStatic
-    get() = NativeAutomatorGrpc.getTapOnNotificationMethod()
 
   public val debugMethod: MethodDescriptor<Contracts.Empty, Contracts.Empty>
     @JvmStatic
@@ -266,48 +266,6 @@ public object NativeAutomatorGrpcKt {
         Contracts.Empty = unaryRpc(
       channel,
       NativeAutomatorGrpc.getOpenAppMethod(),
-      request,
-      callOptions,
-      headers
-    )
-
-    /**
-     * Executes this RPC and returns the response message, suspending until the RPC completes
-     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
-     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
-     * with the corresponding exception as a cause.
-     *
-     * @param request The request message to send to the server.
-     *
-     * @param headers Metadata to attach to the request.  Most users will not need this.
-     *
-     * @return The single response from the server.
-     */
-    public suspend fun openNotifications(request: Contracts.Empty, headers: Metadata = Metadata()):
-        Contracts.Empty = unaryRpc(
-      channel,
-      NativeAutomatorGrpc.getOpenNotificationsMethod(),
-      request,
-      callOptions,
-      headers
-    )
-
-    /**
-     * Executes this RPC and returns the response message, suspending until the RPC completes
-     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
-     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
-     * with the corresponding exception as a cause.
-     *
-     * @param request The request message to send to the server.
-     *
-     * @param headers Metadata to attach to the request.  Most users will not need this.
-     *
-     * @return The single response from the server.
-     */
-    public suspend fun closeNotifications(request: Contracts.Empty, headers: Metadata = Metadata()):
-        Contracts.Empty = unaryRpc(
-      channel,
-      NativeAutomatorGrpc.getCloseNotificationsMethod(),
       request,
       callOptions,
       headers
@@ -577,27 +535,6 @@ public object NativeAutomatorGrpcKt {
      *
      * @return The single response from the server.
      */
-    public suspend fun getNotifications(request: Contracts.GetNotificationsRequest,
-        headers: Metadata = Metadata()): Contracts.GetNotificationsResponse = unaryRpc(
-      channel,
-      NativeAutomatorGrpc.getGetNotificationsMethod(),
-      request,
-      callOptions,
-      headers
-    )
-
-    /**
-     * Executes this RPC and returns the response message, suspending until the RPC completes
-     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
-     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
-     * with the corresponding exception as a cause.
-     *
-     * @param request The request message to send to the server.
-     *
-     * @param headers Metadata to attach to the request.  Most users will not need this.
-     *
-     * @return The single response from the server.
-     */
     public suspend fun tap(request: Contracts.TapRequest, headers: Metadata = Metadata()):
         Contracts.Empty = unaryRpc(
       channel,
@@ -682,6 +619,90 @@ public object NativeAutomatorGrpcKt {
      *
      * @return The single response from the server.
      */
+    public suspend fun openNotifications(request: Contracts.Empty, headers: Metadata = Metadata()):
+        Contracts.Empty = unaryRpc(
+      channel,
+      NativeAutomatorGrpc.getOpenNotificationsMethod(),
+      request,
+      callOptions,
+      headers
+    )
+
+    /**
+     * Executes this RPC and returns the response message, suspending until the RPC completes
+     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
+     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
+     * with the corresponding exception as a cause.
+     *
+     * @param request The request message to send to the server.
+     *
+     * @param headers Metadata to attach to the request.  Most users will not need this.
+     *
+     * @return The single response from the server.
+     */
+    public suspend fun closeNotifications(request: Contracts.Empty, headers: Metadata = Metadata()):
+        Contracts.Empty = unaryRpc(
+      channel,
+      NativeAutomatorGrpc.getCloseNotificationsMethod(),
+      request,
+      callOptions,
+      headers
+    )
+
+    /**
+     * Executes this RPC and returns the response message, suspending until the RPC completes
+     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
+     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
+     * with the corresponding exception as a cause.
+     *
+     * @param request The request message to send to the server.
+     *
+     * @param headers Metadata to attach to the request.  Most users will not need this.
+     *
+     * @return The single response from the server.
+     */
+    public suspend fun getNotifications(request: Contracts.GetNotificationsRequest,
+        headers: Metadata = Metadata()): Contracts.GetNotificationsResponse = unaryRpc(
+      channel,
+      NativeAutomatorGrpc.getGetNotificationsMethod(),
+      request,
+      callOptions,
+      headers
+    )
+
+    /**
+     * Executes this RPC and returns the response message, suspending until the RPC completes
+     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
+     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
+     * with the corresponding exception as a cause.
+     *
+     * @param request The request message to send to the server.
+     *
+     * @param headers Metadata to attach to the request.  Most users will not need this.
+     *
+     * @return The single response from the server.
+     */
+    public suspend fun tapOnNotification(request: Contracts.TapOnNotificationRequest,
+        headers: Metadata = Metadata()): Contracts.Empty = unaryRpc(
+      channel,
+      NativeAutomatorGrpc.getTapOnNotificationMethod(),
+      request,
+      callOptions,
+      headers
+    )
+
+    /**
+     * Executes this RPC and returns the response message, suspending until the RPC completes
+     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
+     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
+     * with the corresponding exception as a cause.
+     *
+     * @param request The request message to send to the server.
+     *
+     * @param headers Metadata to attach to the request.  Most users will not need this.
+     *
+     * @return The single response from the server.
+     */
     public suspend fun handlePermissionDialog(request: Contracts.HandlePermissionRequest,
         headers: Metadata = Metadata()): Contracts.Empty = unaryRpc(
       channel,
@@ -707,27 +728,6 @@ public object NativeAutomatorGrpcKt {
         headers: Metadata = Metadata()): Contracts.Empty = unaryRpc(
       channel,
       NativeAutomatorGrpc.getSetLocationAccuracyMethod(),
-      request,
-      callOptions,
-      headers
-    )
-
-    /**
-     * Executes this RPC and returns the response message, suspending until the RPC completes
-     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
-     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
-     * with the corresponding exception as a cause.
-     *
-     * @param request The request message to send to the server.
-     *
-     * @param headers Metadata to attach to the request.  Most users will not need this.
-     *
-     * @return The single response from the server.
-     */
-    public suspend fun tapOnNotification(request: Contracts.TapOnNotificationRequest,
-        headers: Metadata = Metadata()): Contracts.Empty = unaryRpc(
-      channel,
-      NativeAutomatorGrpc.getTapOnNotificationMethod(),
       request,
       callOptions,
       headers
@@ -830,34 +830,6 @@ public object NativeAutomatorGrpcKt {
      */
     public open suspend fun openApp(request: Contracts.OpenAppRequest): Contracts.Empty = throw
         StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.openApp is unimplemented"))
-
-    /**
-     * Returns the response to an RPC for patrol.NativeAutomator.openNotifications.
-     *
-     * If this method fails with a [StatusException], the RPC will fail with the corresponding
-     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
-     * will fail
-     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
-     * fail with `Status.UNKNOWN` with the exception as a cause.
-     *
-     * @param request The request from the client.
-     */
-    public open suspend fun openNotifications(request: Contracts.Empty): Contracts.Empty = throw
-        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.openNotifications is unimplemented"))
-
-    /**
-     * Returns the response to an RPC for patrol.NativeAutomator.closeNotifications.
-     *
-     * If this method fails with a [StatusException], the RPC will fail with the corresponding
-     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
-     * will fail
-     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
-     * fail with `Status.UNKNOWN` with the exception as a cause.
-     *
-     * @param request The request from the client.
-     */
-    public open suspend fun closeNotifications(request: Contracts.Empty): Contracts.Empty = throw
-        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.closeNotifications is unimplemented"))
 
     /**
      * Returns the response to an RPC for patrol.NativeAutomator.openQuickSettings.
@@ -1038,21 +1010,6 @@ public object NativeAutomatorGrpcKt {
         StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.getNativeWidgets is unimplemented"))
 
     /**
-     * Returns the response to an RPC for patrol.NativeAutomator.getNotifications.
-     *
-     * If this method fails with a [StatusException], the RPC will fail with the corresponding
-     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
-     * will fail
-     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
-     * fail with `Status.UNKNOWN` with the exception as a cause.
-     *
-     * @param request The request from the client.
-     */
-    public open suspend fun getNotifications(request: Contracts.GetNotificationsRequest):
-        Contracts.GetNotificationsResponse = throw
-        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.getNotifications is unimplemented"))
-
-    /**
      * Returns the response to an RPC for patrol.NativeAutomator.tap.
      *
      * If this method fails with a [StatusException], the RPC will fail with the corresponding
@@ -1109,6 +1066,64 @@ public object NativeAutomatorGrpcKt {
         StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.swipe is unimplemented"))
 
     /**
+     * Returns the response to an RPC for patrol.NativeAutomator.openNotifications.
+     *
+     * If this method fails with a [StatusException], the RPC will fail with the corresponding
+     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
+     * will fail
+     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
+     * fail with `Status.UNKNOWN` with the exception as a cause.
+     *
+     * @param request The request from the client.
+     */
+    public open suspend fun openNotifications(request: Contracts.Empty): Contracts.Empty = throw
+        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.openNotifications is unimplemented"))
+
+    /**
+     * Returns the response to an RPC for patrol.NativeAutomator.closeNotifications.
+     *
+     * If this method fails with a [StatusException], the RPC will fail with the corresponding
+     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
+     * will fail
+     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
+     * fail with `Status.UNKNOWN` with the exception as a cause.
+     *
+     * @param request The request from the client.
+     */
+    public open suspend fun closeNotifications(request: Contracts.Empty): Contracts.Empty = throw
+        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.closeNotifications is unimplemented"))
+
+    /**
+     * Returns the response to an RPC for patrol.NativeAutomator.getNotifications.
+     *
+     * If this method fails with a [StatusException], the RPC will fail with the corresponding
+     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
+     * will fail
+     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
+     * fail with `Status.UNKNOWN` with the exception as a cause.
+     *
+     * @param request The request from the client.
+     */
+    public open suspend fun getNotifications(request: Contracts.GetNotificationsRequest):
+        Contracts.GetNotificationsResponse = throw
+        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.getNotifications is unimplemented"))
+
+    /**
+     * Returns the response to an RPC for patrol.NativeAutomator.tapOnNotification.
+     *
+     * If this method fails with a [StatusException], the RPC will fail with the corresponding
+     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
+     * will fail
+     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
+     * fail with `Status.UNKNOWN` with the exception as a cause.
+     *
+     * @param request The request from the client.
+     */
+    public open suspend fun tapOnNotification(request: Contracts.TapOnNotificationRequest):
+        Contracts.Empty = throw
+        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.tapOnNotification is unimplemented"))
+
+    /**
      * Returns the response to an RPC for patrol.NativeAutomator.handlePermissionDialog.
      *
      * If this method fails with a [StatusException], the RPC will fail with the corresponding
@@ -1137,21 +1152,6 @@ public object NativeAutomatorGrpcKt {
     public open suspend fun setLocationAccuracy(request: Contracts.SetLocationAccuracyRequest):
         Contracts.Empty = throw
         StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.setLocationAccuracy is unimplemented"))
-
-    /**
-     * Returns the response to an RPC for patrol.NativeAutomator.tapOnNotification.
-     *
-     * If this method fails with a [StatusException], the RPC will fail with the corresponding
-     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
-     * will fail
-     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
-     * fail with `Status.UNKNOWN` with the exception as a cause.
-     *
-     * @param request The request from the client.
-     */
-    public open suspend fun tapOnNotification(request: Contracts.TapOnNotificationRequest):
-        Contracts.Empty = throw
-        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.tapOnNotification is unimplemented"))
 
     /**
      * Returns the response to an RPC for patrol.NativeAutomator.debug.
@@ -1193,16 +1193,6 @@ public object NativeAutomatorGrpcKt {
       context = this.context,
       descriptor = NativeAutomatorGrpc.getOpenAppMethod(),
       implementation = ::openApp
-    ))
-      .addMethod(unaryServerMethodDefinition(
-      context = this.context,
-      descriptor = NativeAutomatorGrpc.getOpenNotificationsMethod(),
-      implementation = ::openNotifications
-    ))
-      .addMethod(unaryServerMethodDefinition(
-      context = this.context,
-      descriptor = NativeAutomatorGrpc.getCloseNotificationsMethod(),
-      implementation = ::closeNotifications
     ))
       .addMethod(unaryServerMethodDefinition(
       context = this.context,
@@ -1266,11 +1256,6 @@ public object NativeAutomatorGrpcKt {
     ))
       .addMethod(unaryServerMethodDefinition(
       context = this.context,
-      descriptor = NativeAutomatorGrpc.getGetNotificationsMethod(),
-      implementation = ::getNotifications
-    ))
-      .addMethod(unaryServerMethodDefinition(
-      context = this.context,
       descriptor = NativeAutomatorGrpc.getTapMethod(),
       implementation = ::tap
     ))
@@ -1291,6 +1276,26 @@ public object NativeAutomatorGrpcKt {
     ))
       .addMethod(unaryServerMethodDefinition(
       context = this.context,
+      descriptor = NativeAutomatorGrpc.getOpenNotificationsMethod(),
+      implementation = ::openNotifications
+    ))
+      .addMethod(unaryServerMethodDefinition(
+      context = this.context,
+      descriptor = NativeAutomatorGrpc.getCloseNotificationsMethod(),
+      implementation = ::closeNotifications
+    ))
+      .addMethod(unaryServerMethodDefinition(
+      context = this.context,
+      descriptor = NativeAutomatorGrpc.getGetNotificationsMethod(),
+      implementation = ::getNotifications
+    ))
+      .addMethod(unaryServerMethodDefinition(
+      context = this.context,
+      descriptor = NativeAutomatorGrpc.getTapOnNotificationMethod(),
+      implementation = ::tapOnNotification
+    ))
+      .addMethod(unaryServerMethodDefinition(
+      context = this.context,
       descriptor = NativeAutomatorGrpc.getHandlePermissionDialogMethod(),
       implementation = ::handlePermissionDialog
     ))
@@ -1298,11 +1303,6 @@ public object NativeAutomatorGrpcKt {
       context = this.context,
       descriptor = NativeAutomatorGrpc.getSetLocationAccuracyMethod(),
       implementation = ::setLocationAccuracy
-    ))
-      .addMethod(unaryServerMethodDefinition(
-      context = this.context,
-      descriptor = NativeAutomatorGrpc.getTapOnNotificationMethod(),
-      implementation = ::tapOnNotification
     ))
       .addMethod(unaryServerMethodDefinition(
       context = this.context,

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/ContractsGrpcKt.kt
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/ContractsGrpcKt.kt
@@ -60,6 +60,27 @@ public object NativeAutomatorGrpcKt {
     @JvmStatic
     get() = NativeAutomatorGrpc.getOpenQuickSettingsMethod()
 
+  public val getNativeWidgetsMethod:
+      MethodDescriptor<Contracts.GetNativeWidgetsRequest, Contracts.GetNativeWidgetsResponse>
+    @JvmStatic
+    get() = NativeAutomatorGrpc.getGetNativeWidgetsMethod()
+
+  public val tapMethod: MethodDescriptor<Contracts.TapRequest, Contracts.Empty>
+    @JvmStatic
+    get() = NativeAutomatorGrpc.getTapMethod()
+
+  public val doubleTapMethod: MethodDescriptor<Contracts.TapRequest, Contracts.Empty>
+    @JvmStatic
+    get() = NativeAutomatorGrpc.getDoubleTapMethod()
+
+  public val enterTextMethod: MethodDescriptor<Contracts.EnterTextRequest, Contracts.Empty>
+    @JvmStatic
+    get() = NativeAutomatorGrpc.getEnterTextMethod()
+
+  public val swipeMethod: MethodDescriptor<Contracts.SwipeRequest, Contracts.Empty>
+    @JvmStatic
+    get() = NativeAutomatorGrpc.getSwipeMethod()
+
   public val enableAirplaneModeMethod:
       MethodDescriptor<Contracts.AirplaneModeRequest, Contracts.Empty>
     @JvmStatic
@@ -101,27 +122,6 @@ public object NativeAutomatorGrpcKt {
   public val disableDarkModeMethod: MethodDescriptor<Contracts.DarkModeRequest, Contracts.Empty>
     @JvmStatic
     get() = NativeAutomatorGrpc.getDisableDarkModeMethod()
-
-  public val getNativeWidgetsMethod:
-      MethodDescriptor<Contracts.GetNativeWidgetsRequest, Contracts.GetNativeWidgetsResponse>
-    @JvmStatic
-    get() = NativeAutomatorGrpc.getGetNativeWidgetsMethod()
-
-  public val tapMethod: MethodDescriptor<Contracts.TapRequest, Contracts.Empty>
-    @JvmStatic
-    get() = NativeAutomatorGrpc.getTapMethod()
-
-  public val doubleTapMethod: MethodDescriptor<Contracts.TapRequest, Contracts.Empty>
-    @JvmStatic
-    get() = NativeAutomatorGrpc.getDoubleTapMethod()
-
-  public val enterTextMethod: MethodDescriptor<Contracts.EnterTextRequest, Contracts.Empty>
-    @JvmStatic
-    get() = NativeAutomatorGrpc.getEnterTextMethod()
-
-  public val swipeMethod: MethodDescriptor<Contracts.SwipeRequest, Contracts.Empty>
-    @JvmStatic
-    get() = NativeAutomatorGrpc.getSwipeMethod()
 
   public val openNotificationsMethod: MethodDescriptor<Contracts.Empty, Contracts.Empty>
     @JvmStatic
@@ -287,6 +287,111 @@ public object NativeAutomatorGrpcKt {
         headers: Metadata = Metadata()): Contracts.Empty = unaryRpc(
       channel,
       NativeAutomatorGrpc.getOpenQuickSettingsMethod(),
+      request,
+      callOptions,
+      headers
+    )
+
+    /**
+     * Executes this RPC and returns the response message, suspending until the RPC completes
+     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
+     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
+     * with the corresponding exception as a cause.
+     *
+     * @param request The request message to send to the server.
+     *
+     * @param headers Metadata to attach to the request.  Most users will not need this.
+     *
+     * @return The single response from the server.
+     */
+    public suspend fun getNativeWidgets(request: Contracts.GetNativeWidgetsRequest,
+        headers: Metadata = Metadata()): Contracts.GetNativeWidgetsResponse = unaryRpc(
+      channel,
+      NativeAutomatorGrpc.getGetNativeWidgetsMethod(),
+      request,
+      callOptions,
+      headers
+    )
+
+    /**
+     * Executes this RPC and returns the response message, suspending until the RPC completes
+     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
+     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
+     * with the corresponding exception as a cause.
+     *
+     * @param request The request message to send to the server.
+     *
+     * @param headers Metadata to attach to the request.  Most users will not need this.
+     *
+     * @return The single response from the server.
+     */
+    public suspend fun tap(request: Contracts.TapRequest, headers: Metadata = Metadata()):
+        Contracts.Empty = unaryRpc(
+      channel,
+      NativeAutomatorGrpc.getTapMethod(),
+      request,
+      callOptions,
+      headers
+    )
+
+    /**
+     * Executes this RPC and returns the response message, suspending until the RPC completes
+     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
+     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
+     * with the corresponding exception as a cause.
+     *
+     * @param request The request message to send to the server.
+     *
+     * @param headers Metadata to attach to the request.  Most users will not need this.
+     *
+     * @return The single response from the server.
+     */
+    public suspend fun doubleTap(request: Contracts.TapRequest, headers: Metadata = Metadata()):
+        Contracts.Empty = unaryRpc(
+      channel,
+      NativeAutomatorGrpc.getDoubleTapMethod(),
+      request,
+      callOptions,
+      headers
+    )
+
+    /**
+     * Executes this RPC and returns the response message, suspending until the RPC completes
+     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
+     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
+     * with the corresponding exception as a cause.
+     *
+     * @param request The request message to send to the server.
+     *
+     * @param headers Metadata to attach to the request.  Most users will not need this.
+     *
+     * @return The single response from the server.
+     */
+    public suspend fun enterText(request: Contracts.EnterTextRequest, headers: Metadata =
+        Metadata()): Contracts.Empty = unaryRpc(
+      channel,
+      NativeAutomatorGrpc.getEnterTextMethod(),
+      request,
+      callOptions,
+      headers
+    )
+
+    /**
+     * Executes this RPC and returns the response message, suspending until the RPC completes
+     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
+     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
+     * with the corresponding exception as a cause.
+     *
+     * @param request The request message to send to the server.
+     *
+     * @param headers Metadata to attach to the request.  Most users will not need this.
+     *
+     * @return The single response from the server.
+     */
+    public suspend fun swipe(request: Contracts.SwipeRequest, headers: Metadata = Metadata()):
+        Contracts.Empty = unaryRpc(
+      channel,
+      NativeAutomatorGrpc.getSwipeMethod(),
       request,
       callOptions,
       headers
@@ -497,111 +602,6 @@ public object NativeAutomatorGrpcKt {
         Metadata()): Contracts.Empty = unaryRpc(
       channel,
       NativeAutomatorGrpc.getDisableDarkModeMethod(),
-      request,
-      callOptions,
-      headers
-    )
-
-    /**
-     * Executes this RPC and returns the response message, suspending until the RPC completes
-     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
-     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
-     * with the corresponding exception as a cause.
-     *
-     * @param request The request message to send to the server.
-     *
-     * @param headers Metadata to attach to the request.  Most users will not need this.
-     *
-     * @return The single response from the server.
-     */
-    public suspend fun getNativeWidgets(request: Contracts.GetNativeWidgetsRequest,
-        headers: Metadata = Metadata()): Contracts.GetNativeWidgetsResponse = unaryRpc(
-      channel,
-      NativeAutomatorGrpc.getGetNativeWidgetsMethod(),
-      request,
-      callOptions,
-      headers
-    )
-
-    /**
-     * Executes this RPC and returns the response message, suspending until the RPC completes
-     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
-     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
-     * with the corresponding exception as a cause.
-     *
-     * @param request The request message to send to the server.
-     *
-     * @param headers Metadata to attach to the request.  Most users will not need this.
-     *
-     * @return The single response from the server.
-     */
-    public suspend fun tap(request: Contracts.TapRequest, headers: Metadata = Metadata()):
-        Contracts.Empty = unaryRpc(
-      channel,
-      NativeAutomatorGrpc.getTapMethod(),
-      request,
-      callOptions,
-      headers
-    )
-
-    /**
-     * Executes this RPC and returns the response message, suspending until the RPC completes
-     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
-     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
-     * with the corresponding exception as a cause.
-     *
-     * @param request The request message to send to the server.
-     *
-     * @param headers Metadata to attach to the request.  Most users will not need this.
-     *
-     * @return The single response from the server.
-     */
-    public suspend fun doubleTap(request: Contracts.TapRequest, headers: Metadata = Metadata()):
-        Contracts.Empty = unaryRpc(
-      channel,
-      NativeAutomatorGrpc.getDoubleTapMethod(),
-      request,
-      callOptions,
-      headers
-    )
-
-    /**
-     * Executes this RPC and returns the response message, suspending until the RPC completes
-     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
-     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
-     * with the corresponding exception as a cause.
-     *
-     * @param request The request message to send to the server.
-     *
-     * @param headers Metadata to attach to the request.  Most users will not need this.
-     *
-     * @return The single response from the server.
-     */
-    public suspend fun enterText(request: Contracts.EnterTextRequest, headers: Metadata =
-        Metadata()): Contracts.Empty = unaryRpc(
-      channel,
-      NativeAutomatorGrpc.getEnterTextMethod(),
-      request,
-      callOptions,
-      headers
-    )
-
-    /**
-     * Executes this RPC and returns the response message, suspending until the RPC completes
-     * with [`Status.OK`][Status].  If the RPC completes with another status, a corresponding
-     * [StatusException] is thrown.  If this coroutine is cancelled, the RPC is also cancelled
-     * with the corresponding exception as a cause.
-     *
-     * @param request The request message to send to the server.
-     *
-     * @param headers Metadata to attach to the request.  Most users will not need this.
-     *
-     * @return The single response from the server.
-     */
-    public suspend fun swipe(request: Contracts.SwipeRequest, headers: Metadata = Metadata()):
-        Contracts.Empty = unaryRpc(
-      channel,
-      NativeAutomatorGrpc.getSwipeMethod(),
       request,
       callOptions,
       headers
@@ -847,6 +847,77 @@ public object NativeAutomatorGrpcKt {
         StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.openQuickSettings is unimplemented"))
 
     /**
+     * Returns the response to an RPC for patrol.NativeAutomator.getNativeWidgets.
+     *
+     * If this method fails with a [StatusException], the RPC will fail with the corresponding
+     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
+     * will fail
+     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
+     * fail with `Status.UNKNOWN` with the exception as a cause.
+     *
+     * @param request The request from the client.
+     */
+    public open suspend fun getNativeWidgets(request: Contracts.GetNativeWidgetsRequest):
+        Contracts.GetNativeWidgetsResponse = throw
+        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.getNativeWidgets is unimplemented"))
+
+    /**
+     * Returns the response to an RPC for patrol.NativeAutomator.tap.
+     *
+     * If this method fails with a [StatusException], the RPC will fail with the corresponding
+     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
+     * will fail
+     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
+     * fail with `Status.UNKNOWN` with the exception as a cause.
+     *
+     * @param request The request from the client.
+     */
+    public open suspend fun tap(request: Contracts.TapRequest): Contracts.Empty = throw
+        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.tap is unimplemented"))
+
+    /**
+     * Returns the response to an RPC for patrol.NativeAutomator.doubleTap.
+     *
+     * If this method fails with a [StatusException], the RPC will fail with the corresponding
+     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
+     * will fail
+     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
+     * fail with `Status.UNKNOWN` with the exception as a cause.
+     *
+     * @param request The request from the client.
+     */
+    public open suspend fun doubleTap(request: Contracts.TapRequest): Contracts.Empty = throw
+        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.doubleTap is unimplemented"))
+
+    /**
+     * Returns the response to an RPC for patrol.NativeAutomator.enterText.
+     *
+     * If this method fails with a [StatusException], the RPC will fail with the corresponding
+     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
+     * will fail
+     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
+     * fail with `Status.UNKNOWN` with the exception as a cause.
+     *
+     * @param request The request from the client.
+     */
+    public open suspend fun enterText(request: Contracts.EnterTextRequest): Contracts.Empty = throw
+        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.enterText is unimplemented"))
+
+    /**
+     * Returns the response to an RPC for patrol.NativeAutomator.swipe.
+     *
+     * If this method fails with a [StatusException], the RPC will fail with the corresponding
+     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
+     * will fail
+     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
+     * fail with `Status.UNKNOWN` with the exception as a cause.
+     *
+     * @param request The request from the client.
+     */
+    public open suspend fun swipe(request: Contracts.SwipeRequest): Contracts.Empty = throw
+        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.swipe is unimplemented"))
+
+    /**
      * Returns the response to an RPC for patrol.NativeAutomator.enableAirplaneMode.
      *
      * If this method fails with a [StatusException], the RPC will fail with the corresponding
@@ -995,77 +1066,6 @@ public object NativeAutomatorGrpcKt {
         StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.disableDarkMode is unimplemented"))
 
     /**
-     * Returns the response to an RPC for patrol.NativeAutomator.getNativeWidgets.
-     *
-     * If this method fails with a [StatusException], the RPC will fail with the corresponding
-     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
-     * will fail
-     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
-     * fail with `Status.UNKNOWN` with the exception as a cause.
-     *
-     * @param request The request from the client.
-     */
-    public open suspend fun getNativeWidgets(request: Contracts.GetNativeWidgetsRequest):
-        Contracts.GetNativeWidgetsResponse = throw
-        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.getNativeWidgets is unimplemented"))
-
-    /**
-     * Returns the response to an RPC for patrol.NativeAutomator.tap.
-     *
-     * If this method fails with a [StatusException], the RPC will fail with the corresponding
-     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
-     * will fail
-     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
-     * fail with `Status.UNKNOWN` with the exception as a cause.
-     *
-     * @param request The request from the client.
-     */
-    public open suspend fun tap(request: Contracts.TapRequest): Contracts.Empty = throw
-        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.tap is unimplemented"))
-
-    /**
-     * Returns the response to an RPC for patrol.NativeAutomator.doubleTap.
-     *
-     * If this method fails with a [StatusException], the RPC will fail with the corresponding
-     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
-     * will fail
-     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
-     * fail with `Status.UNKNOWN` with the exception as a cause.
-     *
-     * @param request The request from the client.
-     */
-    public open suspend fun doubleTap(request: Contracts.TapRequest): Contracts.Empty = throw
-        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.doubleTap is unimplemented"))
-
-    /**
-     * Returns the response to an RPC for patrol.NativeAutomator.enterText.
-     *
-     * If this method fails with a [StatusException], the RPC will fail with the corresponding
-     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
-     * will fail
-     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
-     * fail with `Status.UNKNOWN` with the exception as a cause.
-     *
-     * @param request The request from the client.
-     */
-    public open suspend fun enterText(request: Contracts.EnterTextRequest): Contracts.Empty = throw
-        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.enterText is unimplemented"))
-
-    /**
-     * Returns the response to an RPC for patrol.NativeAutomator.swipe.
-     *
-     * If this method fails with a [StatusException], the RPC will fail with the corresponding
-     * [Status].  If this method fails with a [java.util.concurrent.CancellationException], the RPC
-     * will fail
-     * with status `Status.CANCELLED`.  If this method fails for any other reason, the RPC will
-     * fail with `Status.UNKNOWN` with the exception as a cause.
-     *
-     * @param request The request from the client.
-     */
-    public open suspend fun swipe(request: Contracts.SwipeRequest): Contracts.Empty = throw
-        StatusException(UNIMPLEMENTED.withDescription("Method patrol.NativeAutomator.swipe is unimplemented"))
-
-    /**
      * Returns the response to an RPC for patrol.NativeAutomator.openNotifications.
      *
      * If this method fails with a [StatusException], the RPC will fail with the corresponding
@@ -1201,6 +1201,31 @@ public object NativeAutomatorGrpcKt {
     ))
       .addMethod(unaryServerMethodDefinition(
       context = this.context,
+      descriptor = NativeAutomatorGrpc.getGetNativeWidgetsMethod(),
+      implementation = ::getNativeWidgets
+    ))
+      .addMethod(unaryServerMethodDefinition(
+      context = this.context,
+      descriptor = NativeAutomatorGrpc.getTapMethod(),
+      implementation = ::tap
+    ))
+      .addMethod(unaryServerMethodDefinition(
+      context = this.context,
+      descriptor = NativeAutomatorGrpc.getDoubleTapMethod(),
+      implementation = ::doubleTap
+    ))
+      .addMethod(unaryServerMethodDefinition(
+      context = this.context,
+      descriptor = NativeAutomatorGrpc.getEnterTextMethod(),
+      implementation = ::enterText
+    ))
+      .addMethod(unaryServerMethodDefinition(
+      context = this.context,
+      descriptor = NativeAutomatorGrpc.getSwipeMethod(),
+      implementation = ::swipe
+    ))
+      .addMethod(unaryServerMethodDefinition(
+      context = this.context,
       descriptor = NativeAutomatorGrpc.getEnableAirplaneModeMethod(),
       implementation = ::enableAirplaneMode
     ))
@@ -1248,31 +1273,6 @@ public object NativeAutomatorGrpcKt {
       context = this.context,
       descriptor = NativeAutomatorGrpc.getDisableDarkModeMethod(),
       implementation = ::disableDarkMode
-    ))
-      .addMethod(unaryServerMethodDefinition(
-      context = this.context,
-      descriptor = NativeAutomatorGrpc.getGetNativeWidgetsMethod(),
-      implementation = ::getNativeWidgets
-    ))
-      .addMethod(unaryServerMethodDefinition(
-      context = this.context,
-      descriptor = NativeAutomatorGrpc.getTapMethod(),
-      implementation = ::tap
-    ))
-      .addMethod(unaryServerMethodDefinition(
-      context = this.context,
-      descriptor = NativeAutomatorGrpc.getDoubleTapMethod(),
-      implementation = ::doubleTap
-    ))
-      .addMethod(unaryServerMethodDefinition(
-      context = this.context,
-      descriptor = NativeAutomatorGrpc.getEnterTextMethod(),
-      implementation = ::enterText
-    ))
-      .addMethod(unaryServerMethodDefinition(
-      context = this.context,
-      descriptor = NativeAutomatorGrpc.getSwipeMethod(),
-      implementation = ::swipe
     ))
       .addMethod(unaryServerMethodDefinition(
       context = this.context,

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/NativeAutomatorGrpc.java
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/NativeAutomatorGrpc.java
@@ -731,6 +731,37 @@ public final class NativeAutomatorGrpc {
     return getCloseNotificationsMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getCloseHeadsUpNotificationMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "closeHeadsUpNotification",
+      requestType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
+      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getCloseHeadsUpNotificationMethod() {
+    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty, pl.leancode.automatorserver.contracts.Contracts.Empty> getCloseHeadsUpNotificationMethod;
+    if ((getCloseHeadsUpNotificationMethod = NativeAutomatorGrpc.getCloseHeadsUpNotificationMethod) == null) {
+      synchronized (NativeAutomatorGrpc.class) {
+        if ((getCloseHeadsUpNotificationMethod = NativeAutomatorGrpc.getCloseHeadsUpNotificationMethod) == null) {
+          NativeAutomatorGrpc.getCloseHeadsUpNotificationMethod = getCloseHeadsUpNotificationMethod =
+              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.Empty, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "closeHeadsUpNotification"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
+              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("closeHeadsUpNotification"))
+              .build();
+        }
+      }
+    }
+    return getCloseHeadsUpNotificationMethod;
+  }
+
   private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest,
       pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> getGetNotificationsMethod;
 
@@ -1109,6 +1140,13 @@ public final class NativeAutomatorGrpc {
 
     /**
      */
+    public void closeHeadsUpNotification(pl.leancode.automatorserver.contracts.Contracts.Empty request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getCloseHeadsUpNotificationMethod(), responseObserver);
+    }
+
+    /**
+     */
     public void getNotifications(pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest request,
         io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetNotificationsMethod(), responseObserver);
@@ -1308,6 +1346,13 @@ public final class NativeAutomatorGrpc {
                 pl.leancode.automatorserver.contracts.Contracts.Empty,
                 pl.leancode.automatorserver.contracts.Contracts.Empty>(
                   this, METHODID_CLOSE_NOTIFICATIONS)))
+          .addMethod(
+            getCloseHeadsUpNotificationMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                pl.leancode.automatorserver.contracts.Contracts.Empty,
+                pl.leancode.automatorserver.contracts.Contracts.Empty>(
+                  this, METHODID_CLOSE_HEADS_UP_NOTIFICATION)))
           .addMethod(
             getGetNotificationsMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
@@ -1559,6 +1604,14 @@ public final class NativeAutomatorGrpc {
 
     /**
      */
+    public void closeHeadsUpNotification(pl.leancode.automatorserver.contracts.Contracts.Empty request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getCloseHeadsUpNotificationMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     */
     public void getNotifications(pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest request,
         io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
@@ -1786,6 +1839,13 @@ public final class NativeAutomatorGrpc {
     public pl.leancode.automatorserver.contracts.Contracts.Empty closeNotifications(pl.leancode.automatorserver.contracts.Contracts.Empty request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getCloseNotificationsMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public pl.leancode.automatorserver.contracts.Contracts.Empty closeHeadsUpNotification(pl.leancode.automatorserver.contracts.Contracts.Empty request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getCloseHeadsUpNotificationMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2039,6 +2099,14 @@ public final class NativeAutomatorGrpc {
 
     /**
      */
+    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> closeHeadsUpNotification(
+        pl.leancode.automatorserver.contracts.Contracts.Empty request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getCloseHeadsUpNotificationMethod(), getCallOptions()), request);
+    }
+
+    /**
+     */
     public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> getNotifications(
         pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
@@ -2104,11 +2172,12 @@ public final class NativeAutomatorGrpc {
   private static final int METHODID_DISABLE_DARK_MODE = 20;
   private static final int METHODID_OPEN_NOTIFICATIONS = 21;
   private static final int METHODID_CLOSE_NOTIFICATIONS = 22;
-  private static final int METHODID_GET_NOTIFICATIONS = 23;
-  private static final int METHODID_TAP_ON_NOTIFICATION = 24;
-  private static final int METHODID_HANDLE_PERMISSION_DIALOG = 25;
-  private static final int METHODID_SET_LOCATION_ACCURACY = 26;
-  private static final int METHODID_DEBUG = 27;
+  private static final int METHODID_CLOSE_HEADS_UP_NOTIFICATION = 23;
+  private static final int METHODID_GET_NOTIFICATIONS = 24;
+  private static final int METHODID_TAP_ON_NOTIFICATION = 25;
+  private static final int METHODID_HANDLE_PERMISSION_DIALOG = 26;
+  private static final int METHODID_SET_LOCATION_ACCURACY = 27;
+  private static final int METHODID_DEBUG = 28;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -2219,6 +2288,10 @@ public final class NativeAutomatorGrpc {
           serviceImpl.closeNotifications((pl.leancode.automatorserver.contracts.Contracts.Empty) request,
               (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
           break;
+        case METHODID_CLOSE_HEADS_UP_NOTIFICATION:
+          serviceImpl.closeHeadsUpNotification((pl.leancode.automatorserver.contracts.Contracts.Empty) request,
+              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
+          break;
         case METHODID_GET_NOTIFICATIONS:
           serviceImpl.getNotifications((pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest) request,
               (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse>) responseObserver);
@@ -2323,6 +2396,7 @@ public final class NativeAutomatorGrpc {
               .addMethod(getDisableDarkModeMethod())
               .addMethod(getOpenNotificationsMethod())
               .addMethod(getCloseNotificationsMethod())
+              .addMethod(getCloseHeadsUpNotificationMethod())
               .addMethod(getGetNotificationsMethod())
               .addMethod(getTapOnNotificationMethod())
               .addMethod(getHandlePermissionDialogMethod())

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/NativeAutomatorGrpc.java
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/NativeAutomatorGrpc.java
@@ -204,6 +204,161 @@ public final class NativeAutomatorGrpc {
     return getOpenQuickSettingsMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest,
+      pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> getGetNativeWidgetsMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "getNativeWidgets",
+      requestType = pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest.class,
+      responseType = pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest,
+      pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> getGetNativeWidgetsMethod() {
+    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest, pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> getGetNativeWidgetsMethod;
+    if ((getGetNativeWidgetsMethod = NativeAutomatorGrpc.getGetNativeWidgetsMethod) == null) {
+      synchronized (NativeAutomatorGrpc.class) {
+        if ((getGetNativeWidgetsMethod = NativeAutomatorGrpc.getGetNativeWidgetsMethod) == null) {
+          NativeAutomatorGrpc.getGetNativeWidgetsMethod = getGetNativeWidgetsMethod =
+              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest, pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "getNativeWidgets"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("getNativeWidgets"))
+              .build();
+        }
+      }
+    }
+    return getGetNativeWidgetsMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapRequest,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getTapMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "tap",
+      requestType = pl.leancode.automatorserver.contracts.Contracts.TapRequest.class,
+      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapRequest,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getTapMethod() {
+    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapRequest, pl.leancode.automatorserver.contracts.Contracts.Empty> getTapMethod;
+    if ((getTapMethod = NativeAutomatorGrpc.getTapMethod) == null) {
+      synchronized (NativeAutomatorGrpc.class) {
+        if ((getTapMethod = NativeAutomatorGrpc.getTapMethod) == null) {
+          NativeAutomatorGrpc.getTapMethod = getTapMethod =
+              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.TapRequest, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "tap"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.TapRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
+              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("tap"))
+              .build();
+        }
+      }
+    }
+    return getTapMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapRequest,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getDoubleTapMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "doubleTap",
+      requestType = pl.leancode.automatorserver.contracts.Contracts.TapRequest.class,
+      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapRequest,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getDoubleTapMethod() {
+    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapRequest, pl.leancode.automatorserver.contracts.Contracts.Empty> getDoubleTapMethod;
+    if ((getDoubleTapMethod = NativeAutomatorGrpc.getDoubleTapMethod) == null) {
+      synchronized (NativeAutomatorGrpc.class) {
+        if ((getDoubleTapMethod = NativeAutomatorGrpc.getDoubleTapMethod) == null) {
+          NativeAutomatorGrpc.getDoubleTapMethod = getDoubleTapMethod =
+              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.TapRequest, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "doubleTap"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.TapRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
+              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("doubleTap"))
+              .build();
+        }
+      }
+    }
+    return getDoubleTapMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getEnterTextMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "enterText",
+      requestType = pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest.class,
+      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getEnterTextMethod() {
+    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest, pl.leancode.automatorserver.contracts.Contracts.Empty> getEnterTextMethod;
+    if ((getEnterTextMethod = NativeAutomatorGrpc.getEnterTextMethod) == null) {
+      synchronized (NativeAutomatorGrpc.class) {
+        if ((getEnterTextMethod = NativeAutomatorGrpc.getEnterTextMethod) == null) {
+          NativeAutomatorGrpc.getEnterTextMethod = getEnterTextMethod =
+              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "enterText"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
+              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("enterText"))
+              .build();
+        }
+      }
+    }
+    return getEnterTextMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.SwipeRequest,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getSwipeMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "swipe",
+      requestType = pl.leancode.automatorserver.contracts.Contracts.SwipeRequest.class,
+      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.SwipeRequest,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getSwipeMethod() {
+    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.SwipeRequest, pl.leancode.automatorserver.contracts.Contracts.Empty> getSwipeMethod;
+    if ((getSwipeMethod = NativeAutomatorGrpc.getSwipeMethod) == null) {
+      synchronized (NativeAutomatorGrpc.class) {
+        if ((getSwipeMethod = NativeAutomatorGrpc.getSwipeMethod) == null) {
+          NativeAutomatorGrpc.getSwipeMethod = getSwipeMethod =
+              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.SwipeRequest, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "swipe"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.SwipeRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
+              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("swipe"))
+              .build();
+        }
+      }
+    }
+    return getSwipeMethod;
+  }
+
   private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.AirplaneModeRequest,
       pl.leancode.automatorserver.contracts.Contracts.Empty> getEnableAirplaneModeMethod;
 
@@ -512,161 +667,6 @@ public final class NativeAutomatorGrpc {
       }
     }
     return getDisableDarkModeMethod;
-  }
-
-  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest,
-      pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> getGetNativeWidgetsMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "getNativeWidgets",
-      requestType = pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest.class,
-      responseType = pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest,
-      pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> getGetNativeWidgetsMethod() {
-    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest, pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> getGetNativeWidgetsMethod;
-    if ((getGetNativeWidgetsMethod = NativeAutomatorGrpc.getGetNativeWidgetsMethod) == null) {
-      synchronized (NativeAutomatorGrpc.class) {
-        if ((getGetNativeWidgetsMethod = NativeAutomatorGrpc.getGetNativeWidgetsMethod) == null) {
-          NativeAutomatorGrpc.getGetNativeWidgetsMethod = getGetNativeWidgetsMethod =
-              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest, pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "getNativeWidgets"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("getNativeWidgets"))
-              .build();
-        }
-      }
-    }
-    return getGetNativeWidgetsMethod;
-  }
-
-  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapRequest,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getTapMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "tap",
-      requestType = pl.leancode.automatorserver.contracts.Contracts.TapRequest.class,
-      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapRequest,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getTapMethod() {
-    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapRequest, pl.leancode.automatorserver.contracts.Contracts.Empty> getTapMethod;
-    if ((getTapMethod = NativeAutomatorGrpc.getTapMethod) == null) {
-      synchronized (NativeAutomatorGrpc.class) {
-        if ((getTapMethod = NativeAutomatorGrpc.getTapMethod) == null) {
-          NativeAutomatorGrpc.getTapMethod = getTapMethod =
-              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.TapRequest, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "tap"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.TapRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
-              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("tap"))
-              .build();
-        }
-      }
-    }
-    return getTapMethod;
-  }
-
-  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapRequest,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getDoubleTapMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "doubleTap",
-      requestType = pl.leancode.automatorserver.contracts.Contracts.TapRequest.class,
-      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapRequest,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getDoubleTapMethod() {
-    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapRequest, pl.leancode.automatorserver.contracts.Contracts.Empty> getDoubleTapMethod;
-    if ((getDoubleTapMethod = NativeAutomatorGrpc.getDoubleTapMethod) == null) {
-      synchronized (NativeAutomatorGrpc.class) {
-        if ((getDoubleTapMethod = NativeAutomatorGrpc.getDoubleTapMethod) == null) {
-          NativeAutomatorGrpc.getDoubleTapMethod = getDoubleTapMethod =
-              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.TapRequest, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "doubleTap"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.TapRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
-              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("doubleTap"))
-              .build();
-        }
-      }
-    }
-    return getDoubleTapMethod;
-  }
-
-  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getEnterTextMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "enterText",
-      requestType = pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest.class,
-      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getEnterTextMethod() {
-    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest, pl.leancode.automatorserver.contracts.Contracts.Empty> getEnterTextMethod;
-    if ((getEnterTextMethod = NativeAutomatorGrpc.getEnterTextMethod) == null) {
-      synchronized (NativeAutomatorGrpc.class) {
-        if ((getEnterTextMethod = NativeAutomatorGrpc.getEnterTextMethod) == null) {
-          NativeAutomatorGrpc.getEnterTextMethod = getEnterTextMethod =
-              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "enterText"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
-              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("enterText"))
-              .build();
-        }
-      }
-    }
-    return getEnterTextMethod;
-  }
-
-  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.SwipeRequest,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getSwipeMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "swipe",
-      requestType = pl.leancode.automatorserver.contracts.Contracts.SwipeRequest.class,
-      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.SwipeRequest,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getSwipeMethod() {
-    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.SwipeRequest, pl.leancode.automatorserver.contracts.Contracts.Empty> getSwipeMethod;
-    if ((getSwipeMethod = NativeAutomatorGrpc.getSwipeMethod) == null) {
-      synchronized (NativeAutomatorGrpc.class) {
-        if ((getSwipeMethod = NativeAutomatorGrpc.getSwipeMethod) == null) {
-          NativeAutomatorGrpc.getSwipeMethod = getSwipeMethod =
-              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.SwipeRequest, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "swipe"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.SwipeRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
-              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("swipe"))
-              .build();
-        }
-      }
-    }
-    return getSwipeMethod;
   }
 
   private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty,
@@ -981,6 +981,44 @@ public final class NativeAutomatorGrpc {
 
     /**
      * <pre>
+     * general UI interaction
+     * </pre>
+     */
+    public void getNativeWidgets(pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetNativeWidgetsMethod(), responseObserver);
+    }
+
+    /**
+     */
+    public void tap(pl.leancode.automatorserver.contracts.Contracts.TapRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getTapMethod(), responseObserver);
+    }
+
+    /**
+     */
+    public void doubleTap(pl.leancode.automatorserver.contracts.Contracts.TapRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getDoubleTapMethod(), responseObserver);
+    }
+
+    /**
+     */
+    public void enterText(pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getEnterTextMethod(), responseObserver);
+    }
+
+    /**
+     */
+    public void swipe(pl.leancode.automatorserver.contracts.Contracts.SwipeRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getSwipeMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
      * services
      * </pre>
      */
@@ -1050,44 +1088,6 @@ public final class NativeAutomatorGrpc {
     public void disableDarkMode(pl.leancode.automatorserver.contracts.Contracts.DarkModeRequest request,
         io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getDisableDarkModeMethod(), responseObserver);
-    }
-
-    /**
-     * <pre>
-     * general UI interaction
-     * </pre>
-     */
-    public void getNativeWidgets(pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetNativeWidgetsMethod(), responseObserver);
-    }
-
-    /**
-     */
-    public void tap(pl.leancode.automatorserver.contracts.Contracts.TapRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getTapMethod(), responseObserver);
-    }
-
-    /**
-     */
-    public void doubleTap(pl.leancode.automatorserver.contracts.Contracts.TapRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getDoubleTapMethod(), responseObserver);
-    }
-
-    /**
-     */
-    public void enterText(pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getEnterTextMethod(), responseObserver);
-    }
-
-    /**
-     */
-    public void swipe(pl.leancode.automatorserver.contracts.Contracts.SwipeRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getSwipeMethod(), responseObserver);
     }
 
     /**
@@ -1190,6 +1190,41 @@ public final class NativeAutomatorGrpc {
                 pl.leancode.automatorserver.contracts.Contracts.Empty>(
                   this, METHODID_OPEN_QUICK_SETTINGS)))
           .addMethod(
+            getGetNativeWidgetsMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest,
+                pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse>(
+                  this, METHODID_GET_NATIVE_WIDGETS)))
+          .addMethod(
+            getTapMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                pl.leancode.automatorserver.contracts.Contracts.TapRequest,
+                pl.leancode.automatorserver.contracts.Contracts.Empty>(
+                  this, METHODID_TAP)))
+          .addMethod(
+            getDoubleTapMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                pl.leancode.automatorserver.contracts.Contracts.TapRequest,
+                pl.leancode.automatorserver.contracts.Contracts.Empty>(
+                  this, METHODID_DOUBLE_TAP)))
+          .addMethod(
+            getEnterTextMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest,
+                pl.leancode.automatorserver.contracts.Contracts.Empty>(
+                  this, METHODID_ENTER_TEXT)))
+          .addMethod(
+            getSwipeMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                pl.leancode.automatorserver.contracts.Contracts.SwipeRequest,
+                pl.leancode.automatorserver.contracts.Contracts.Empty>(
+                  this, METHODID_SWIPE)))
+          .addMethod(
             getEnableAirplaneModeMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
@@ -1259,41 +1294,6 @@ public final class NativeAutomatorGrpc {
                 pl.leancode.automatorserver.contracts.Contracts.DarkModeRequest,
                 pl.leancode.automatorserver.contracts.Contracts.Empty>(
                   this, METHODID_DISABLE_DARK_MODE)))
-          .addMethod(
-            getGetNativeWidgetsMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest,
-                pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse>(
-                  this, METHODID_GET_NATIVE_WIDGETS)))
-          .addMethod(
-            getTapMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                pl.leancode.automatorserver.contracts.Contracts.TapRequest,
-                pl.leancode.automatorserver.contracts.Contracts.Empty>(
-                  this, METHODID_TAP)))
-          .addMethod(
-            getDoubleTapMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                pl.leancode.automatorserver.contracts.Contracts.TapRequest,
-                pl.leancode.automatorserver.contracts.Contracts.Empty>(
-                  this, METHODID_DOUBLE_TAP)))
-          .addMethod(
-            getEnterTextMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest,
-                pl.leancode.automatorserver.contracts.Contracts.Empty>(
-                  this, METHODID_ENTER_TEXT)))
-          .addMethod(
-            getSwipeMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                pl.leancode.automatorserver.contracts.Contracts.SwipeRequest,
-                pl.leancode.automatorserver.contracts.Contracts.Empty>(
-                  this, METHODID_SWIPE)))
           .addMethod(
             getOpenNotificationsMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
@@ -1414,6 +1414,49 @@ public final class NativeAutomatorGrpc {
 
     /**
      * <pre>
+     * general UI interaction
+     * </pre>
+     */
+    public void getNativeWidgets(pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getGetNativeWidgetsMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     */
+    public void tap(pl.leancode.automatorserver.contracts.Contracts.TapRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getTapMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     */
+    public void doubleTap(pl.leancode.automatorserver.contracts.Contracts.TapRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getDoubleTapMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     */
+    public void enterText(pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getEnterTextMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     */
+    public void swipe(pl.leancode.automatorserver.contracts.Contracts.SwipeRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getSwipeMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
      * services
      * </pre>
      */
@@ -1493,49 +1536,6 @@ public final class NativeAutomatorGrpc {
         io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getDisableDarkModeMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     * <pre>
-     * general UI interaction
-     * </pre>
-     */
-    public void getNativeWidgets(pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getGetNativeWidgetsMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     */
-    public void tap(pl.leancode.automatorserver.contracts.Contracts.TapRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getTapMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     */
-    public void doubleTap(pl.leancode.automatorserver.contracts.Contracts.TapRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getDoubleTapMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     */
-    public void enterText(pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getEnterTextMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     */
-    public void swipe(pl.leancode.automatorserver.contracts.Contracts.SwipeRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getSwipeMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1662,6 +1662,44 @@ public final class NativeAutomatorGrpc {
 
     /**
      * <pre>
+     * general UI interaction
+     * </pre>
+     */
+    public pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse getNativeWidgets(pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getGetNativeWidgetsMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public pl.leancode.automatorserver.contracts.Contracts.Empty tap(pl.leancode.automatorserver.contracts.Contracts.TapRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getTapMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public pl.leancode.automatorserver.contracts.Contracts.Empty doubleTap(pl.leancode.automatorserver.contracts.Contracts.TapRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getDoubleTapMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public pl.leancode.automatorserver.contracts.Contracts.Empty enterText(pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getEnterTextMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public pl.leancode.automatorserver.contracts.Contracts.Empty swipe(pl.leancode.automatorserver.contracts.Contracts.SwipeRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getSwipeMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
      * services
      * </pre>
      */
@@ -1731,44 +1769,6 @@ public final class NativeAutomatorGrpc {
     public pl.leancode.automatorserver.contracts.Contracts.Empty disableDarkMode(pl.leancode.automatorserver.contracts.Contracts.DarkModeRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getDisableDarkModeMethod(), getCallOptions(), request);
-    }
-
-    /**
-     * <pre>
-     * general UI interaction
-     * </pre>
-     */
-    public pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse getNativeWidgets(pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getGetNativeWidgetsMethod(), getCallOptions(), request);
-    }
-
-    /**
-     */
-    public pl.leancode.automatorserver.contracts.Contracts.Empty tap(pl.leancode.automatorserver.contracts.Contracts.TapRequest request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getTapMethod(), getCallOptions(), request);
-    }
-
-    /**
-     */
-    public pl.leancode.automatorserver.contracts.Contracts.Empty doubleTap(pl.leancode.automatorserver.contracts.Contracts.TapRequest request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getDoubleTapMethod(), getCallOptions(), request);
-    }
-
-    /**
-     */
-    public pl.leancode.automatorserver.contracts.Contracts.Empty enterText(pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getEnterTextMethod(), getCallOptions(), request);
-    }
-
-    /**
-     */
-    public pl.leancode.automatorserver.contracts.Contracts.Empty swipe(pl.leancode.automatorserver.contracts.Contracts.SwipeRequest request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getSwipeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1894,6 +1894,49 @@ public final class NativeAutomatorGrpc {
 
     /**
      * <pre>
+     * general UI interaction
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> getNativeWidgets(
+        pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getGetNativeWidgetsMethod(), getCallOptions()), request);
+    }
+
+    /**
+     */
+    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> tap(
+        pl.leancode.automatorserver.contracts.Contracts.TapRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getTapMethod(), getCallOptions()), request);
+    }
+
+    /**
+     */
+    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> doubleTap(
+        pl.leancode.automatorserver.contracts.Contracts.TapRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getDoubleTapMethod(), getCallOptions()), request);
+    }
+
+    /**
+     */
+    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> enterText(
+        pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getEnterTextMethod(), getCallOptions()), request);
+    }
+
+    /**
+     */
+    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> swipe(
+        pl.leancode.automatorserver.contracts.Contracts.SwipeRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getSwipeMethod(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
      * services
      * </pre>
      */
@@ -1977,49 +2020,6 @@ public final class NativeAutomatorGrpc {
 
     /**
      * <pre>
-     * general UI interaction
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> getNativeWidgets(
-        pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getGetNativeWidgetsMethod(), getCallOptions()), request);
-    }
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> tap(
-        pl.leancode.automatorserver.contracts.Contracts.TapRequest request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getTapMethod(), getCallOptions()), request);
-    }
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> doubleTap(
-        pl.leancode.automatorserver.contracts.Contracts.TapRequest request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getDoubleTapMethod(), getCallOptions()), request);
-    }
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> enterText(
-        pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getEnterTextMethod(), getCallOptions()), request);
-    }
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> swipe(
-        pl.leancode.automatorserver.contracts.Contracts.SwipeRequest request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getSwipeMethod(), getCallOptions()), request);
-    }
-
-    /**
-     * <pre>
      * notifications
      * </pre>
      */
@@ -2087,21 +2087,21 @@ public final class NativeAutomatorGrpc {
   private static final int METHODID_DOUBLE_PRESS_RECENT_APPS = 3;
   private static final int METHODID_OPEN_APP = 4;
   private static final int METHODID_OPEN_QUICK_SETTINGS = 5;
-  private static final int METHODID_ENABLE_AIRPLANE_MODE = 6;
-  private static final int METHODID_DISABLE_AIRPLANE_MODE = 7;
-  private static final int METHODID_ENABLE_WI_FI = 8;
-  private static final int METHODID_DISABLE_WI_FI = 9;
-  private static final int METHODID_ENABLE_CELLULAR = 10;
-  private static final int METHODID_DISABLE_CELLULAR = 11;
-  private static final int METHODID_ENABLE_BLUETOOTH = 12;
-  private static final int METHODID_DISABLE_BLUETOOTH = 13;
-  private static final int METHODID_ENABLE_DARK_MODE = 14;
-  private static final int METHODID_DISABLE_DARK_MODE = 15;
-  private static final int METHODID_GET_NATIVE_WIDGETS = 16;
-  private static final int METHODID_TAP = 17;
-  private static final int METHODID_DOUBLE_TAP = 18;
-  private static final int METHODID_ENTER_TEXT = 19;
-  private static final int METHODID_SWIPE = 20;
+  private static final int METHODID_GET_NATIVE_WIDGETS = 6;
+  private static final int METHODID_TAP = 7;
+  private static final int METHODID_DOUBLE_TAP = 8;
+  private static final int METHODID_ENTER_TEXT = 9;
+  private static final int METHODID_SWIPE = 10;
+  private static final int METHODID_ENABLE_AIRPLANE_MODE = 11;
+  private static final int METHODID_DISABLE_AIRPLANE_MODE = 12;
+  private static final int METHODID_ENABLE_WI_FI = 13;
+  private static final int METHODID_DISABLE_WI_FI = 14;
+  private static final int METHODID_ENABLE_CELLULAR = 15;
+  private static final int METHODID_DISABLE_CELLULAR = 16;
+  private static final int METHODID_ENABLE_BLUETOOTH = 17;
+  private static final int METHODID_DISABLE_BLUETOOTH = 18;
+  private static final int METHODID_ENABLE_DARK_MODE = 19;
+  private static final int METHODID_DISABLE_DARK_MODE = 20;
   private static final int METHODID_OPEN_NOTIFICATIONS = 21;
   private static final int METHODID_CLOSE_NOTIFICATIONS = 22;
   private static final int METHODID_GET_NOTIFICATIONS = 23;
@@ -2151,6 +2151,26 @@ public final class NativeAutomatorGrpc {
           serviceImpl.openQuickSettings((pl.leancode.automatorserver.contracts.Contracts.OpenQuickSettingsRequest) request,
               (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
           break;
+        case METHODID_GET_NATIVE_WIDGETS:
+          serviceImpl.getNativeWidgets((pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest) request,
+              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse>) responseObserver);
+          break;
+        case METHODID_TAP:
+          serviceImpl.tap((pl.leancode.automatorserver.contracts.Contracts.TapRequest) request,
+              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
+          break;
+        case METHODID_DOUBLE_TAP:
+          serviceImpl.doubleTap((pl.leancode.automatorserver.contracts.Contracts.TapRequest) request,
+              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
+          break;
+        case METHODID_ENTER_TEXT:
+          serviceImpl.enterText((pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest) request,
+              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
+          break;
+        case METHODID_SWIPE:
+          serviceImpl.swipe((pl.leancode.automatorserver.contracts.Contracts.SwipeRequest) request,
+              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
+          break;
         case METHODID_ENABLE_AIRPLANE_MODE:
           serviceImpl.enableAirplaneMode((pl.leancode.automatorserver.contracts.Contracts.AirplaneModeRequest) request,
               (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
@@ -2189,26 +2209,6 @@ public final class NativeAutomatorGrpc {
           break;
         case METHODID_DISABLE_DARK_MODE:
           serviceImpl.disableDarkMode((pl.leancode.automatorserver.contracts.Contracts.DarkModeRequest) request,
-              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
-          break;
-        case METHODID_GET_NATIVE_WIDGETS:
-          serviceImpl.getNativeWidgets((pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest) request,
-              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse>) responseObserver);
-          break;
-        case METHODID_TAP:
-          serviceImpl.tap((pl.leancode.automatorserver.contracts.Contracts.TapRequest) request,
-              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
-          break;
-        case METHODID_DOUBLE_TAP:
-          serviceImpl.doubleTap((pl.leancode.automatorserver.contracts.Contracts.TapRequest) request,
-              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
-          break;
-        case METHODID_ENTER_TEXT:
-          serviceImpl.enterText((pl.leancode.automatorserver.contracts.Contracts.EnterTextRequest) request,
-              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
-          break;
-        case METHODID_SWIPE:
-          serviceImpl.swipe((pl.leancode.automatorserver.contracts.Contracts.SwipeRequest) request,
               (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
           break;
         case METHODID_OPEN_NOTIFICATIONS:
@@ -2306,6 +2306,11 @@ public final class NativeAutomatorGrpc {
               .addMethod(getDoublePressRecentAppsMethod())
               .addMethod(getOpenAppMethod())
               .addMethod(getOpenQuickSettingsMethod())
+              .addMethod(getGetNativeWidgetsMethod())
+              .addMethod(getTapMethod())
+              .addMethod(getDoubleTapMethod())
+              .addMethod(getEnterTextMethod())
+              .addMethod(getSwipeMethod())
               .addMethod(getEnableAirplaneModeMethod())
               .addMethod(getDisableAirplaneModeMethod())
               .addMethod(getEnableWiFiMethod())
@@ -2316,11 +2321,6 @@ public final class NativeAutomatorGrpc {
               .addMethod(getDisableBluetoothMethod())
               .addMethod(getEnableDarkModeMethod())
               .addMethod(getDisableDarkModeMethod())
-              .addMethod(getGetNativeWidgetsMethod())
-              .addMethod(getTapMethod())
-              .addMethod(getDoubleTapMethod())
-              .addMethod(getEnterTextMethod())
-              .addMethod(getSwipeMethod())
               .addMethod(getOpenNotificationsMethod())
               .addMethod(getCloseNotificationsMethod())
               .addMethod(getGetNotificationsMethod())

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/NativeAutomatorGrpc.java
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/NativeAutomatorGrpc.java
@@ -173,68 +173,6 @@ public final class NativeAutomatorGrpc {
     return getOpenAppMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getOpenNotificationsMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "openNotifications",
-      requestType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
-      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getOpenNotificationsMethod() {
-    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty, pl.leancode.automatorserver.contracts.Contracts.Empty> getOpenNotificationsMethod;
-    if ((getOpenNotificationsMethod = NativeAutomatorGrpc.getOpenNotificationsMethod) == null) {
-      synchronized (NativeAutomatorGrpc.class) {
-        if ((getOpenNotificationsMethod = NativeAutomatorGrpc.getOpenNotificationsMethod) == null) {
-          NativeAutomatorGrpc.getOpenNotificationsMethod = getOpenNotificationsMethod =
-              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.Empty, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "openNotifications"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
-              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("openNotifications"))
-              .build();
-        }
-      }
-    }
-    return getOpenNotificationsMethod;
-  }
-
-  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getCloseNotificationsMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "closeNotifications",
-      requestType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
-      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getCloseNotificationsMethod() {
-    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty, pl.leancode.automatorserver.contracts.Contracts.Empty> getCloseNotificationsMethod;
-    if ((getCloseNotificationsMethod = NativeAutomatorGrpc.getCloseNotificationsMethod) == null) {
-      synchronized (NativeAutomatorGrpc.class) {
-        if ((getCloseNotificationsMethod = NativeAutomatorGrpc.getCloseNotificationsMethod) == null) {
-          NativeAutomatorGrpc.getCloseNotificationsMethod = getCloseNotificationsMethod =
-              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.Empty, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "closeNotifications"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
-              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("closeNotifications"))
-              .build();
-        }
-      }
-    }
-    return getCloseNotificationsMethod;
-  }
-
   private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.OpenQuickSettingsRequest,
       pl.leancode.automatorserver.contracts.Contracts.Empty> getOpenQuickSettingsMethod;
 
@@ -607,37 +545,6 @@ public final class NativeAutomatorGrpc {
     return getGetNativeWidgetsMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest,
-      pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> getGetNotificationsMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "getNotifications",
-      requestType = pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest.class,
-      responseType = pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest,
-      pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> getGetNotificationsMethod() {
-    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest, pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> getGetNotificationsMethod;
-    if ((getGetNotificationsMethod = NativeAutomatorGrpc.getGetNotificationsMethod) == null) {
-      synchronized (NativeAutomatorGrpc.class) {
-        if ((getGetNotificationsMethod = NativeAutomatorGrpc.getGetNotificationsMethod) == null) {
-          NativeAutomatorGrpc.getGetNotificationsMethod = getGetNotificationsMethod =
-              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest, pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "getNotifications"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("getNotifications"))
-              .build();
-        }
-      }
-    }
-    return getGetNotificationsMethod;
-  }
-
   private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapRequest,
       pl.leancode.automatorserver.contracts.Contracts.Empty> getTapMethod;
 
@@ -762,6 +669,130 @@ public final class NativeAutomatorGrpc {
     return getSwipeMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getOpenNotificationsMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "openNotifications",
+      requestType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
+      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getOpenNotificationsMethod() {
+    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty, pl.leancode.automatorserver.contracts.Contracts.Empty> getOpenNotificationsMethod;
+    if ((getOpenNotificationsMethod = NativeAutomatorGrpc.getOpenNotificationsMethod) == null) {
+      synchronized (NativeAutomatorGrpc.class) {
+        if ((getOpenNotificationsMethod = NativeAutomatorGrpc.getOpenNotificationsMethod) == null) {
+          NativeAutomatorGrpc.getOpenNotificationsMethod = getOpenNotificationsMethod =
+              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.Empty, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "openNotifications"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
+              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("openNotifications"))
+              .build();
+        }
+      }
+    }
+    return getOpenNotificationsMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getCloseNotificationsMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "closeNotifications",
+      requestType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
+      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getCloseNotificationsMethod() {
+    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty, pl.leancode.automatorserver.contracts.Contracts.Empty> getCloseNotificationsMethod;
+    if ((getCloseNotificationsMethod = NativeAutomatorGrpc.getCloseNotificationsMethod) == null) {
+      synchronized (NativeAutomatorGrpc.class) {
+        if ((getCloseNotificationsMethod = NativeAutomatorGrpc.getCloseNotificationsMethod) == null) {
+          NativeAutomatorGrpc.getCloseNotificationsMethod = getCloseNotificationsMethod =
+              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.Empty, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "closeNotifications"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
+              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("closeNotifications"))
+              .build();
+        }
+      }
+    }
+    return getCloseNotificationsMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest,
+      pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> getGetNotificationsMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "getNotifications",
+      requestType = pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest.class,
+      responseType = pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest,
+      pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> getGetNotificationsMethod() {
+    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest, pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> getGetNotificationsMethod;
+    if ((getGetNotificationsMethod = NativeAutomatorGrpc.getGetNotificationsMethod) == null) {
+      synchronized (NativeAutomatorGrpc.class) {
+        if ((getGetNotificationsMethod = NativeAutomatorGrpc.getGetNotificationsMethod) == null) {
+          NativeAutomatorGrpc.getGetNotificationsMethod = getGetNotificationsMethod =
+              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest, pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "getNotifications"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("getNotifications"))
+              .build();
+        }
+      }
+    }
+    return getGetNotificationsMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getTapOnNotificationMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "tapOnNotification",
+      requestType = pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest.class,
+      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest,
+      pl.leancode.automatorserver.contracts.Contracts.Empty> getTapOnNotificationMethod() {
+    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest, pl.leancode.automatorserver.contracts.Contracts.Empty> getTapOnNotificationMethod;
+    if ((getTapOnNotificationMethod = NativeAutomatorGrpc.getTapOnNotificationMethod) == null) {
+      synchronized (NativeAutomatorGrpc.class) {
+        if ((getTapOnNotificationMethod = NativeAutomatorGrpc.getTapOnNotificationMethod) == null) {
+          NativeAutomatorGrpc.getTapOnNotificationMethod = getTapOnNotificationMethod =
+              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "tapOnNotification"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
+              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("tapOnNotification"))
+              .build();
+        }
+      }
+    }
+    return getTapOnNotificationMethod;
+  }
+
   private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.HandlePermissionRequest,
       pl.leancode.automatorserver.contracts.Contracts.Empty> getHandlePermissionDialogMethod;
 
@@ -822,37 +853,6 @@ public final class NativeAutomatorGrpc {
       }
     }
     return getSetLocationAccuracyMethod;
-  }
-
-  private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getTapOnNotificationMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "tapOnNotification",
-      requestType = pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest.class,
-      responseType = pl.leancode.automatorserver.contracts.Contracts.Empty.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest,
-      pl.leancode.automatorserver.contracts.Contracts.Empty> getTapOnNotificationMethod() {
-    io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest, pl.leancode.automatorserver.contracts.Contracts.Empty> getTapOnNotificationMethod;
-    if ((getTapOnNotificationMethod = NativeAutomatorGrpc.getTapOnNotificationMethod) == null) {
-      synchronized (NativeAutomatorGrpc.class) {
-        if ((getTapOnNotificationMethod = NativeAutomatorGrpc.getTapOnNotificationMethod) == null) {
-          NativeAutomatorGrpc.getTapOnNotificationMethod = getTapOnNotificationMethod =
-              io.grpc.MethodDescriptor.<pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest, pl.leancode.automatorserver.contracts.Contracts.Empty>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "tapOnNotification"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  pl.leancode.automatorserver.contracts.Contracts.Empty.getDefaultInstance()))
-              .setSchemaDescriptor(new NativeAutomatorMethodDescriptorSupplier("tapOnNotification"))
-              .build();
-        }
-      }
-    }
-    return getTapOnNotificationMethod;
   }
 
   private static volatile io.grpc.MethodDescriptor<pl.leancode.automatorserver.contracts.Contracts.Empty,
@@ -974,20 +974,6 @@ public final class NativeAutomatorGrpc {
 
     /**
      */
-    public void openNotifications(pl.leancode.automatorserver.contracts.Contracts.Empty request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getOpenNotificationsMethod(), responseObserver);
-    }
-
-    /**
-     */
-    public void closeNotifications(pl.leancode.automatorserver.contracts.Contracts.Empty request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getCloseNotificationsMethod(), responseObserver);
-    }
-
-    /**
-     */
     public void openQuickSettings(pl.leancode.automatorserver.contracts.Contracts.OpenQuickSettingsRequest request,
         io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getOpenQuickSettingsMethod(), responseObserver);
@@ -1067,17 +1053,13 @@ public final class NativeAutomatorGrpc {
     }
 
     /**
+     * <pre>
+     * general UI interaction
+     * </pre>
      */
     public void getNativeWidgets(pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest request,
         io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetNativeWidgetsMethod(), responseObserver);
-    }
-
-    /**
-     */
-    public void getNotifications(pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetNotificationsMethod(), responseObserver);
     }
 
     /**
@@ -1109,6 +1091,40 @@ public final class NativeAutomatorGrpc {
     }
 
     /**
+     * <pre>
+     * notifications
+     * </pre>
+     */
+    public void openNotifications(pl.leancode.automatorserver.contracts.Contracts.Empty request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getOpenNotificationsMethod(), responseObserver);
+    }
+
+    /**
+     */
+    public void closeNotifications(pl.leancode.automatorserver.contracts.Contracts.Empty request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getCloseNotificationsMethod(), responseObserver);
+    }
+
+    /**
+     */
+    public void getNotifications(pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetNotificationsMethod(), responseObserver);
+    }
+
+    /**
+     */
+    public void tapOnNotification(pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getTapOnNotificationMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * permissions
+     * </pre>
      */
     public void handlePermissionDialog(pl.leancode.automatorserver.contracts.Contracts.HandlePermissionRequest request,
         io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
@@ -1120,13 +1136,6 @@ public final class NativeAutomatorGrpc {
     public void setLocationAccuracy(pl.leancode.automatorserver.contracts.Contracts.SetLocationAccuracyRequest request,
         io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getSetLocationAccuracyMethod(), responseObserver);
-    }
-
-    /**
-     */
-    public void tapOnNotification(pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getTapOnNotificationMethod(), responseObserver);
     }
 
     /**
@@ -1173,20 +1182,6 @@ public final class NativeAutomatorGrpc {
                 pl.leancode.automatorserver.contracts.Contracts.OpenAppRequest,
                 pl.leancode.automatorserver.contracts.Contracts.Empty>(
                   this, METHODID_OPEN_APP)))
-          .addMethod(
-            getOpenNotificationsMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                pl.leancode.automatorserver.contracts.Contracts.Empty,
-                pl.leancode.automatorserver.contracts.Contracts.Empty>(
-                  this, METHODID_OPEN_NOTIFICATIONS)))
-          .addMethod(
-            getCloseNotificationsMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                pl.leancode.automatorserver.contracts.Contracts.Empty,
-                pl.leancode.automatorserver.contracts.Contracts.Empty>(
-                  this, METHODID_CLOSE_NOTIFICATIONS)))
           .addMethod(
             getOpenQuickSettingsMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
@@ -1272,13 +1267,6 @@ public final class NativeAutomatorGrpc {
                 pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse>(
                   this, METHODID_GET_NATIVE_WIDGETS)))
           .addMethod(
-            getGetNotificationsMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest,
-                pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse>(
-                  this, METHODID_GET_NOTIFICATIONS)))
-          .addMethod(
             getTapMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
@@ -1307,6 +1295,34 @@ public final class NativeAutomatorGrpc {
                 pl.leancode.automatorserver.contracts.Contracts.Empty>(
                   this, METHODID_SWIPE)))
           .addMethod(
+            getOpenNotificationsMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                pl.leancode.automatorserver.contracts.Contracts.Empty,
+                pl.leancode.automatorserver.contracts.Contracts.Empty>(
+                  this, METHODID_OPEN_NOTIFICATIONS)))
+          .addMethod(
+            getCloseNotificationsMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                pl.leancode.automatorserver.contracts.Contracts.Empty,
+                pl.leancode.automatorserver.contracts.Contracts.Empty>(
+                  this, METHODID_CLOSE_NOTIFICATIONS)))
+          .addMethod(
+            getGetNotificationsMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest,
+                pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse>(
+                  this, METHODID_GET_NOTIFICATIONS)))
+          .addMethod(
+            getTapOnNotificationMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest,
+                pl.leancode.automatorserver.contracts.Contracts.Empty>(
+                  this, METHODID_TAP_ON_NOTIFICATION)))
+          .addMethod(
             getHandlePermissionDialogMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
@@ -1320,13 +1336,6 @@ public final class NativeAutomatorGrpc {
                 pl.leancode.automatorserver.contracts.Contracts.SetLocationAccuracyRequest,
                 pl.leancode.automatorserver.contracts.Contracts.Empty>(
                   this, METHODID_SET_LOCATION_ACCURACY)))
-          .addMethod(
-            getTapOnNotificationMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest,
-                pl.leancode.automatorserver.contracts.Contracts.Empty>(
-                  this, METHODID_TAP_ON_NOTIFICATION)))
           .addMethod(
             getDebugMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
@@ -1393,22 +1402,6 @@ public final class NativeAutomatorGrpc {
         io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getOpenAppMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     */
-    public void openNotifications(pl.leancode.automatorserver.contracts.Contracts.Empty request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getOpenNotificationsMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     */
-    public void closeNotifications(pl.leancode.automatorserver.contracts.Contracts.Empty request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getCloseNotificationsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1503,19 +1496,14 @@ public final class NativeAutomatorGrpc {
     }
 
     /**
+     * <pre>
+     * general UI interaction
+     * </pre>
      */
     public void getNativeWidgets(pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest request,
         io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getGetNativeWidgetsMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     */
-    public void getNotifications(pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getGetNotificationsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1551,6 +1539,44 @@ public final class NativeAutomatorGrpc {
     }
 
     /**
+     * <pre>
+     * notifications
+     * </pre>
+     */
+    public void openNotifications(pl.leancode.automatorserver.contracts.Contracts.Empty request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getOpenNotificationsMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     */
+    public void closeNotifications(pl.leancode.automatorserver.contracts.Contracts.Empty request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getCloseNotificationsMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     */
+    public void getNotifications(pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getGetNotificationsMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     */
+    public void tapOnNotification(pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest request,
+        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getTapOnNotificationMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * permissions
+     * </pre>
      */
     public void handlePermissionDialog(pl.leancode.automatorserver.contracts.Contracts.HandlePermissionRequest request,
         io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
@@ -1564,14 +1590,6 @@ public final class NativeAutomatorGrpc {
         io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getSetLocationAccuracyMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     */
-    public void tapOnNotification(pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest request,
-        io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getTapOnNotificationMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1633,20 +1651,6 @@ public final class NativeAutomatorGrpc {
     public pl.leancode.automatorserver.contracts.Contracts.Empty openApp(pl.leancode.automatorserver.contracts.Contracts.OpenAppRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getOpenAppMethod(), getCallOptions(), request);
-    }
-
-    /**
-     */
-    public pl.leancode.automatorserver.contracts.Contracts.Empty openNotifications(pl.leancode.automatorserver.contracts.Contracts.Empty request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getOpenNotificationsMethod(), getCallOptions(), request);
-    }
-
-    /**
-     */
-    public pl.leancode.automatorserver.contracts.Contracts.Empty closeNotifications(pl.leancode.automatorserver.contracts.Contracts.Empty request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getCloseNotificationsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1730,17 +1734,13 @@ public final class NativeAutomatorGrpc {
     }
 
     /**
+     * <pre>
+     * general UI interaction
+     * </pre>
      */
     public pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse getNativeWidgets(pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getGetNativeWidgetsMethod(), getCallOptions(), request);
-    }
-
-    /**
-     */
-    public pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse getNotifications(pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getGetNotificationsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1772,6 +1772,40 @@ public final class NativeAutomatorGrpc {
     }
 
     /**
+     * <pre>
+     * notifications
+     * </pre>
+     */
+    public pl.leancode.automatorserver.contracts.Contracts.Empty openNotifications(pl.leancode.automatorserver.contracts.Contracts.Empty request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getOpenNotificationsMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public pl.leancode.automatorserver.contracts.Contracts.Empty closeNotifications(pl.leancode.automatorserver.contracts.Contracts.Empty request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getCloseNotificationsMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse getNotifications(pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getGetNotificationsMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public pl.leancode.automatorserver.contracts.Contracts.Empty tapOnNotification(pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getTapOnNotificationMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * permissions
+     * </pre>
      */
     public pl.leancode.automatorserver.contracts.Contracts.Empty handlePermissionDialog(pl.leancode.automatorserver.contracts.Contracts.HandlePermissionRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
@@ -1783,13 +1817,6 @@ public final class NativeAutomatorGrpc {
     public pl.leancode.automatorserver.contracts.Contracts.Empty setLocationAccuracy(pl.leancode.automatorserver.contracts.Contracts.SetLocationAccuracyRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getSetLocationAccuracyMethod(), getCallOptions(), request);
-    }
-
-    /**
-     */
-    public pl.leancode.automatorserver.contracts.Contracts.Empty tapOnNotification(pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getTapOnNotificationMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1855,22 +1882,6 @@ public final class NativeAutomatorGrpc {
         pl.leancode.automatorserver.contracts.Contracts.OpenAppRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getOpenAppMethod(), getCallOptions()), request);
-    }
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> openNotifications(
-        pl.leancode.automatorserver.contracts.Contracts.Empty request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getOpenNotificationsMethod(), getCallOptions()), request);
-    }
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> closeNotifications(
-        pl.leancode.automatorserver.contracts.Contracts.Empty request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getCloseNotificationsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1965,19 +1976,14 @@ public final class NativeAutomatorGrpc {
     }
 
     /**
+     * <pre>
+     * general UI interaction
+     * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse> getNativeWidgets(
         pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getGetNativeWidgetsMethod(), getCallOptions()), request);
-    }
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> getNotifications(
-        pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getGetNotificationsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2013,6 +2019,44 @@ public final class NativeAutomatorGrpc {
     }
 
     /**
+     * <pre>
+     * notifications
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> openNotifications(
+        pl.leancode.automatorserver.contracts.Contracts.Empty request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getOpenNotificationsMethod(), getCallOptions()), request);
+    }
+
+    /**
+     */
+    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> closeNotifications(
+        pl.leancode.automatorserver.contracts.Contracts.Empty request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getCloseNotificationsMethod(), getCallOptions()), request);
+    }
+
+    /**
+     */
+    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse> getNotifications(
+        pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getGetNotificationsMethod(), getCallOptions()), request);
+    }
+
+    /**
+     */
+    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> tapOnNotification(
+        pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getTapOnNotificationMethod(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * permissions
+     * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> handlePermissionDialog(
         pl.leancode.automatorserver.contracts.Contracts.HandlePermissionRequest request) {
@@ -2030,14 +2074,6 @@ public final class NativeAutomatorGrpc {
 
     /**
      */
-    public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> tapOnNotification(
-        pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getTapOnNotificationMethod(), getCallOptions()), request);
-    }
-
-    /**
-     */
     public com.google.common.util.concurrent.ListenableFuture<pl.leancode.automatorserver.contracts.Contracts.Empty> debug(
         pl.leancode.automatorserver.contracts.Contracts.Empty request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
@@ -2050,28 +2086,28 @@ public final class NativeAutomatorGrpc {
   private static final int METHODID_PRESS_RECENT_APPS = 2;
   private static final int METHODID_DOUBLE_PRESS_RECENT_APPS = 3;
   private static final int METHODID_OPEN_APP = 4;
-  private static final int METHODID_OPEN_NOTIFICATIONS = 5;
-  private static final int METHODID_CLOSE_NOTIFICATIONS = 6;
-  private static final int METHODID_OPEN_QUICK_SETTINGS = 7;
-  private static final int METHODID_ENABLE_AIRPLANE_MODE = 8;
-  private static final int METHODID_DISABLE_AIRPLANE_MODE = 9;
-  private static final int METHODID_ENABLE_WI_FI = 10;
-  private static final int METHODID_DISABLE_WI_FI = 11;
-  private static final int METHODID_ENABLE_CELLULAR = 12;
-  private static final int METHODID_DISABLE_CELLULAR = 13;
-  private static final int METHODID_ENABLE_BLUETOOTH = 14;
-  private static final int METHODID_DISABLE_BLUETOOTH = 15;
-  private static final int METHODID_ENABLE_DARK_MODE = 16;
-  private static final int METHODID_DISABLE_DARK_MODE = 17;
-  private static final int METHODID_GET_NATIVE_WIDGETS = 18;
-  private static final int METHODID_GET_NOTIFICATIONS = 19;
-  private static final int METHODID_TAP = 20;
-  private static final int METHODID_DOUBLE_TAP = 21;
-  private static final int METHODID_ENTER_TEXT = 22;
-  private static final int METHODID_SWIPE = 23;
-  private static final int METHODID_HANDLE_PERMISSION_DIALOG = 24;
-  private static final int METHODID_SET_LOCATION_ACCURACY = 25;
-  private static final int METHODID_TAP_ON_NOTIFICATION = 26;
+  private static final int METHODID_OPEN_QUICK_SETTINGS = 5;
+  private static final int METHODID_ENABLE_AIRPLANE_MODE = 6;
+  private static final int METHODID_DISABLE_AIRPLANE_MODE = 7;
+  private static final int METHODID_ENABLE_WI_FI = 8;
+  private static final int METHODID_DISABLE_WI_FI = 9;
+  private static final int METHODID_ENABLE_CELLULAR = 10;
+  private static final int METHODID_DISABLE_CELLULAR = 11;
+  private static final int METHODID_ENABLE_BLUETOOTH = 12;
+  private static final int METHODID_DISABLE_BLUETOOTH = 13;
+  private static final int METHODID_ENABLE_DARK_MODE = 14;
+  private static final int METHODID_DISABLE_DARK_MODE = 15;
+  private static final int METHODID_GET_NATIVE_WIDGETS = 16;
+  private static final int METHODID_TAP = 17;
+  private static final int METHODID_DOUBLE_TAP = 18;
+  private static final int METHODID_ENTER_TEXT = 19;
+  private static final int METHODID_SWIPE = 20;
+  private static final int METHODID_OPEN_NOTIFICATIONS = 21;
+  private static final int METHODID_CLOSE_NOTIFICATIONS = 22;
+  private static final int METHODID_GET_NOTIFICATIONS = 23;
+  private static final int METHODID_TAP_ON_NOTIFICATION = 24;
+  private static final int METHODID_HANDLE_PERMISSION_DIALOG = 25;
+  private static final int METHODID_SET_LOCATION_ACCURACY = 26;
   private static final int METHODID_DEBUG = 27;
 
   private static final class MethodHandlers<Req, Resp> implements
@@ -2109,14 +2145,6 @@ public final class NativeAutomatorGrpc {
           break;
         case METHODID_OPEN_APP:
           serviceImpl.openApp((pl.leancode.automatorserver.contracts.Contracts.OpenAppRequest) request,
-              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
-          break;
-        case METHODID_OPEN_NOTIFICATIONS:
-          serviceImpl.openNotifications((pl.leancode.automatorserver.contracts.Contracts.Empty) request,
-              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
-          break;
-        case METHODID_CLOSE_NOTIFICATIONS:
-          serviceImpl.closeNotifications((pl.leancode.automatorserver.contracts.Contracts.Empty) request,
               (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
           break;
         case METHODID_OPEN_QUICK_SETTINGS:
@@ -2167,10 +2195,6 @@ public final class NativeAutomatorGrpc {
           serviceImpl.getNativeWidgets((pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsRequest) request,
               (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNativeWidgetsResponse>) responseObserver);
           break;
-        case METHODID_GET_NOTIFICATIONS:
-          serviceImpl.getNotifications((pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest) request,
-              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse>) responseObserver);
-          break;
         case METHODID_TAP:
           serviceImpl.tap((pl.leancode.automatorserver.contracts.Contracts.TapRequest) request,
               (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
@@ -2187,16 +2211,28 @@ public final class NativeAutomatorGrpc {
           serviceImpl.swipe((pl.leancode.automatorserver.contracts.Contracts.SwipeRequest) request,
               (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
           break;
+        case METHODID_OPEN_NOTIFICATIONS:
+          serviceImpl.openNotifications((pl.leancode.automatorserver.contracts.Contracts.Empty) request,
+              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
+          break;
+        case METHODID_CLOSE_NOTIFICATIONS:
+          serviceImpl.closeNotifications((pl.leancode.automatorserver.contracts.Contracts.Empty) request,
+              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
+          break;
+        case METHODID_GET_NOTIFICATIONS:
+          serviceImpl.getNotifications((pl.leancode.automatorserver.contracts.Contracts.GetNotificationsRequest) request,
+              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.GetNotificationsResponse>) responseObserver);
+          break;
+        case METHODID_TAP_ON_NOTIFICATION:
+          serviceImpl.tapOnNotification((pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest) request,
+              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
+          break;
         case METHODID_HANDLE_PERMISSION_DIALOG:
           serviceImpl.handlePermissionDialog((pl.leancode.automatorserver.contracts.Contracts.HandlePermissionRequest) request,
               (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
           break;
         case METHODID_SET_LOCATION_ACCURACY:
           serviceImpl.setLocationAccuracy((pl.leancode.automatorserver.contracts.Contracts.SetLocationAccuracyRequest) request,
-              (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
-          break;
-        case METHODID_TAP_ON_NOTIFICATION:
-          serviceImpl.tapOnNotification((pl.leancode.automatorserver.contracts.Contracts.TapOnNotificationRequest) request,
               (io.grpc.stub.StreamObserver<pl.leancode.automatorserver.contracts.Contracts.Empty>) responseObserver);
           break;
         case METHODID_DEBUG:
@@ -2269,8 +2305,6 @@ public final class NativeAutomatorGrpc {
               .addMethod(getPressRecentAppsMethod())
               .addMethod(getDoublePressRecentAppsMethod())
               .addMethod(getOpenAppMethod())
-              .addMethod(getOpenNotificationsMethod())
-              .addMethod(getCloseNotificationsMethod())
               .addMethod(getOpenQuickSettingsMethod())
               .addMethod(getEnableAirplaneModeMethod())
               .addMethod(getDisableAirplaneModeMethod())
@@ -2283,14 +2317,16 @@ public final class NativeAutomatorGrpc {
               .addMethod(getEnableDarkModeMethod())
               .addMethod(getDisableDarkModeMethod())
               .addMethod(getGetNativeWidgetsMethod())
-              .addMethod(getGetNotificationsMethod())
               .addMethod(getTapMethod())
               .addMethod(getDoubleTapMethod())
               .addMethod(getEnterTextMethod())
               .addMethod(getSwipeMethod())
+              .addMethod(getOpenNotificationsMethod())
+              .addMethod(getCloseNotificationsMethod())
+              .addMethod(getGetNotificationsMethod())
+              .addMethod(getTapOnNotificationMethod())
               .addMethod(getHandlePermissionDialogMethod())
               .addMethod(getSetLocationAccuracyMethod())
-              .addMethod(getTapOnNotificationMethod())
               .addMethod(getDebugMethod())
               .build();
         }

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/NotificationKt.kt
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/NotificationKt.kt
@@ -79,6 +79,23 @@ object NotificationKt {
     fun clearContent() {
       _builder.clearContent()
     }
+
+    /**
+     * <code>string raw = 4;</code>
+     */
+    var raw: kotlin.String
+      @JvmName("getRaw")
+      get() = _builder.getRaw()
+      @JvmName("setRaw")
+      set(value) {
+        _builder.setRaw(value)
+      }
+    /**
+     * <code>string raw = 4;</code>
+     */
+    fun clearRaw() {
+      _builder.clearRaw()
+    }
   }
 }
 @kotlin.jvm.JvmSynthetic

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/TapRequestKt.kt
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/contracts/TapRequestKt.kt
@@ -23,7 +23,7 @@ object TapRequestKt {
     internal fun _build(): pl.leancode.automatorserver.contracts.Contracts.TapRequest = _builder.build()
 
     /**
-     * <code>.patrol.Selector Selector = 1;</code>
+     * <code>.patrol.Selector selector = 1;</code>
      */
     var selector: pl.leancode.automatorserver.contracts.Contracts.Selector
       @JvmName("getSelector")
@@ -33,13 +33,13 @@ object TapRequestKt {
         _builder.setSelector(value)
       }
     /**
-     * <code>.patrol.Selector Selector = 1;</code>
+     * <code>.patrol.Selector selector = 1;</code>
      */
     fun clearSelector() {
       _builder.clearSelector()
     }
     /**
-     * <code>.patrol.Selector Selector = 1;</code>
+     * <code>.patrol.Selector selector = 1;</code>
      * @return Whether the selector field is set.
      */
     fun hasSelector(): kotlin.Boolean {

--- a/AutomatorServer/ios/AutomatorServerUITests/NativeAutomatorServer.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/NativeAutomatorServer.swift
@@ -245,7 +245,7 @@ final class NativeAutomatorServer: Patrol_NativeAutomatorAsyncProvider {
     case .index(let index):
       automation.tapOnNotification(by: Int(index))
     case .selector(let selector):
-      automation.tapOnNotification(by: selector.text)
+      automation.tapOnNotification(by: selector.textContains)
     default:
       throw PatrolError.generic("tapOnNotification(): neither index nor selector are set")
     }

--- a/AutomatorServer/ios/AutomatorServerUITests/NativeAutomatorServer.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/NativeAutomatorServer.swift
@@ -243,10 +243,14 @@ final class NativeAutomatorServer: Patrol_NativeAutomatorAsyncProvider {
   ) async throws -> Empty {
     switch request.findBy {
     case .index(let index):
-      automation.tapOnNotification(by: index)
+      automation.tapOnNotification(by: Int(index))
     case .selector(let selector):
       automation.tapOnNotification(by: selector.text)
+    default:
+      throw PatrolError.generic("tapOnNotification(): neither index nor selector are set")
     }
+    
+    return Empty()
   }
   
   func debug(

--- a/AutomatorServer/ios/AutomatorServerUITests/NativeAutomatorServer.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/NativeAutomatorServer.swift
@@ -241,7 +241,12 @@ final class NativeAutomatorServer: Patrol_NativeAutomatorAsyncProvider {
     request: Patrol_TapOnNotificationRequest,
     context: GRPCAsyncServerCallContext
   ) async throws -> Empty {
-    throw PatrolError.generic("tapOnNotification() is not supported on iOS")
+    switch request.findBy {
+    case .index(let index):
+      automation.tapOnNotification(by: index)
+    case .selector(let selector):
+      automation.tapOnNotification(by: selector.text)
+    }
   }
   
   func debug(

--- a/AutomatorServer/ios/AutomatorServerUITests/NativeAutomatorServer.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/NativeAutomatorServer.swift
@@ -59,6 +59,14 @@ final class NativeAutomatorServer: Patrol_NativeAutomatorAsyncProvider {
     return Empty()
   }
   
+  func closeHeadsUpNotification(
+    request: Empty,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Empty {
+    try await automation.closeHeadsUpNotification()
+    return Empty()
+  }
+  
   func openQuickSettings(
     request: Patrol_OpenQuickSettingsRequest,
     context: GRPCAsyncServerCallContext

--- a/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
@@ -219,12 +219,18 @@ class PatrolAutomation {
   }
   
   func closeHeadsUpNotification() async throws {
+    // If the notification was triggered just now, let's wait for it
+    try await Task.sleep(nanoseconds: UInt64(2 * Double(NSEC_PER_SEC)))
+    
     runAction("closing heads up notification") {
       let start = self.springboard.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.12))
       let end = self.springboard.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.07))
       start.press(forDuration: 0.1, thenDragTo: end)
     }
     
+    // We can't open notification shade immediately after dismissing
+    // the heads-up notification. Let's wait some reasonable amount of
+    // time for it.
     try await Task.sleep(nanoseconds: UInt64(1 * Double(NSEC_PER_SEC)))
   }
   

--- a/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
@@ -239,6 +239,7 @@ class PatrolAutomation {
       let cells = self.springboard.buttons.matching(identifier: "NotificationCell").allElementsBoundByIndex
       if !cells.indices.contains(index) {
         Logger.shared.e("notification at index \(index) doesn't exist")
+        return
       }
       
       cells[index].tap()

--- a/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
@@ -248,7 +248,7 @@ class PatrolAutomation {
   func tapOnNotification(by index: Int) {
     runAction("tapping on notification at index \(index)") {
       let cells = self.springboard.buttons.matching(identifier: "NotificationCell").allElementsBoundByIndex
-      if !cells.indices.contains(index) {
+      guard cells.indices.contains(index) else {
         Logger.shared.e("notification at index \(index) doesn't exist")
         return
       }

--- a/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
@@ -194,28 +194,28 @@ class PatrolAutomation {
   }
 
   func tap(on text: String, inApp appId: String) {
-    runAction("tapping on \(text)") {
+    runAction("tapping on text \(text)") {
       let app = XCUIApplication(bundleIdentifier: appId)
       app.descendants(matching: .any)[text].firstMatch.tap()
     }
   }
 
   func doubleTap(on text: String, inApp appId: String) {
-    runAction("double tapping on \"\(text)\"") {
+    runAction("double tapping on text \(format: text)") {
       let app = XCUIApplication(bundleIdentifier: appId)
       app.descendants(matching: .any)[text].firstMatch.tap()
     }
   }
 
   func enterText(_ data: String, by text: String, inApp appId: String) {
-    runAction("entering text \"\(text)\"") {
+    runAction("entering text \(format: data) into text field with text \(text)") {
       let app = XCUIApplication(bundleIdentifier: appId)
       app.textFields[text].firstMatch.typeText(data)
     }
   }
 
   func enterText(_ data: String, by index: Int, inApp appId: String) {
-    runAction("entering text \"\(data)\" by index \(index)") {
+    runAction("entering text \(format: data) by index \(index)") {
       let app = XCUIApplication(bundleIdentifier: appId)
       let textField = app.textFields.element(boundBy: index)
       if textField.exists {
@@ -233,10 +233,10 @@ class PatrolAutomation {
       let labels = ["OK", "Allow", "Allow While Using App"]
       
       for label in labels {
-        Logger.shared.i("Checking if button \"\(label)\" exists")
+        Logger.shared.i("Checking if button \(format: label) exists")
         let button = systemAlerts.buttons[label]
         if button.exists {
-          Logger.shared.i("Found button \"\(label)\"")
+          Logger.shared.i("Found button \(format: label)")
           button.tap()
           break
         }
@@ -250,10 +250,10 @@ class PatrolAutomation {
       let labels = ["OK", "Allow", "Allow Once"]
       
       for label in labels {
-        Logger.shared.i("Checking if button \"\(label)\" exists")
+        Logger.shared.i("Checking if button \(format: label) exists")
         let button = systemAlerts.buttons[label]
         if button.exists {
-          Logger.shared.i("Found button \"\(label)\"")
+          Logger.shared.i("Found button \(format: label)")
           button.tap()
           break
         }
@@ -286,6 +286,52 @@ class PatrolAutomation {
       if alerts.buttons["Precise: On"].exists {
         alerts.buttons["Precise: On"].tap()
       }
+    }
+  }
+  
+  func tapOnNotification(by index: Int) {
+    runAction("tapping on notification at index \(index)") {
+      let cells = self.springboard.buttons.allElementsBoundByIndex
+      if !cells.indices.contains(index) {
+        Logger.shared.e("notification at index \(index) doesn't exist")
+        
+      }
+      
+      cells[index].tap()
+    }
+  }
+  
+  func tapOnNotification(by text: String) {
+    runAction("tapping on notification containing text \(format: text)") {
+      let cells = self.springboard.buttons.allElementsBoundByIndex
+      for (i, cell) in cells.enumerated() {
+        if cell.label.contains(text) {
+          Logger.shared.i("Tapping on notification at index \(i) which contains text \(text)")
+          cell.tap()
+        }
+      }
+      
+      Logger.shared.e("No notification contains text \(format: text)")
+    }
+  }
+  
+  func debug() throws {
+    // TODO: Remove later
+    for i in 0...150 {
+      let element = self.springboard.descendants(matching: .any).element(boundBy: i)
+      if !element.exists {
+        break
+      }
+      
+      let label = element.label as String
+      let accLabel = element.accessibilityLabel as String?
+      let ident = element.identifier
+      
+      if label.isEmpty && accLabel?.isEmpty ?? true && ident.isEmpty {
+        continue
+      }
+      
+      Logger.shared.i("index: \(i), label: \(label), accLabel: \(String(describing: accLabel)), ident: \(ident)")
     }
   }
   
@@ -341,24 +387,10 @@ class PatrolAutomation {
 
     group.wait()
   }
-  
-  func debug() throws {
-    // TODO: Remove later
-    for i in 0...150 {
-      let element = self.springboard.descendants(matching: .any).element(boundBy: i)
-      if !element.exists {
-        break
-      }
-      
-      let label = element.label as String
-      let accLabel = element.accessibilityLabel as String?
-      let ident = element.identifier
-      
-      if label.isEmpty && accLabel?.isEmpty ?? true && ident.isEmpty {
-        continue
-      }
-      
-      Logger.shared.i("index: \(i), label: \(label), accLabel: \(String(describing: accLabel)), ident: \(ident)")
-    }
+}
+
+extension String.StringInterpolation {
+  mutating func appendInterpolation(format value: String) {
+      appendInterpolation("\"\(value)\"")
   }
 }

--- a/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
@@ -190,10 +190,6 @@ class PatrolAutomation {
         let notification = Patrol_Notification.with {
           Logger.shared.i("Found notification at index \(i) with label \(format: cell.label)")
           $0.raw = cell.label
-          
-          let components = cell.label.split(separator: ",", maxSplits: 1).map(String.init)
-          $0.appName = components[0]
-          $0.content = components[1]
         }
         notifications.append(notification)
       }

--- a/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
@@ -239,7 +239,6 @@ class PatrolAutomation {
       let cells = self.springboard.buttons.matching(identifier: "NotificationCell").allElementsBoundByIndex
       if !cells.indices.contains(index) {
         Logger.shared.e("notification at index \(index) doesn't exist")
-        self.closeNotifications()
       }
       
       cells[index].tap()
@@ -258,7 +257,6 @@ class PatrolAutomation {
       }
       
       Logger.shared.e("no notification contains text \(format: text)")
-      self.closeNotifications()
     }
   }
   

--- a/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
@@ -218,6 +218,17 @@ class PatrolAutomation {
     }
   }
   
+  func closeHeadsUpNotification() async throws {
+    runAction("closing heads up notification") {
+      let start = self.springboard.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.12))
+      let end = self.springboard.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.07))
+      start.press(forDuration: 0.1, thenDragTo: end)
+    }
+    
+    try await Task.sleep(nanoseconds: UInt64(1 * Double(NSEC_PER_SEC)))
+  }
+  
+  
   func getNotifications() -> [Patrol_Notification] {
     var notifications = [Patrol_Notification]()
     runAction("getting notifications") {
@@ -243,6 +254,7 @@ class PatrolAutomation {
       }
       
       cells[index].tap()
+      self.springboard.staticTexts.matching(identifier: "Open").firstMatch.tap()
     }
   }
   
@@ -253,6 +265,7 @@ class PatrolAutomation {
         if cell.label.contains(text) {
           Logger.shared.i("tapping on notification at index \(i) which contains text \(text)")
           cell.tap()
+          self.springboard.staticTexts.matching(identifier: "Open").firstMatch.tap()
           return
         }
       }

--- a/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
@@ -179,14 +179,23 @@ class PatrolAutomation {
   }
   
   func getNotifications() -> [Patrol_Notification] {
-    let notifications = [Patrol_Notification]()
+    var notifications = [Patrol_Notification]()
     runAction("getting notifications") {
       let cells = self.springboard.buttons.allElementsBoundByIndex
-      for cell in cells {
-        let notification = Patrol_Notification.with {
-          $0.appName = cell.label.components(separatedBy: ",")[0]
-          $0.content = cell.label.components(separatedBy: ",")[1]
+      for (i, cell) in cells.enumerated() {
+        if cell.identifier != "NotificationCell" {
+          continue
         }
+        
+        let notification = Patrol_Notification.with {
+          Logger.shared.i("Found notification at index \(i) with label \(format: cell.label)")
+          $0.raw = cell.label
+          
+          let components = cell.label.split(separator: ",", maxSplits: 1).map(String.init)
+          $0.appName = components[0]
+          $0.content = components[1]
+        }
+        notifications.append(notification)
       }
     }
     
@@ -316,22 +325,24 @@ class PatrolAutomation {
   }
   
   func debug() throws {
-    // TODO: Remove later
-    for i in 0...150 {
-      let element = self.springboard.descendants(matching: .any).element(boundBy: i)
-      if !element.exists {
-        break
+    runAction("debug()") {
+      // TODO: Remove later
+      for i in 0...150 {
+        let element = self.springboard.descendants(matching: .any).element(boundBy: i)
+        if !element.exists {
+          break
+        }
+        
+        let label = element.label as String
+        let accLabel = element.accessibilityLabel as String?
+        let ident = element.identifier
+        
+        if label.isEmpty && accLabel?.isEmpty ?? true && ident.isEmpty {
+          continue
+        }
+        
+        Logger.shared.i("index: \(i), label: \(label), accLabel: \(String(describing: accLabel)), ident: \(ident)")
       }
-      
-      let label = element.label as String
-      let accLabel = element.accessibilityLabel as String?
-      let ident = element.identifier
-      
-      if label.isEmpty && accLabel?.isEmpty ?? true && ident.isEmpty {
-        continue
-      }
-      
-      Logger.shared.i("index: \(i), label: \(label), accLabel: \(String(describing: accLabel)), ident: \(ident)")
     }
   }
   

--- a/AutomatorServer/ios/AutomatorServerUITests/contracts.grpc.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/contracts.grpc.swift
@@ -63,6 +63,31 @@ internal protocol Patrol_NativeAutomatorClientProtocol: GRPCClient {
     callOptions: CallOptions?
   ) -> UnaryCall<Patrol_OpenQuickSettingsRequest, Patrol_Empty>
 
+  func getNativeWidgets(
+    _ request: Patrol_GetNativeWidgetsRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse>
+
+  func tap(
+    _ request: Patrol_TapRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Patrol_TapRequest, Patrol_Empty>
+
+  func doubleTap(
+    _ request: Patrol_TapRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Patrol_TapRequest, Patrol_Empty>
+
+  func enterText(
+    _ request: Patrol_EnterTextRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Patrol_EnterTextRequest, Patrol_Empty>
+
+  func swipe(
+    _ request: Patrol_SwipeRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Patrol_SwipeRequest, Patrol_Empty>
+
   func enableAirplaneMode(
     _ request: Patrol_AirplaneModeRequest,
     callOptions: CallOptions?
@@ -112,31 +137,6 @@ internal protocol Patrol_NativeAutomatorClientProtocol: GRPCClient {
     _ request: Patrol_DarkModeRequest,
     callOptions: CallOptions?
   ) -> UnaryCall<Patrol_DarkModeRequest, Patrol_Empty>
-
-  func getNativeWidgets(
-    _ request: Patrol_GetNativeWidgetsRequest,
-    callOptions: CallOptions?
-  ) -> UnaryCall<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse>
-
-  func tap(
-    _ request: Patrol_TapRequest,
-    callOptions: CallOptions?
-  ) -> UnaryCall<Patrol_TapRequest, Patrol_Empty>
-
-  func doubleTap(
-    _ request: Patrol_TapRequest,
-    callOptions: CallOptions?
-  ) -> UnaryCall<Patrol_TapRequest, Patrol_Empty>
-
-  func enterText(
-    _ request: Patrol_EnterTextRequest,
-    callOptions: CallOptions?
-  ) -> UnaryCall<Patrol_EnterTextRequest, Patrol_Empty>
-
-  func swipe(
-    _ request: Patrol_SwipeRequest,
-    callOptions: CallOptions?
-  ) -> UnaryCall<Patrol_SwipeRequest, Patrol_Empty>
 
   func openNotifications(
     _ request: Patrol_Empty,
@@ -284,6 +284,96 @@ extension Patrol_NativeAutomatorClientProtocol {
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeopenQuickSettingsInterceptors() ?? []
+    )
+  }
+
+  /// general UI interaction
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to getNativeWidgets.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  internal func getNativeWidgets(
+    _ request: Patrol_GetNativeWidgetsRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse> {
+    return self.makeUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.getNativeWidgets.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makegetNativeWidgetsInterceptors() ?? []
+    )
+  }
+
+  /// Unary call to tap
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to tap.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  internal func tap(
+    _ request: Patrol_TapRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Patrol_TapRequest, Patrol_Empty> {
+    return self.makeUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.tap.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.maketapInterceptors() ?? []
+    )
+  }
+
+  /// Unary call to doubleTap
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to doubleTap.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  internal func doubleTap(
+    _ request: Patrol_TapRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Patrol_TapRequest, Patrol_Empty> {
+    return self.makeUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.doubleTap.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makedoubleTapInterceptors() ?? []
+    )
+  }
+
+  /// Unary call to enterText
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to enterText.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  internal func enterText(
+    _ request: Patrol_EnterTextRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Patrol_EnterTextRequest, Patrol_Empty> {
+    return self.makeUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.enterText.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeenterTextInterceptors() ?? []
+    )
+  }
+
+  /// Unary call to swipe
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to swipe.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  internal func swipe(
+    _ request: Patrol_SwipeRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Patrol_SwipeRequest, Patrol_Empty> {
+    return self.makeUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.swipe.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeswipeInterceptors() ?? []
     )
   }
 
@@ -464,96 +554,6 @@ extension Patrol_NativeAutomatorClientProtocol {
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makedisableDarkModeInterceptors() ?? []
-    )
-  }
-
-  /// general UI interaction
-  ///
-  /// - Parameters:
-  ///   - request: Request to send to getNativeWidgets.
-  ///   - callOptions: Call options.
-  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
-  internal func getNativeWidgets(
-    _ request: Patrol_GetNativeWidgetsRequest,
-    callOptions: CallOptions? = nil
-  ) -> UnaryCall<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse> {
-    return self.makeUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.getNativeWidgets.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makegetNativeWidgetsInterceptors() ?? []
-    )
-  }
-
-  /// Unary call to tap
-  ///
-  /// - Parameters:
-  ///   - request: Request to send to tap.
-  ///   - callOptions: Call options.
-  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
-  internal func tap(
-    _ request: Patrol_TapRequest,
-    callOptions: CallOptions? = nil
-  ) -> UnaryCall<Patrol_TapRequest, Patrol_Empty> {
-    return self.makeUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.tap.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.maketapInterceptors() ?? []
-    )
-  }
-
-  /// Unary call to doubleTap
-  ///
-  /// - Parameters:
-  ///   - request: Request to send to doubleTap.
-  ///   - callOptions: Call options.
-  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
-  internal func doubleTap(
-    _ request: Patrol_TapRequest,
-    callOptions: CallOptions? = nil
-  ) -> UnaryCall<Patrol_TapRequest, Patrol_Empty> {
-    return self.makeUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.doubleTap.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makedoubleTapInterceptors() ?? []
-    )
-  }
-
-  /// Unary call to enterText
-  ///
-  /// - Parameters:
-  ///   - request: Request to send to enterText.
-  ///   - callOptions: Call options.
-  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
-  internal func enterText(
-    _ request: Patrol_EnterTextRequest,
-    callOptions: CallOptions? = nil
-  ) -> UnaryCall<Patrol_EnterTextRequest, Patrol_Empty> {
-    return self.makeUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.enterText.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makeenterTextInterceptors() ?? []
-    )
-  }
-
-  /// Unary call to swipe
-  ///
-  /// - Parameters:
-  ///   - request: Request to send to swipe.
-  ///   - callOptions: Call options.
-  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
-  internal func swipe(
-    _ request: Patrol_SwipeRequest,
-    callOptions: CallOptions? = nil
-  ) -> UnaryCall<Patrol_SwipeRequest, Patrol_Empty> {
-    return self.makeUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.swipe.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makeswipeInterceptors() ?? []
     )
   }
 
@@ -780,6 +780,31 @@ internal protocol Patrol_NativeAutomatorAsyncClientProtocol: GRPCClient {
     callOptions: CallOptions?
   ) -> GRPCAsyncUnaryCall<Patrol_OpenQuickSettingsRequest, Patrol_Empty>
 
+  func makeGetNativeWidgetsCall(
+    _ request: Patrol_GetNativeWidgetsRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse>
+
+  func makeTapCall(
+    _ request: Patrol_TapRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Patrol_TapRequest, Patrol_Empty>
+
+  func makeDoubleTapCall(
+    _ request: Patrol_TapRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Patrol_TapRequest, Patrol_Empty>
+
+  func makeEnterTextCall(
+    _ request: Patrol_EnterTextRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Patrol_EnterTextRequest, Patrol_Empty>
+
+  func makeSwipeCall(
+    _ request: Patrol_SwipeRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Patrol_SwipeRequest, Patrol_Empty>
+
   func makeEnableAirplaneModeCall(
     _ request: Patrol_AirplaneModeRequest,
     callOptions: CallOptions?
@@ -829,31 +854,6 @@ internal protocol Patrol_NativeAutomatorAsyncClientProtocol: GRPCClient {
     _ request: Patrol_DarkModeRequest,
     callOptions: CallOptions?
   ) -> GRPCAsyncUnaryCall<Patrol_DarkModeRequest, Patrol_Empty>
-
-  func makeGetNativeWidgetsCall(
-    _ request: Patrol_GetNativeWidgetsRequest,
-    callOptions: CallOptions?
-  ) -> GRPCAsyncUnaryCall<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse>
-
-  func makeTapCall(
-    _ request: Patrol_TapRequest,
-    callOptions: CallOptions?
-  ) -> GRPCAsyncUnaryCall<Patrol_TapRequest, Patrol_Empty>
-
-  func makeDoubleTapCall(
-    _ request: Patrol_TapRequest,
-    callOptions: CallOptions?
-  ) -> GRPCAsyncUnaryCall<Patrol_TapRequest, Patrol_Empty>
-
-  func makeEnterTextCall(
-    _ request: Patrol_EnterTextRequest,
-    callOptions: CallOptions?
-  ) -> GRPCAsyncUnaryCall<Patrol_EnterTextRequest, Patrol_Empty>
-
-  func makeSwipeCall(
-    _ request: Patrol_SwipeRequest,
-    callOptions: CallOptions?
-  ) -> GRPCAsyncUnaryCall<Patrol_SwipeRequest, Patrol_Empty>
 
   func makeOpenNotificationsCall(
     _ request: Patrol_Empty,
@@ -970,6 +970,66 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeopenQuickSettingsInterceptors() ?? []
+    )
+  }
+
+  internal func makeGetNativeWidgetsCall(
+    _ request: Patrol_GetNativeWidgetsRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse> {
+    return self.makeAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.getNativeWidgets.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makegetNativeWidgetsInterceptors() ?? []
+    )
+  }
+
+  internal func makeTapCall(
+    _ request: Patrol_TapRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Patrol_TapRequest, Patrol_Empty> {
+    return self.makeAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.tap.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.maketapInterceptors() ?? []
+    )
+  }
+
+  internal func makeDoubleTapCall(
+    _ request: Patrol_TapRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Patrol_TapRequest, Patrol_Empty> {
+    return self.makeAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.doubleTap.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makedoubleTapInterceptors() ?? []
+    )
+  }
+
+  internal func makeEnterTextCall(
+    _ request: Patrol_EnterTextRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Patrol_EnterTextRequest, Patrol_Empty> {
+    return self.makeAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.enterText.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeenterTextInterceptors() ?? []
+    )
+  }
+
+  internal func makeSwipeCall(
+    _ request: Patrol_SwipeRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Patrol_SwipeRequest, Patrol_Empty> {
+    return self.makeAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.swipe.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeswipeInterceptors() ?? []
     )
   }
 
@@ -1090,66 +1150,6 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makedisableDarkModeInterceptors() ?? []
-    )
-  }
-
-  internal func makeGetNativeWidgetsCall(
-    _ request: Patrol_GetNativeWidgetsRequest,
-    callOptions: CallOptions? = nil
-  ) -> GRPCAsyncUnaryCall<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse> {
-    return self.makeAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.getNativeWidgets.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makegetNativeWidgetsInterceptors() ?? []
-    )
-  }
-
-  internal func makeTapCall(
-    _ request: Patrol_TapRequest,
-    callOptions: CallOptions? = nil
-  ) -> GRPCAsyncUnaryCall<Patrol_TapRequest, Patrol_Empty> {
-    return self.makeAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.tap.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.maketapInterceptors() ?? []
-    )
-  }
-
-  internal func makeDoubleTapCall(
-    _ request: Patrol_TapRequest,
-    callOptions: CallOptions? = nil
-  ) -> GRPCAsyncUnaryCall<Patrol_TapRequest, Patrol_Empty> {
-    return self.makeAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.doubleTap.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makedoubleTapInterceptors() ?? []
-    )
-  }
-
-  internal func makeEnterTextCall(
-    _ request: Patrol_EnterTextRequest,
-    callOptions: CallOptions? = nil
-  ) -> GRPCAsyncUnaryCall<Patrol_EnterTextRequest, Patrol_Empty> {
-    return self.makeAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.enterText.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makeenterTextInterceptors() ?? []
-    )
-  }
-
-  internal func makeSwipeCall(
-    _ request: Patrol_SwipeRequest,
-    callOptions: CallOptions? = nil
-  ) -> GRPCAsyncUnaryCall<Patrol_SwipeRequest, Patrol_Empty> {
-    return self.makeAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.swipe.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makeswipeInterceptors() ?? []
     )
   }
 
@@ -1312,6 +1312,66 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
     )
   }
 
+  internal func getNativeWidgets(
+    _ request: Patrol_GetNativeWidgetsRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Patrol_GetNativeWidgetsResponse {
+    return try await self.performAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.getNativeWidgets.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makegetNativeWidgetsInterceptors() ?? []
+    )
+  }
+
+  internal func tap(
+    _ request: Patrol_TapRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Patrol_Empty {
+    return try await self.performAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.tap.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.maketapInterceptors() ?? []
+    )
+  }
+
+  internal func doubleTap(
+    _ request: Patrol_TapRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Patrol_Empty {
+    return try await self.performAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.doubleTap.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makedoubleTapInterceptors() ?? []
+    )
+  }
+
+  internal func enterText(
+    _ request: Patrol_EnterTextRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Patrol_Empty {
+    return try await self.performAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.enterText.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeenterTextInterceptors() ?? []
+    )
+  }
+
+  internal func swipe(
+    _ request: Patrol_SwipeRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Patrol_Empty {
+    return try await self.performAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.swipe.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeswipeInterceptors() ?? []
+    )
+  }
+
   internal func enableAirplaneMode(
     _ request: Patrol_AirplaneModeRequest,
     callOptions: CallOptions? = nil
@@ -1429,66 +1489,6 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makedisableDarkModeInterceptors() ?? []
-    )
-  }
-
-  internal func getNativeWidgets(
-    _ request: Patrol_GetNativeWidgetsRequest,
-    callOptions: CallOptions? = nil
-  ) async throws -> Patrol_GetNativeWidgetsResponse {
-    return try await self.performAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.getNativeWidgets.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makegetNativeWidgetsInterceptors() ?? []
-    )
-  }
-
-  internal func tap(
-    _ request: Patrol_TapRequest,
-    callOptions: CallOptions? = nil
-  ) async throws -> Patrol_Empty {
-    return try await self.performAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.tap.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.maketapInterceptors() ?? []
-    )
-  }
-
-  internal func doubleTap(
-    _ request: Patrol_TapRequest,
-    callOptions: CallOptions? = nil
-  ) async throws -> Patrol_Empty {
-    return try await self.performAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.doubleTap.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makedoubleTapInterceptors() ?? []
-    )
-  }
-
-  internal func enterText(
-    _ request: Patrol_EnterTextRequest,
-    callOptions: CallOptions? = nil
-  ) async throws -> Patrol_Empty {
-    return try await self.performAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.enterText.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makeenterTextInterceptors() ?? []
-    )
-  }
-
-  internal func swipe(
-    _ request: Patrol_SwipeRequest,
-    callOptions: CallOptions? = nil
-  ) async throws -> Patrol_Empty {
-    return try await self.performAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.swipe.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makeswipeInterceptors() ?? []
     )
   }
 
@@ -1616,6 +1616,21 @@ internal protocol Patrol_NativeAutomatorClientInterceptorFactoryProtocol: GRPCSe
   /// - Returns: Interceptors to use when invoking 'openQuickSettings'.
   func makeopenQuickSettingsInterceptors() -> [ClientInterceptor<Patrol_OpenQuickSettingsRequest, Patrol_Empty>]
 
+  /// - Returns: Interceptors to use when invoking 'getNativeWidgets'.
+  func makegetNativeWidgetsInterceptors() -> [ClientInterceptor<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'tap'.
+  func maketapInterceptors() -> [ClientInterceptor<Patrol_TapRequest, Patrol_Empty>]
+
+  /// - Returns: Interceptors to use when invoking 'doubleTap'.
+  func makedoubleTapInterceptors() -> [ClientInterceptor<Patrol_TapRequest, Patrol_Empty>]
+
+  /// - Returns: Interceptors to use when invoking 'enterText'.
+  func makeenterTextInterceptors() -> [ClientInterceptor<Patrol_EnterTextRequest, Patrol_Empty>]
+
+  /// - Returns: Interceptors to use when invoking 'swipe'.
+  func makeswipeInterceptors() -> [ClientInterceptor<Patrol_SwipeRequest, Patrol_Empty>]
+
   /// - Returns: Interceptors to use when invoking 'enableAirplaneMode'.
   func makeenableAirplaneModeInterceptors() -> [ClientInterceptor<Patrol_AirplaneModeRequest, Patrol_Empty>]
 
@@ -1645,21 +1660,6 @@ internal protocol Patrol_NativeAutomatorClientInterceptorFactoryProtocol: GRPCSe
 
   /// - Returns: Interceptors to use when invoking 'disableDarkMode'.
   func makedisableDarkModeInterceptors() -> [ClientInterceptor<Patrol_DarkModeRequest, Patrol_Empty>]
-
-  /// - Returns: Interceptors to use when invoking 'getNativeWidgets'.
-  func makegetNativeWidgetsInterceptors() -> [ClientInterceptor<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'tap'.
-  func maketapInterceptors() -> [ClientInterceptor<Patrol_TapRequest, Patrol_Empty>]
-
-  /// - Returns: Interceptors to use when invoking 'doubleTap'.
-  func makedoubleTapInterceptors() -> [ClientInterceptor<Patrol_TapRequest, Patrol_Empty>]
-
-  /// - Returns: Interceptors to use when invoking 'enterText'.
-  func makeenterTextInterceptors() -> [ClientInterceptor<Patrol_EnterTextRequest, Patrol_Empty>]
-
-  /// - Returns: Interceptors to use when invoking 'swipe'.
-  func makeswipeInterceptors() -> [ClientInterceptor<Patrol_SwipeRequest, Patrol_Empty>]
 
   /// - Returns: Interceptors to use when invoking 'openNotifications'.
   func makeopenNotificationsInterceptors() -> [ClientInterceptor<Patrol_Empty, Patrol_Empty>]
@@ -1694,6 +1694,11 @@ internal enum Patrol_NativeAutomatorClientMetadata {
       Patrol_NativeAutomatorClientMetadata.Methods.doublePressRecentApps,
       Patrol_NativeAutomatorClientMetadata.Methods.openApp,
       Patrol_NativeAutomatorClientMetadata.Methods.openQuickSettings,
+      Patrol_NativeAutomatorClientMetadata.Methods.getNativeWidgets,
+      Patrol_NativeAutomatorClientMetadata.Methods.tap,
+      Patrol_NativeAutomatorClientMetadata.Methods.doubleTap,
+      Patrol_NativeAutomatorClientMetadata.Methods.enterText,
+      Patrol_NativeAutomatorClientMetadata.Methods.swipe,
       Patrol_NativeAutomatorClientMetadata.Methods.enableAirplaneMode,
       Patrol_NativeAutomatorClientMetadata.Methods.disableAirplaneMode,
       Patrol_NativeAutomatorClientMetadata.Methods.enableWiFi,
@@ -1704,11 +1709,6 @@ internal enum Patrol_NativeAutomatorClientMetadata {
       Patrol_NativeAutomatorClientMetadata.Methods.disableBluetooth,
       Patrol_NativeAutomatorClientMetadata.Methods.enableDarkMode,
       Patrol_NativeAutomatorClientMetadata.Methods.disableDarkMode,
-      Patrol_NativeAutomatorClientMetadata.Methods.getNativeWidgets,
-      Patrol_NativeAutomatorClientMetadata.Methods.tap,
-      Patrol_NativeAutomatorClientMetadata.Methods.doubleTap,
-      Patrol_NativeAutomatorClientMetadata.Methods.enterText,
-      Patrol_NativeAutomatorClientMetadata.Methods.swipe,
       Patrol_NativeAutomatorClientMetadata.Methods.openNotifications,
       Patrol_NativeAutomatorClientMetadata.Methods.closeNotifications,
       Patrol_NativeAutomatorClientMetadata.Methods.getNotifications,
@@ -1753,6 +1753,36 @@ internal enum Patrol_NativeAutomatorClientMetadata {
     internal static let openQuickSettings = GRPCMethodDescriptor(
       name: "openQuickSettings",
       path: "/patrol.NativeAutomator/openQuickSettings",
+      type: GRPCCallType.unary
+    )
+
+    internal static let getNativeWidgets = GRPCMethodDescriptor(
+      name: "getNativeWidgets",
+      path: "/patrol.NativeAutomator/getNativeWidgets",
+      type: GRPCCallType.unary
+    )
+
+    internal static let tap = GRPCMethodDescriptor(
+      name: "tap",
+      path: "/patrol.NativeAutomator/tap",
+      type: GRPCCallType.unary
+    )
+
+    internal static let doubleTap = GRPCMethodDescriptor(
+      name: "doubleTap",
+      path: "/patrol.NativeAutomator/doubleTap",
+      type: GRPCCallType.unary
+    )
+
+    internal static let enterText = GRPCMethodDescriptor(
+      name: "enterText",
+      path: "/patrol.NativeAutomator/enterText",
+      type: GRPCCallType.unary
+    )
+
+    internal static let swipe = GRPCMethodDescriptor(
+      name: "swipe",
+      path: "/patrol.NativeAutomator/swipe",
       type: GRPCCallType.unary
     )
 
@@ -1813,36 +1843,6 @@ internal enum Patrol_NativeAutomatorClientMetadata {
     internal static let disableDarkMode = GRPCMethodDescriptor(
       name: "disableDarkMode",
       path: "/patrol.NativeAutomator/disableDarkMode",
-      type: GRPCCallType.unary
-    )
-
-    internal static let getNativeWidgets = GRPCMethodDescriptor(
-      name: "getNativeWidgets",
-      path: "/patrol.NativeAutomator/getNativeWidgets",
-      type: GRPCCallType.unary
-    )
-
-    internal static let tap = GRPCMethodDescriptor(
-      name: "tap",
-      path: "/patrol.NativeAutomator/tap",
-      type: GRPCCallType.unary
-    )
-
-    internal static let doubleTap = GRPCMethodDescriptor(
-      name: "doubleTap",
-      path: "/patrol.NativeAutomator/doubleTap",
-      type: GRPCCallType.unary
-    )
-
-    internal static let enterText = GRPCMethodDescriptor(
-      name: "enterText",
-      path: "/patrol.NativeAutomator/enterText",
-      type: GRPCCallType.unary
-    )
-
-    internal static let swipe = GRPCMethodDescriptor(
-      name: "swipe",
-      path: "/patrol.NativeAutomator/swipe",
       type: GRPCCallType.unary
     )
 
@@ -1908,6 +1908,17 @@ internal protocol Patrol_NativeAutomatorProvider: CallHandlerProvider {
 
   func openQuickSettings(request: Patrol_OpenQuickSettingsRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 
+  /// general UI interaction
+  func getNativeWidgets(request: Patrol_GetNativeWidgetsRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_GetNativeWidgetsResponse>
+
+  func tap(request: Patrol_TapRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
+
+  func doubleTap(request: Patrol_TapRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
+
+  func enterText(request: Patrol_EnterTextRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
+
+  func swipe(request: Patrol_SwipeRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
+
   /// services
   func enableAirplaneMode(request: Patrol_AirplaneModeRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 
@@ -1928,17 +1939,6 @@ internal protocol Patrol_NativeAutomatorProvider: CallHandlerProvider {
   func enableDarkMode(request: Patrol_DarkModeRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 
   func disableDarkMode(request: Patrol_DarkModeRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
-
-  /// general UI interaction
-  func getNativeWidgets(request: Patrol_GetNativeWidgetsRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_GetNativeWidgetsResponse>
-
-  func tap(request: Patrol_TapRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
-
-  func doubleTap(request: Patrol_TapRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
-
-  func enterText(request: Patrol_EnterTextRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
-
-  func swipe(request: Patrol_SwipeRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 
   /// notifications
   func openNotifications(request: Patrol_Empty, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
@@ -2021,6 +2021,51 @@ extension Patrol_NativeAutomatorProvider {
         responseSerializer: ProtobufSerializer<Patrol_Empty>(),
         interceptors: self.interceptors?.makeopenQuickSettingsInterceptors() ?? [],
         userFunction: self.openQuickSettings(request:context:)
+      )
+
+    case "getNativeWidgets":
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_GetNativeWidgetsRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_GetNativeWidgetsResponse>(),
+        interceptors: self.interceptors?.makegetNativeWidgetsInterceptors() ?? [],
+        userFunction: self.getNativeWidgets(request:context:)
+      )
+
+    case "tap":
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_TapRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.maketapInterceptors() ?? [],
+        userFunction: self.tap(request:context:)
+      )
+
+    case "doubleTap":
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_TapRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.makedoubleTapInterceptors() ?? [],
+        userFunction: self.doubleTap(request:context:)
+      )
+
+    case "enterText":
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_EnterTextRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.makeenterTextInterceptors() ?? [],
+        userFunction: self.enterText(request:context:)
+      )
+
+    case "swipe":
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_SwipeRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.makeswipeInterceptors() ?? [],
+        userFunction: self.swipe(request:context:)
       )
 
     case "enableAirplaneMode":
@@ -2111,51 +2156,6 @@ extension Patrol_NativeAutomatorProvider {
         responseSerializer: ProtobufSerializer<Patrol_Empty>(),
         interceptors: self.interceptors?.makedisableDarkModeInterceptors() ?? [],
         userFunction: self.disableDarkMode(request:context:)
-      )
-
-    case "getNativeWidgets":
-      return UnaryServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_GetNativeWidgetsRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_GetNativeWidgetsResponse>(),
-        interceptors: self.interceptors?.makegetNativeWidgetsInterceptors() ?? [],
-        userFunction: self.getNativeWidgets(request:context:)
-      )
-
-    case "tap":
-      return UnaryServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_TapRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.maketapInterceptors() ?? [],
-        userFunction: self.tap(request:context:)
-      )
-
-    case "doubleTap":
-      return UnaryServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_TapRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.makedoubleTapInterceptors() ?? [],
-        userFunction: self.doubleTap(request:context:)
-      )
-
-    case "enterText":
-      return UnaryServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_EnterTextRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.makeenterTextInterceptors() ?? [],
-        userFunction: self.enterText(request:context:)
-      )
-
-    case "swipe":
-      return UnaryServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_SwipeRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.makeswipeInterceptors() ?? [],
-        userFunction: self.swipe(request:context:)
       )
 
     case "openNotifications":
@@ -2267,6 +2267,32 @@ internal protocol Patrol_NativeAutomatorAsyncProvider: CallHandlerProvider {
     context: GRPCAsyncServerCallContext
   ) async throws -> Patrol_Empty
 
+  /// general UI interaction
+  @Sendable func getNativeWidgets(
+    request: Patrol_GetNativeWidgetsRequest,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Patrol_GetNativeWidgetsResponse
+
+  @Sendable func tap(
+    request: Patrol_TapRequest,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Patrol_Empty
+
+  @Sendable func doubleTap(
+    request: Patrol_TapRequest,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Patrol_Empty
+
+  @Sendable func enterText(
+    request: Patrol_EnterTextRequest,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Patrol_Empty
+
+  @Sendable func swipe(
+    request: Patrol_SwipeRequest,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Patrol_Empty
+
   /// services
   @Sendable func enableAirplaneMode(
     request: Patrol_AirplaneModeRequest,
@@ -2315,32 +2341,6 @@ internal protocol Patrol_NativeAutomatorAsyncProvider: CallHandlerProvider {
 
   @Sendable func disableDarkMode(
     request: Patrol_DarkModeRequest,
-    context: GRPCAsyncServerCallContext
-  ) async throws -> Patrol_Empty
-
-  /// general UI interaction
-  @Sendable func getNativeWidgets(
-    request: Patrol_GetNativeWidgetsRequest,
-    context: GRPCAsyncServerCallContext
-  ) async throws -> Patrol_GetNativeWidgetsResponse
-
-  @Sendable func tap(
-    request: Patrol_TapRequest,
-    context: GRPCAsyncServerCallContext
-  ) async throws -> Patrol_Empty
-
-  @Sendable func doubleTap(
-    request: Patrol_TapRequest,
-    context: GRPCAsyncServerCallContext
-  ) async throws -> Patrol_Empty
-
-  @Sendable func enterText(
-    request: Patrol_EnterTextRequest,
-    context: GRPCAsyncServerCallContext
-  ) async throws -> Patrol_Empty
-
-  @Sendable func swipe(
-    request: Patrol_SwipeRequest,
     context: GRPCAsyncServerCallContext
   ) async throws -> Patrol_Empty
 
@@ -2455,6 +2455,51 @@ extension Patrol_NativeAutomatorAsyncProvider {
         wrapping: self.openQuickSettings(request:context:)
       )
 
+    case "getNativeWidgets":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_GetNativeWidgetsRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_GetNativeWidgetsResponse>(),
+        interceptors: self.interceptors?.makegetNativeWidgetsInterceptors() ?? [],
+        wrapping: self.getNativeWidgets(request:context:)
+      )
+
+    case "tap":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_TapRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.maketapInterceptors() ?? [],
+        wrapping: self.tap(request:context:)
+      )
+
+    case "doubleTap":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_TapRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.makedoubleTapInterceptors() ?? [],
+        wrapping: self.doubleTap(request:context:)
+      )
+
+    case "enterText":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_EnterTextRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.makeenterTextInterceptors() ?? [],
+        wrapping: self.enterText(request:context:)
+      )
+
+    case "swipe":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_SwipeRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.makeswipeInterceptors() ?? [],
+        wrapping: self.swipe(request:context:)
+      )
+
     case "enableAirplaneMode":
       return GRPCAsyncServerHandler(
         context: context,
@@ -2543,51 +2588,6 @@ extension Patrol_NativeAutomatorAsyncProvider {
         responseSerializer: ProtobufSerializer<Patrol_Empty>(),
         interceptors: self.interceptors?.makedisableDarkModeInterceptors() ?? [],
         wrapping: self.disableDarkMode(request:context:)
-      )
-
-    case "getNativeWidgets":
-      return GRPCAsyncServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_GetNativeWidgetsRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_GetNativeWidgetsResponse>(),
-        interceptors: self.interceptors?.makegetNativeWidgetsInterceptors() ?? [],
-        wrapping: self.getNativeWidgets(request:context:)
-      )
-
-    case "tap":
-      return GRPCAsyncServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_TapRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.maketapInterceptors() ?? [],
-        wrapping: self.tap(request:context:)
-      )
-
-    case "doubleTap":
-      return GRPCAsyncServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_TapRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.makedoubleTapInterceptors() ?? [],
-        wrapping: self.doubleTap(request:context:)
-      )
-
-    case "enterText":
-      return GRPCAsyncServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_EnterTextRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.makeenterTextInterceptors() ?? [],
-        wrapping: self.enterText(request:context:)
-      )
-
-    case "swipe":
-      return GRPCAsyncServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_SwipeRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.makeswipeInterceptors() ?? [],
-        wrapping: self.swipe(request:context:)
       )
 
     case "openNotifications":
@@ -2687,6 +2687,26 @@ internal protocol Patrol_NativeAutomatorServerInterceptorFactoryProtocol {
   ///   Defaults to calling `self.makeInterceptors()`.
   func makeopenQuickSettingsInterceptors() -> [ServerInterceptor<Patrol_OpenQuickSettingsRequest, Patrol_Empty>]
 
+  /// - Returns: Interceptors to use when handling 'getNativeWidgets'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makegetNativeWidgetsInterceptors() -> [ServerInterceptor<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse>]
+
+  /// - Returns: Interceptors to use when handling 'tap'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func maketapInterceptors() -> [ServerInterceptor<Patrol_TapRequest, Patrol_Empty>]
+
+  /// - Returns: Interceptors to use when handling 'doubleTap'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makedoubleTapInterceptors() -> [ServerInterceptor<Patrol_TapRequest, Patrol_Empty>]
+
+  /// - Returns: Interceptors to use when handling 'enterText'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeenterTextInterceptors() -> [ServerInterceptor<Patrol_EnterTextRequest, Patrol_Empty>]
+
+  /// - Returns: Interceptors to use when handling 'swipe'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeswipeInterceptors() -> [ServerInterceptor<Patrol_SwipeRequest, Patrol_Empty>]
+
   /// - Returns: Interceptors to use when handling 'enableAirplaneMode'.
   ///   Defaults to calling `self.makeInterceptors()`.
   func makeenableAirplaneModeInterceptors() -> [ServerInterceptor<Patrol_AirplaneModeRequest, Patrol_Empty>]
@@ -2726,26 +2746,6 @@ internal protocol Patrol_NativeAutomatorServerInterceptorFactoryProtocol {
   /// - Returns: Interceptors to use when handling 'disableDarkMode'.
   ///   Defaults to calling `self.makeInterceptors()`.
   func makedisableDarkModeInterceptors() -> [ServerInterceptor<Patrol_DarkModeRequest, Patrol_Empty>]
-
-  /// - Returns: Interceptors to use when handling 'getNativeWidgets'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makegetNativeWidgetsInterceptors() -> [ServerInterceptor<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse>]
-
-  /// - Returns: Interceptors to use when handling 'tap'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func maketapInterceptors() -> [ServerInterceptor<Patrol_TapRequest, Patrol_Empty>]
-
-  /// - Returns: Interceptors to use when handling 'doubleTap'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makedoubleTapInterceptors() -> [ServerInterceptor<Patrol_TapRequest, Patrol_Empty>]
-
-  /// - Returns: Interceptors to use when handling 'enterText'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeenterTextInterceptors() -> [ServerInterceptor<Patrol_EnterTextRequest, Patrol_Empty>]
-
-  /// - Returns: Interceptors to use when handling 'swipe'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeswipeInterceptors() -> [ServerInterceptor<Patrol_SwipeRequest, Patrol_Empty>]
 
   /// - Returns: Interceptors to use when handling 'openNotifications'.
   ///   Defaults to calling `self.makeInterceptors()`.
@@ -2787,6 +2787,11 @@ internal enum Patrol_NativeAutomatorServerMetadata {
       Patrol_NativeAutomatorServerMetadata.Methods.doublePressRecentApps,
       Patrol_NativeAutomatorServerMetadata.Methods.openApp,
       Patrol_NativeAutomatorServerMetadata.Methods.openQuickSettings,
+      Patrol_NativeAutomatorServerMetadata.Methods.getNativeWidgets,
+      Patrol_NativeAutomatorServerMetadata.Methods.tap,
+      Patrol_NativeAutomatorServerMetadata.Methods.doubleTap,
+      Patrol_NativeAutomatorServerMetadata.Methods.enterText,
+      Patrol_NativeAutomatorServerMetadata.Methods.swipe,
       Patrol_NativeAutomatorServerMetadata.Methods.enableAirplaneMode,
       Patrol_NativeAutomatorServerMetadata.Methods.disableAirplaneMode,
       Patrol_NativeAutomatorServerMetadata.Methods.enableWiFi,
@@ -2797,11 +2802,6 @@ internal enum Patrol_NativeAutomatorServerMetadata {
       Patrol_NativeAutomatorServerMetadata.Methods.disableBluetooth,
       Patrol_NativeAutomatorServerMetadata.Methods.enableDarkMode,
       Patrol_NativeAutomatorServerMetadata.Methods.disableDarkMode,
-      Patrol_NativeAutomatorServerMetadata.Methods.getNativeWidgets,
-      Patrol_NativeAutomatorServerMetadata.Methods.tap,
-      Patrol_NativeAutomatorServerMetadata.Methods.doubleTap,
-      Patrol_NativeAutomatorServerMetadata.Methods.enterText,
-      Patrol_NativeAutomatorServerMetadata.Methods.swipe,
       Patrol_NativeAutomatorServerMetadata.Methods.openNotifications,
       Patrol_NativeAutomatorServerMetadata.Methods.closeNotifications,
       Patrol_NativeAutomatorServerMetadata.Methods.getNotifications,
@@ -2846,6 +2846,36 @@ internal enum Patrol_NativeAutomatorServerMetadata {
     internal static let openQuickSettings = GRPCMethodDescriptor(
       name: "openQuickSettings",
       path: "/patrol.NativeAutomator/openQuickSettings",
+      type: GRPCCallType.unary
+    )
+
+    internal static let getNativeWidgets = GRPCMethodDescriptor(
+      name: "getNativeWidgets",
+      path: "/patrol.NativeAutomator/getNativeWidgets",
+      type: GRPCCallType.unary
+    )
+
+    internal static let tap = GRPCMethodDescriptor(
+      name: "tap",
+      path: "/patrol.NativeAutomator/tap",
+      type: GRPCCallType.unary
+    )
+
+    internal static let doubleTap = GRPCMethodDescriptor(
+      name: "doubleTap",
+      path: "/patrol.NativeAutomator/doubleTap",
+      type: GRPCCallType.unary
+    )
+
+    internal static let enterText = GRPCMethodDescriptor(
+      name: "enterText",
+      path: "/patrol.NativeAutomator/enterText",
+      type: GRPCCallType.unary
+    )
+
+    internal static let swipe = GRPCMethodDescriptor(
+      name: "swipe",
+      path: "/patrol.NativeAutomator/swipe",
       type: GRPCCallType.unary
     )
 
@@ -2906,36 +2936,6 @@ internal enum Patrol_NativeAutomatorServerMetadata {
     internal static let disableDarkMode = GRPCMethodDescriptor(
       name: "disableDarkMode",
       path: "/patrol.NativeAutomator/disableDarkMode",
-      type: GRPCCallType.unary
-    )
-
-    internal static let getNativeWidgets = GRPCMethodDescriptor(
-      name: "getNativeWidgets",
-      path: "/patrol.NativeAutomator/getNativeWidgets",
-      type: GRPCCallType.unary
-    )
-
-    internal static let tap = GRPCMethodDescriptor(
-      name: "tap",
-      path: "/patrol.NativeAutomator/tap",
-      type: GRPCCallType.unary
-    )
-
-    internal static let doubleTap = GRPCMethodDescriptor(
-      name: "doubleTap",
-      path: "/patrol.NativeAutomator/doubleTap",
-      type: GRPCCallType.unary
-    )
-
-    internal static let enterText = GRPCMethodDescriptor(
-      name: "enterText",
-      path: "/patrol.NativeAutomator/enterText",
-      type: GRPCCallType.unary
-    )
-
-    internal static let swipe = GRPCMethodDescriptor(
-      name: "swipe",
-      path: "/patrol.NativeAutomator/swipe",
       type: GRPCCallType.unary
     )
 

--- a/AutomatorServer/ios/AutomatorServerUITests/contracts.grpc.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/contracts.grpc.swift
@@ -58,16 +58,6 @@ internal protocol Patrol_NativeAutomatorClientProtocol: GRPCClient {
     callOptions: CallOptions?
   ) -> UnaryCall<Patrol_OpenAppRequest, Patrol_Empty>
 
-  func openNotifications(
-    _ request: Patrol_Empty,
-    callOptions: CallOptions?
-  ) -> UnaryCall<Patrol_Empty, Patrol_Empty>
-
-  func closeNotifications(
-    _ request: Patrol_Empty,
-    callOptions: CallOptions?
-  ) -> UnaryCall<Patrol_Empty, Patrol_Empty>
-
   func openQuickSettings(
     _ request: Patrol_OpenQuickSettingsRequest,
     callOptions: CallOptions?
@@ -128,11 +118,6 @@ internal protocol Patrol_NativeAutomatorClientProtocol: GRPCClient {
     callOptions: CallOptions?
   ) -> UnaryCall<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse>
 
-  func getNotifications(
-    _ request: Patrol_GetNotificationsRequest,
-    callOptions: CallOptions?
-  ) -> UnaryCall<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse>
-
   func tap(
     _ request: Patrol_TapRequest,
     callOptions: CallOptions?
@@ -153,6 +138,26 @@ internal protocol Patrol_NativeAutomatorClientProtocol: GRPCClient {
     callOptions: CallOptions?
   ) -> UnaryCall<Patrol_SwipeRequest, Patrol_Empty>
 
+  func openNotifications(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Patrol_Empty, Patrol_Empty>
+
+  func closeNotifications(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Patrol_Empty, Patrol_Empty>
+
+  func getNotifications(
+    _ request: Patrol_GetNotificationsRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse>
+
+  func tapOnNotification(
+    _ request: Patrol_TapOnNotificationRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Patrol_TapOnNotificationRequest, Patrol_Empty>
+
   func handlePermissionDialog(
     _ request: Patrol_HandlePermissionRequest,
     callOptions: CallOptions?
@@ -162,11 +167,6 @@ internal protocol Patrol_NativeAutomatorClientProtocol: GRPCClient {
     _ request: Patrol_SetLocationAccuracyRequest,
     callOptions: CallOptions?
   ) -> UnaryCall<Patrol_SetLocationAccuracyRequest, Patrol_Empty>
-
-  func tapOnNotification(
-    _ request: Patrol_TapOnNotificationRequest,
-    callOptions: CallOptions?
-  ) -> UnaryCall<Patrol_TapOnNotificationRequest, Patrol_Empty>
 
   func debug(
     _ request: Patrol_Empty,
@@ -266,42 +266,6 @@ extension Patrol_NativeAutomatorClientProtocol {
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeopenAppInterceptors() ?? []
-    )
-  }
-
-  /// Unary call to openNotifications
-  ///
-  /// - Parameters:
-  ///   - request: Request to send to openNotifications.
-  ///   - callOptions: Call options.
-  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
-  internal func openNotifications(
-    _ request: Patrol_Empty,
-    callOptions: CallOptions? = nil
-  ) -> UnaryCall<Patrol_Empty, Patrol_Empty> {
-    return self.makeUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.openNotifications.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makeopenNotificationsInterceptors() ?? []
-    )
-  }
-
-  /// Unary call to closeNotifications
-  ///
-  /// - Parameters:
-  ///   - request: Request to send to closeNotifications.
-  ///   - callOptions: Call options.
-  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
-  internal func closeNotifications(
-    _ request: Patrol_Empty,
-    callOptions: CallOptions? = nil
-  ) -> UnaryCall<Patrol_Empty, Patrol_Empty> {
-    return self.makeUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.closeNotifications.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makecloseNotificationsInterceptors() ?? []
     )
   }
 
@@ -503,7 +467,7 @@ extension Patrol_NativeAutomatorClientProtocol {
     )
   }
 
-  /// Unary call to getNativeWidgets
+  /// general UI interaction
   ///
   /// - Parameters:
   ///   - request: Request to send to getNativeWidgets.
@@ -518,24 +482,6 @@ extension Patrol_NativeAutomatorClientProtocol {
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makegetNativeWidgetsInterceptors() ?? []
-    )
-  }
-
-  /// Unary call to getNotifications
-  ///
-  /// - Parameters:
-  ///   - request: Request to send to getNotifications.
-  ///   - callOptions: Call options.
-  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
-  internal func getNotifications(
-    _ request: Patrol_GetNotificationsRequest,
-    callOptions: CallOptions? = nil
-  ) -> UnaryCall<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse> {
-    return self.makeUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.getNotifications.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makegetNotificationsInterceptors() ?? []
     )
   }
 
@@ -611,7 +557,79 @@ extension Patrol_NativeAutomatorClientProtocol {
     )
   }
 
-  /// Unary call to handlePermissionDialog
+  /// notifications
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to openNotifications.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  internal func openNotifications(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Patrol_Empty, Patrol_Empty> {
+    return self.makeUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.openNotifications.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeopenNotificationsInterceptors() ?? []
+    )
+  }
+
+  /// Unary call to closeNotifications
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to closeNotifications.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  internal func closeNotifications(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Patrol_Empty, Patrol_Empty> {
+    return self.makeUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.closeNotifications.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makecloseNotificationsInterceptors() ?? []
+    )
+  }
+
+  /// Unary call to getNotifications
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to getNotifications.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  internal func getNotifications(
+    _ request: Patrol_GetNotificationsRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse> {
+    return self.makeUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.getNotifications.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makegetNotificationsInterceptors() ?? []
+    )
+  }
+
+  /// Unary call to tapOnNotification
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to tapOnNotification.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  internal func tapOnNotification(
+    _ request: Patrol_TapOnNotificationRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Patrol_TapOnNotificationRequest, Patrol_Empty> {
+    return self.makeUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.tapOnNotification.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.maketapOnNotificationInterceptors() ?? []
+    )
+  }
+
+  /// permissions
   ///
   /// - Parameters:
   ///   - request: Request to send to handlePermissionDialog.
@@ -644,24 +662,6 @@ extension Patrol_NativeAutomatorClientProtocol {
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makesetLocationAccuracyInterceptors() ?? []
-    )
-  }
-
-  /// Unary call to tapOnNotification
-  ///
-  /// - Parameters:
-  ///   - request: Request to send to tapOnNotification.
-  ///   - callOptions: Call options.
-  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
-  internal func tapOnNotification(
-    _ request: Patrol_TapOnNotificationRequest,
-    callOptions: CallOptions? = nil
-  ) -> UnaryCall<Patrol_TapOnNotificationRequest, Patrol_Empty> {
-    return self.makeUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.tapOnNotification.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.maketapOnNotificationInterceptors() ?? []
     )
   }
 
@@ -775,16 +775,6 @@ internal protocol Patrol_NativeAutomatorAsyncClientProtocol: GRPCClient {
     callOptions: CallOptions?
   ) -> GRPCAsyncUnaryCall<Patrol_OpenAppRequest, Patrol_Empty>
 
-  func makeOpenNotificationsCall(
-    _ request: Patrol_Empty,
-    callOptions: CallOptions?
-  ) -> GRPCAsyncUnaryCall<Patrol_Empty, Patrol_Empty>
-
-  func makeCloseNotificationsCall(
-    _ request: Patrol_Empty,
-    callOptions: CallOptions?
-  ) -> GRPCAsyncUnaryCall<Patrol_Empty, Patrol_Empty>
-
   func makeOpenQuickSettingsCall(
     _ request: Patrol_OpenQuickSettingsRequest,
     callOptions: CallOptions?
@@ -845,11 +835,6 @@ internal protocol Patrol_NativeAutomatorAsyncClientProtocol: GRPCClient {
     callOptions: CallOptions?
   ) -> GRPCAsyncUnaryCall<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse>
 
-  func makeGetNotificationsCall(
-    _ request: Patrol_GetNotificationsRequest,
-    callOptions: CallOptions?
-  ) -> GRPCAsyncUnaryCall<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse>
-
   func makeTapCall(
     _ request: Patrol_TapRequest,
     callOptions: CallOptions?
@@ -870,6 +855,26 @@ internal protocol Patrol_NativeAutomatorAsyncClientProtocol: GRPCClient {
     callOptions: CallOptions?
   ) -> GRPCAsyncUnaryCall<Patrol_SwipeRequest, Patrol_Empty>
 
+  func makeOpenNotificationsCall(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Patrol_Empty, Patrol_Empty>
+
+  func makeCloseNotificationsCall(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Patrol_Empty, Patrol_Empty>
+
+  func makeGetNotificationsCall(
+    _ request: Patrol_GetNotificationsRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse>
+
+  func makeTapOnNotificationCall(
+    _ request: Patrol_TapOnNotificationRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Patrol_TapOnNotificationRequest, Patrol_Empty>
+
   func makeHandlePermissionDialogCall(
     _ request: Patrol_HandlePermissionRequest,
     callOptions: CallOptions?
@@ -879,11 +884,6 @@ internal protocol Patrol_NativeAutomatorAsyncClientProtocol: GRPCClient {
     _ request: Patrol_SetLocationAccuracyRequest,
     callOptions: CallOptions?
   ) -> GRPCAsyncUnaryCall<Patrol_SetLocationAccuracyRequest, Patrol_Empty>
-
-  func makeTapOnNotificationCall(
-    _ request: Patrol_TapOnNotificationRequest,
-    callOptions: CallOptions?
-  ) -> GRPCAsyncUnaryCall<Patrol_TapOnNotificationRequest, Patrol_Empty>
 
   func makeDebugCall(
     _ request: Patrol_Empty,
@@ -958,30 +958,6 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeopenAppInterceptors() ?? []
-    )
-  }
-
-  internal func makeOpenNotificationsCall(
-    _ request: Patrol_Empty,
-    callOptions: CallOptions? = nil
-  ) -> GRPCAsyncUnaryCall<Patrol_Empty, Patrol_Empty> {
-    return self.makeAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.openNotifications.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makeopenNotificationsInterceptors() ?? []
-    )
-  }
-
-  internal func makeCloseNotificationsCall(
-    _ request: Patrol_Empty,
-    callOptions: CallOptions? = nil
-  ) -> GRPCAsyncUnaryCall<Patrol_Empty, Patrol_Empty> {
-    return self.makeAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.closeNotifications.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makecloseNotificationsInterceptors() ?? []
     )
   }
 
@@ -1129,18 +1105,6 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
     )
   }
 
-  internal func makeGetNotificationsCall(
-    _ request: Patrol_GetNotificationsRequest,
-    callOptions: CallOptions? = nil
-  ) -> GRPCAsyncUnaryCall<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse> {
-    return self.makeAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.getNotifications.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makegetNotificationsInterceptors() ?? []
-    )
-  }
-
   internal func makeTapCall(
     _ request: Patrol_TapRequest,
     callOptions: CallOptions? = nil
@@ -1189,6 +1153,54 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
     )
   }
 
+  internal func makeOpenNotificationsCall(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Patrol_Empty, Patrol_Empty> {
+    return self.makeAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.openNotifications.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeopenNotificationsInterceptors() ?? []
+    )
+  }
+
+  internal func makeCloseNotificationsCall(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Patrol_Empty, Patrol_Empty> {
+    return self.makeAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.closeNotifications.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makecloseNotificationsInterceptors() ?? []
+    )
+  }
+
+  internal func makeGetNotificationsCall(
+    _ request: Patrol_GetNotificationsRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse> {
+    return self.makeAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.getNotifications.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makegetNotificationsInterceptors() ?? []
+    )
+  }
+
+  internal func makeTapOnNotificationCall(
+    _ request: Patrol_TapOnNotificationRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Patrol_TapOnNotificationRequest, Patrol_Empty> {
+    return self.makeAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.tapOnNotification.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.maketapOnNotificationInterceptors() ?? []
+    )
+  }
+
   internal func makeHandlePermissionDialogCall(
     _ request: Patrol_HandlePermissionRequest,
     callOptions: CallOptions? = nil
@@ -1210,18 +1222,6 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makesetLocationAccuracyInterceptors() ?? []
-    )
-  }
-
-  internal func makeTapOnNotificationCall(
-    _ request: Patrol_TapOnNotificationRequest,
-    callOptions: CallOptions? = nil
-  ) -> GRPCAsyncUnaryCall<Patrol_TapOnNotificationRequest, Patrol_Empty> {
-    return self.makeAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.tapOnNotification.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.maketapOnNotificationInterceptors() ?? []
     )
   }
 
@@ -1297,30 +1297,6 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeopenAppInterceptors() ?? []
-    )
-  }
-
-  internal func openNotifications(
-    _ request: Patrol_Empty,
-    callOptions: CallOptions? = nil
-  ) async throws -> Patrol_Empty {
-    return try await self.performAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.openNotifications.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makeopenNotificationsInterceptors() ?? []
-    )
-  }
-
-  internal func closeNotifications(
-    _ request: Patrol_Empty,
-    callOptions: CallOptions? = nil
-  ) async throws -> Patrol_Empty {
-    return try await self.performAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.closeNotifications.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makecloseNotificationsInterceptors() ?? []
     )
   }
 
@@ -1468,18 +1444,6 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
     )
   }
 
-  internal func getNotifications(
-    _ request: Patrol_GetNotificationsRequest,
-    callOptions: CallOptions? = nil
-  ) async throws -> Patrol_GetNotificationsResponse {
-    return try await self.performAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.getNotifications.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.makegetNotificationsInterceptors() ?? []
-    )
-  }
-
   internal func tap(
     _ request: Patrol_TapRequest,
     callOptions: CallOptions? = nil
@@ -1528,6 +1492,54 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
     )
   }
 
+  internal func openNotifications(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions? = nil
+  ) async throws -> Patrol_Empty {
+    return try await self.performAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.openNotifications.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeopenNotificationsInterceptors() ?? []
+    )
+  }
+
+  internal func closeNotifications(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions? = nil
+  ) async throws -> Patrol_Empty {
+    return try await self.performAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.closeNotifications.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makecloseNotificationsInterceptors() ?? []
+    )
+  }
+
+  internal func getNotifications(
+    _ request: Patrol_GetNotificationsRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Patrol_GetNotificationsResponse {
+    return try await self.performAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.getNotifications.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makegetNotificationsInterceptors() ?? []
+    )
+  }
+
+  internal func tapOnNotification(
+    _ request: Patrol_TapOnNotificationRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Patrol_Empty {
+    return try await self.performAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.tapOnNotification.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.maketapOnNotificationInterceptors() ?? []
+    )
+  }
+
   internal func handlePermissionDialog(
     _ request: Patrol_HandlePermissionRequest,
     callOptions: CallOptions? = nil
@@ -1549,18 +1561,6 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makesetLocationAccuracyInterceptors() ?? []
-    )
-  }
-
-  internal func tapOnNotification(
-    _ request: Patrol_TapOnNotificationRequest,
-    callOptions: CallOptions? = nil
-  ) async throws -> Patrol_Empty {
-    return try await self.performAsyncUnaryCall(
-      path: Patrol_NativeAutomatorClientMetadata.Methods.tapOnNotification.path,
-      request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: self.interceptors?.maketapOnNotificationInterceptors() ?? []
     )
   }
 
@@ -1613,12 +1613,6 @@ internal protocol Patrol_NativeAutomatorClientInterceptorFactoryProtocol: GRPCSe
   /// - Returns: Interceptors to use when invoking 'openApp'.
   func makeopenAppInterceptors() -> [ClientInterceptor<Patrol_OpenAppRequest, Patrol_Empty>]
 
-  /// - Returns: Interceptors to use when invoking 'openNotifications'.
-  func makeopenNotificationsInterceptors() -> [ClientInterceptor<Patrol_Empty, Patrol_Empty>]
-
-  /// - Returns: Interceptors to use when invoking 'closeNotifications'.
-  func makecloseNotificationsInterceptors() -> [ClientInterceptor<Patrol_Empty, Patrol_Empty>]
-
   /// - Returns: Interceptors to use when invoking 'openQuickSettings'.
   func makeopenQuickSettingsInterceptors() -> [ClientInterceptor<Patrol_OpenQuickSettingsRequest, Patrol_Empty>]
 
@@ -1655,9 +1649,6 @@ internal protocol Patrol_NativeAutomatorClientInterceptorFactoryProtocol: GRPCSe
   /// - Returns: Interceptors to use when invoking 'getNativeWidgets'.
   func makegetNativeWidgetsInterceptors() -> [ClientInterceptor<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse>]
 
-  /// - Returns: Interceptors to use when invoking 'getNotifications'.
-  func makegetNotificationsInterceptors() -> [ClientInterceptor<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse>]
-
   /// - Returns: Interceptors to use when invoking 'tap'.
   func maketapInterceptors() -> [ClientInterceptor<Patrol_TapRequest, Patrol_Empty>]
 
@@ -1670,14 +1661,23 @@ internal protocol Patrol_NativeAutomatorClientInterceptorFactoryProtocol: GRPCSe
   /// - Returns: Interceptors to use when invoking 'swipe'.
   func makeswipeInterceptors() -> [ClientInterceptor<Patrol_SwipeRequest, Patrol_Empty>]
 
+  /// - Returns: Interceptors to use when invoking 'openNotifications'.
+  func makeopenNotificationsInterceptors() -> [ClientInterceptor<Patrol_Empty, Patrol_Empty>]
+
+  /// - Returns: Interceptors to use when invoking 'closeNotifications'.
+  func makecloseNotificationsInterceptors() -> [ClientInterceptor<Patrol_Empty, Patrol_Empty>]
+
+  /// - Returns: Interceptors to use when invoking 'getNotifications'.
+  func makegetNotificationsInterceptors() -> [ClientInterceptor<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'tapOnNotification'.
+  func maketapOnNotificationInterceptors() -> [ClientInterceptor<Patrol_TapOnNotificationRequest, Patrol_Empty>]
+
   /// - Returns: Interceptors to use when invoking 'handlePermissionDialog'.
   func makehandlePermissionDialogInterceptors() -> [ClientInterceptor<Patrol_HandlePermissionRequest, Patrol_Empty>]
 
   /// - Returns: Interceptors to use when invoking 'setLocationAccuracy'.
   func makesetLocationAccuracyInterceptors() -> [ClientInterceptor<Patrol_SetLocationAccuracyRequest, Patrol_Empty>]
-
-  /// - Returns: Interceptors to use when invoking 'tapOnNotification'.
-  func maketapOnNotificationInterceptors() -> [ClientInterceptor<Patrol_TapOnNotificationRequest, Patrol_Empty>]
 
   /// - Returns: Interceptors to use when invoking 'debug'.
   func makedebugInterceptors() -> [ClientInterceptor<Patrol_Empty, Patrol_Empty>]
@@ -1693,8 +1693,6 @@ internal enum Patrol_NativeAutomatorClientMetadata {
       Patrol_NativeAutomatorClientMetadata.Methods.pressRecentApps,
       Patrol_NativeAutomatorClientMetadata.Methods.doublePressRecentApps,
       Patrol_NativeAutomatorClientMetadata.Methods.openApp,
-      Patrol_NativeAutomatorClientMetadata.Methods.openNotifications,
-      Patrol_NativeAutomatorClientMetadata.Methods.closeNotifications,
       Patrol_NativeAutomatorClientMetadata.Methods.openQuickSettings,
       Patrol_NativeAutomatorClientMetadata.Methods.enableAirplaneMode,
       Patrol_NativeAutomatorClientMetadata.Methods.disableAirplaneMode,
@@ -1707,14 +1705,16 @@ internal enum Patrol_NativeAutomatorClientMetadata {
       Patrol_NativeAutomatorClientMetadata.Methods.enableDarkMode,
       Patrol_NativeAutomatorClientMetadata.Methods.disableDarkMode,
       Patrol_NativeAutomatorClientMetadata.Methods.getNativeWidgets,
-      Patrol_NativeAutomatorClientMetadata.Methods.getNotifications,
       Patrol_NativeAutomatorClientMetadata.Methods.tap,
       Patrol_NativeAutomatorClientMetadata.Methods.doubleTap,
       Patrol_NativeAutomatorClientMetadata.Methods.enterText,
       Patrol_NativeAutomatorClientMetadata.Methods.swipe,
+      Patrol_NativeAutomatorClientMetadata.Methods.openNotifications,
+      Patrol_NativeAutomatorClientMetadata.Methods.closeNotifications,
+      Patrol_NativeAutomatorClientMetadata.Methods.getNotifications,
+      Patrol_NativeAutomatorClientMetadata.Methods.tapOnNotification,
       Patrol_NativeAutomatorClientMetadata.Methods.handlePermissionDialog,
       Patrol_NativeAutomatorClientMetadata.Methods.setLocationAccuracy,
-      Patrol_NativeAutomatorClientMetadata.Methods.tapOnNotification,
       Patrol_NativeAutomatorClientMetadata.Methods.debug,
     ]
   )
@@ -1747,18 +1747,6 @@ internal enum Patrol_NativeAutomatorClientMetadata {
     internal static let openApp = GRPCMethodDescriptor(
       name: "openApp",
       path: "/patrol.NativeAutomator/openApp",
-      type: GRPCCallType.unary
-    )
-
-    internal static let openNotifications = GRPCMethodDescriptor(
-      name: "openNotifications",
-      path: "/patrol.NativeAutomator/openNotifications",
-      type: GRPCCallType.unary
-    )
-
-    internal static let closeNotifications = GRPCMethodDescriptor(
-      name: "closeNotifications",
-      path: "/patrol.NativeAutomator/closeNotifications",
       type: GRPCCallType.unary
     )
 
@@ -1834,12 +1822,6 @@ internal enum Patrol_NativeAutomatorClientMetadata {
       type: GRPCCallType.unary
     )
 
-    internal static let getNotifications = GRPCMethodDescriptor(
-      name: "getNotifications",
-      path: "/patrol.NativeAutomator/getNotifications",
-      type: GRPCCallType.unary
-    )
-
     internal static let tap = GRPCMethodDescriptor(
       name: "tap",
       path: "/patrol.NativeAutomator/tap",
@@ -1864,6 +1846,30 @@ internal enum Patrol_NativeAutomatorClientMetadata {
       type: GRPCCallType.unary
     )
 
+    internal static let openNotifications = GRPCMethodDescriptor(
+      name: "openNotifications",
+      path: "/patrol.NativeAutomator/openNotifications",
+      type: GRPCCallType.unary
+    )
+
+    internal static let closeNotifications = GRPCMethodDescriptor(
+      name: "closeNotifications",
+      path: "/patrol.NativeAutomator/closeNotifications",
+      type: GRPCCallType.unary
+    )
+
+    internal static let getNotifications = GRPCMethodDescriptor(
+      name: "getNotifications",
+      path: "/patrol.NativeAutomator/getNotifications",
+      type: GRPCCallType.unary
+    )
+
+    internal static let tapOnNotification = GRPCMethodDescriptor(
+      name: "tapOnNotification",
+      path: "/patrol.NativeAutomator/tapOnNotification",
+      type: GRPCCallType.unary
+    )
+
     internal static let handlePermissionDialog = GRPCMethodDescriptor(
       name: "handlePermissionDialog",
       path: "/patrol.NativeAutomator/handlePermissionDialog",
@@ -1873,12 +1879,6 @@ internal enum Patrol_NativeAutomatorClientMetadata {
     internal static let setLocationAccuracy = GRPCMethodDescriptor(
       name: "setLocationAccuracy",
       path: "/patrol.NativeAutomator/setLocationAccuracy",
-      type: GRPCCallType.unary
-    )
-
-    internal static let tapOnNotification = GRPCMethodDescriptor(
-      name: "tapOnNotification",
-      path: "/patrol.NativeAutomator/tapOnNotification",
       type: GRPCCallType.unary
     )
 
@@ -1906,10 +1906,6 @@ internal protocol Patrol_NativeAutomatorProvider: CallHandlerProvider {
 
   func openApp(request: Patrol_OpenAppRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 
-  func openNotifications(request: Patrol_Empty, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
-
-  func closeNotifications(request: Patrol_Empty, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
-
   func openQuickSettings(request: Patrol_OpenQuickSettingsRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 
   /// services
@@ -1933,9 +1929,8 @@ internal protocol Patrol_NativeAutomatorProvider: CallHandlerProvider {
 
   func disableDarkMode(request: Patrol_DarkModeRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 
+  /// general UI interaction
   func getNativeWidgets(request: Patrol_GetNativeWidgetsRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_GetNativeWidgetsResponse>
-
-  func getNotifications(request: Patrol_GetNotificationsRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_GetNotificationsResponse>
 
   func tap(request: Patrol_TapRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 
@@ -1945,11 +1940,19 @@ internal protocol Patrol_NativeAutomatorProvider: CallHandlerProvider {
 
   func swipe(request: Patrol_SwipeRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 
+  /// notifications
+  func openNotifications(request: Patrol_Empty, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
+
+  func closeNotifications(request: Patrol_Empty, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
+
+  func getNotifications(request: Patrol_GetNotificationsRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_GetNotificationsResponse>
+
+  func tapOnNotification(request: Patrol_TapOnNotificationRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
+
+  /// permissions
   func handlePermissionDialog(request: Patrol_HandlePermissionRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 
   func setLocationAccuracy(request: Patrol_SetLocationAccuracyRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
-
-  func tapOnNotification(request: Patrol_TapOnNotificationRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 
   func debug(request: Patrol_Empty, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 }
@@ -2009,24 +2012,6 @@ extension Patrol_NativeAutomatorProvider {
         responseSerializer: ProtobufSerializer<Patrol_Empty>(),
         interceptors: self.interceptors?.makeopenAppInterceptors() ?? [],
         userFunction: self.openApp(request:context:)
-      )
-
-    case "openNotifications":
-      return UnaryServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_Empty>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.makeopenNotificationsInterceptors() ?? [],
-        userFunction: self.openNotifications(request:context:)
-      )
-
-    case "closeNotifications":
-      return UnaryServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_Empty>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.makecloseNotificationsInterceptors() ?? [],
-        userFunction: self.closeNotifications(request:context:)
       )
 
     case "openQuickSettings":
@@ -2137,15 +2122,6 @@ extension Patrol_NativeAutomatorProvider {
         userFunction: self.getNativeWidgets(request:context:)
       )
 
-    case "getNotifications":
-      return UnaryServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_GetNotificationsRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_GetNotificationsResponse>(),
-        interceptors: self.interceptors?.makegetNotificationsInterceptors() ?? [],
-        userFunction: self.getNotifications(request:context:)
-      )
-
     case "tap":
       return UnaryServerHandler(
         context: context,
@@ -2182,6 +2158,42 @@ extension Patrol_NativeAutomatorProvider {
         userFunction: self.swipe(request:context:)
       )
 
+    case "openNotifications":
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_Empty>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.makeopenNotificationsInterceptors() ?? [],
+        userFunction: self.openNotifications(request:context:)
+      )
+
+    case "closeNotifications":
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_Empty>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.makecloseNotificationsInterceptors() ?? [],
+        userFunction: self.closeNotifications(request:context:)
+      )
+
+    case "getNotifications":
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_GetNotificationsRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_GetNotificationsResponse>(),
+        interceptors: self.interceptors?.makegetNotificationsInterceptors() ?? [],
+        userFunction: self.getNotifications(request:context:)
+      )
+
+    case "tapOnNotification":
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_TapOnNotificationRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.maketapOnNotificationInterceptors() ?? [],
+        userFunction: self.tapOnNotification(request:context:)
+      )
+
     case "handlePermissionDialog":
       return UnaryServerHandler(
         context: context,
@@ -2198,15 +2210,6 @@ extension Patrol_NativeAutomatorProvider {
         responseSerializer: ProtobufSerializer<Patrol_Empty>(),
         interceptors: self.interceptors?.makesetLocationAccuracyInterceptors() ?? [],
         userFunction: self.setLocationAccuracy(request:context:)
-      )
-
-    case "tapOnNotification":
-      return UnaryServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_TapOnNotificationRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.maketapOnNotificationInterceptors() ?? [],
-        userFunction: self.tapOnNotification(request:context:)
       )
 
     case "debug":
@@ -2256,16 +2259,6 @@ internal protocol Patrol_NativeAutomatorAsyncProvider: CallHandlerProvider {
 
   @Sendable func openApp(
     request: Patrol_OpenAppRequest,
-    context: GRPCAsyncServerCallContext
-  ) async throws -> Patrol_Empty
-
-  @Sendable func openNotifications(
-    request: Patrol_Empty,
-    context: GRPCAsyncServerCallContext
-  ) async throws -> Patrol_Empty
-
-  @Sendable func closeNotifications(
-    request: Patrol_Empty,
     context: GRPCAsyncServerCallContext
   ) async throws -> Patrol_Empty
 
@@ -2325,15 +2318,11 @@ internal protocol Patrol_NativeAutomatorAsyncProvider: CallHandlerProvider {
     context: GRPCAsyncServerCallContext
   ) async throws -> Patrol_Empty
 
+  /// general UI interaction
   @Sendable func getNativeWidgets(
     request: Patrol_GetNativeWidgetsRequest,
     context: GRPCAsyncServerCallContext
   ) async throws -> Patrol_GetNativeWidgetsResponse
-
-  @Sendable func getNotifications(
-    request: Patrol_GetNotificationsRequest,
-    context: GRPCAsyncServerCallContext
-  ) async throws -> Patrol_GetNotificationsResponse
 
   @Sendable func tap(
     request: Patrol_TapRequest,
@@ -2355,6 +2344,28 @@ internal protocol Patrol_NativeAutomatorAsyncProvider: CallHandlerProvider {
     context: GRPCAsyncServerCallContext
   ) async throws -> Patrol_Empty
 
+  /// notifications
+  @Sendable func openNotifications(
+    request: Patrol_Empty,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Patrol_Empty
+
+  @Sendable func closeNotifications(
+    request: Patrol_Empty,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Patrol_Empty
+
+  @Sendable func getNotifications(
+    request: Patrol_GetNotificationsRequest,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Patrol_GetNotificationsResponse
+
+  @Sendable func tapOnNotification(
+    request: Patrol_TapOnNotificationRequest,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Patrol_Empty
+
+  /// permissions
   @Sendable func handlePermissionDialog(
     request: Patrol_HandlePermissionRequest,
     context: GRPCAsyncServerCallContext
@@ -2362,11 +2373,6 @@ internal protocol Patrol_NativeAutomatorAsyncProvider: CallHandlerProvider {
 
   @Sendable func setLocationAccuracy(
     request: Patrol_SetLocationAccuracyRequest,
-    context: GRPCAsyncServerCallContext
-  ) async throws -> Patrol_Empty
-
-  @Sendable func tapOnNotification(
-    request: Patrol_TapOnNotificationRequest,
     context: GRPCAsyncServerCallContext
   ) async throws -> Patrol_Empty
 
@@ -2438,24 +2444,6 @@ extension Patrol_NativeAutomatorAsyncProvider {
         responseSerializer: ProtobufSerializer<Patrol_Empty>(),
         interceptors: self.interceptors?.makeopenAppInterceptors() ?? [],
         wrapping: self.openApp(request:context:)
-      )
-
-    case "openNotifications":
-      return GRPCAsyncServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_Empty>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.makeopenNotificationsInterceptors() ?? [],
-        wrapping: self.openNotifications(request:context:)
-      )
-
-    case "closeNotifications":
-      return GRPCAsyncServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_Empty>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.makecloseNotificationsInterceptors() ?? [],
-        wrapping: self.closeNotifications(request:context:)
       )
 
     case "openQuickSettings":
@@ -2566,15 +2554,6 @@ extension Patrol_NativeAutomatorAsyncProvider {
         wrapping: self.getNativeWidgets(request:context:)
       )
 
-    case "getNotifications":
-      return GRPCAsyncServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_GetNotificationsRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_GetNotificationsResponse>(),
-        interceptors: self.interceptors?.makegetNotificationsInterceptors() ?? [],
-        wrapping: self.getNotifications(request:context:)
-      )
-
     case "tap":
       return GRPCAsyncServerHandler(
         context: context,
@@ -2611,6 +2590,42 @@ extension Patrol_NativeAutomatorAsyncProvider {
         wrapping: self.swipe(request:context:)
       )
 
+    case "openNotifications":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_Empty>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.makeopenNotificationsInterceptors() ?? [],
+        wrapping: self.openNotifications(request:context:)
+      )
+
+    case "closeNotifications":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_Empty>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.makecloseNotificationsInterceptors() ?? [],
+        wrapping: self.closeNotifications(request:context:)
+      )
+
+    case "getNotifications":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_GetNotificationsRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_GetNotificationsResponse>(),
+        interceptors: self.interceptors?.makegetNotificationsInterceptors() ?? [],
+        wrapping: self.getNotifications(request:context:)
+      )
+
+    case "tapOnNotification":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_TapOnNotificationRequest>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.maketapOnNotificationInterceptors() ?? [],
+        wrapping: self.tapOnNotification(request:context:)
+      )
+
     case "handlePermissionDialog":
       return GRPCAsyncServerHandler(
         context: context,
@@ -2627,15 +2642,6 @@ extension Patrol_NativeAutomatorAsyncProvider {
         responseSerializer: ProtobufSerializer<Patrol_Empty>(),
         interceptors: self.interceptors?.makesetLocationAccuracyInterceptors() ?? [],
         wrapping: self.setLocationAccuracy(request:context:)
-      )
-
-    case "tapOnNotification":
-      return GRPCAsyncServerHandler(
-        context: context,
-        requestDeserializer: ProtobufDeserializer<Patrol_TapOnNotificationRequest>(),
-        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
-        interceptors: self.interceptors?.maketapOnNotificationInterceptors() ?? [],
-        wrapping: self.tapOnNotification(request:context:)
       )
 
     case "debug":
@@ -2676,14 +2682,6 @@ internal protocol Patrol_NativeAutomatorServerInterceptorFactoryProtocol {
   /// - Returns: Interceptors to use when handling 'openApp'.
   ///   Defaults to calling `self.makeInterceptors()`.
   func makeopenAppInterceptors() -> [ServerInterceptor<Patrol_OpenAppRequest, Patrol_Empty>]
-
-  /// - Returns: Interceptors to use when handling 'openNotifications'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeopenNotificationsInterceptors() -> [ServerInterceptor<Patrol_Empty, Patrol_Empty>]
-
-  /// - Returns: Interceptors to use when handling 'closeNotifications'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makecloseNotificationsInterceptors() -> [ServerInterceptor<Patrol_Empty, Patrol_Empty>]
 
   /// - Returns: Interceptors to use when handling 'openQuickSettings'.
   ///   Defaults to calling `self.makeInterceptors()`.
@@ -2733,10 +2731,6 @@ internal protocol Patrol_NativeAutomatorServerInterceptorFactoryProtocol {
   ///   Defaults to calling `self.makeInterceptors()`.
   func makegetNativeWidgetsInterceptors() -> [ServerInterceptor<Patrol_GetNativeWidgetsRequest, Patrol_GetNativeWidgetsResponse>]
 
-  /// - Returns: Interceptors to use when handling 'getNotifications'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makegetNotificationsInterceptors() -> [ServerInterceptor<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse>]
-
   /// - Returns: Interceptors to use when handling 'tap'.
   ///   Defaults to calling `self.makeInterceptors()`.
   func maketapInterceptors() -> [ServerInterceptor<Patrol_TapRequest, Patrol_Empty>]
@@ -2753,6 +2747,22 @@ internal protocol Patrol_NativeAutomatorServerInterceptorFactoryProtocol {
   ///   Defaults to calling `self.makeInterceptors()`.
   func makeswipeInterceptors() -> [ServerInterceptor<Patrol_SwipeRequest, Patrol_Empty>]
 
+  /// - Returns: Interceptors to use when handling 'openNotifications'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeopenNotificationsInterceptors() -> [ServerInterceptor<Patrol_Empty, Patrol_Empty>]
+
+  /// - Returns: Interceptors to use when handling 'closeNotifications'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makecloseNotificationsInterceptors() -> [ServerInterceptor<Patrol_Empty, Patrol_Empty>]
+
+  /// - Returns: Interceptors to use when handling 'getNotifications'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makegetNotificationsInterceptors() -> [ServerInterceptor<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse>]
+
+  /// - Returns: Interceptors to use when handling 'tapOnNotification'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func maketapOnNotificationInterceptors() -> [ServerInterceptor<Patrol_TapOnNotificationRequest, Patrol_Empty>]
+
   /// - Returns: Interceptors to use when handling 'handlePermissionDialog'.
   ///   Defaults to calling `self.makeInterceptors()`.
   func makehandlePermissionDialogInterceptors() -> [ServerInterceptor<Patrol_HandlePermissionRequest, Patrol_Empty>]
@@ -2760,10 +2770,6 @@ internal protocol Patrol_NativeAutomatorServerInterceptorFactoryProtocol {
   /// - Returns: Interceptors to use when handling 'setLocationAccuracy'.
   ///   Defaults to calling `self.makeInterceptors()`.
   func makesetLocationAccuracyInterceptors() -> [ServerInterceptor<Patrol_SetLocationAccuracyRequest, Patrol_Empty>]
-
-  /// - Returns: Interceptors to use when handling 'tapOnNotification'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func maketapOnNotificationInterceptors() -> [ServerInterceptor<Patrol_TapOnNotificationRequest, Patrol_Empty>]
 
   /// - Returns: Interceptors to use when handling 'debug'.
   ///   Defaults to calling `self.makeInterceptors()`.
@@ -2780,8 +2786,6 @@ internal enum Patrol_NativeAutomatorServerMetadata {
       Patrol_NativeAutomatorServerMetadata.Methods.pressRecentApps,
       Patrol_NativeAutomatorServerMetadata.Methods.doublePressRecentApps,
       Patrol_NativeAutomatorServerMetadata.Methods.openApp,
-      Patrol_NativeAutomatorServerMetadata.Methods.openNotifications,
-      Patrol_NativeAutomatorServerMetadata.Methods.closeNotifications,
       Patrol_NativeAutomatorServerMetadata.Methods.openQuickSettings,
       Patrol_NativeAutomatorServerMetadata.Methods.enableAirplaneMode,
       Patrol_NativeAutomatorServerMetadata.Methods.disableAirplaneMode,
@@ -2794,14 +2798,16 @@ internal enum Patrol_NativeAutomatorServerMetadata {
       Patrol_NativeAutomatorServerMetadata.Methods.enableDarkMode,
       Patrol_NativeAutomatorServerMetadata.Methods.disableDarkMode,
       Patrol_NativeAutomatorServerMetadata.Methods.getNativeWidgets,
-      Patrol_NativeAutomatorServerMetadata.Methods.getNotifications,
       Patrol_NativeAutomatorServerMetadata.Methods.tap,
       Patrol_NativeAutomatorServerMetadata.Methods.doubleTap,
       Patrol_NativeAutomatorServerMetadata.Methods.enterText,
       Patrol_NativeAutomatorServerMetadata.Methods.swipe,
+      Patrol_NativeAutomatorServerMetadata.Methods.openNotifications,
+      Patrol_NativeAutomatorServerMetadata.Methods.closeNotifications,
+      Patrol_NativeAutomatorServerMetadata.Methods.getNotifications,
+      Patrol_NativeAutomatorServerMetadata.Methods.tapOnNotification,
       Patrol_NativeAutomatorServerMetadata.Methods.handlePermissionDialog,
       Patrol_NativeAutomatorServerMetadata.Methods.setLocationAccuracy,
-      Patrol_NativeAutomatorServerMetadata.Methods.tapOnNotification,
       Patrol_NativeAutomatorServerMetadata.Methods.debug,
     ]
   )
@@ -2834,18 +2840,6 @@ internal enum Patrol_NativeAutomatorServerMetadata {
     internal static let openApp = GRPCMethodDescriptor(
       name: "openApp",
       path: "/patrol.NativeAutomator/openApp",
-      type: GRPCCallType.unary
-    )
-
-    internal static let openNotifications = GRPCMethodDescriptor(
-      name: "openNotifications",
-      path: "/patrol.NativeAutomator/openNotifications",
-      type: GRPCCallType.unary
-    )
-
-    internal static let closeNotifications = GRPCMethodDescriptor(
-      name: "closeNotifications",
-      path: "/patrol.NativeAutomator/closeNotifications",
       type: GRPCCallType.unary
     )
 
@@ -2921,12 +2915,6 @@ internal enum Patrol_NativeAutomatorServerMetadata {
       type: GRPCCallType.unary
     )
 
-    internal static let getNotifications = GRPCMethodDescriptor(
-      name: "getNotifications",
-      path: "/patrol.NativeAutomator/getNotifications",
-      type: GRPCCallType.unary
-    )
-
     internal static let tap = GRPCMethodDescriptor(
       name: "tap",
       path: "/patrol.NativeAutomator/tap",
@@ -2951,6 +2939,30 @@ internal enum Patrol_NativeAutomatorServerMetadata {
       type: GRPCCallType.unary
     )
 
+    internal static let openNotifications = GRPCMethodDescriptor(
+      name: "openNotifications",
+      path: "/patrol.NativeAutomator/openNotifications",
+      type: GRPCCallType.unary
+    )
+
+    internal static let closeNotifications = GRPCMethodDescriptor(
+      name: "closeNotifications",
+      path: "/patrol.NativeAutomator/closeNotifications",
+      type: GRPCCallType.unary
+    )
+
+    internal static let getNotifications = GRPCMethodDescriptor(
+      name: "getNotifications",
+      path: "/patrol.NativeAutomator/getNotifications",
+      type: GRPCCallType.unary
+    )
+
+    internal static let tapOnNotification = GRPCMethodDescriptor(
+      name: "tapOnNotification",
+      path: "/patrol.NativeAutomator/tapOnNotification",
+      type: GRPCCallType.unary
+    )
+
     internal static let handlePermissionDialog = GRPCMethodDescriptor(
       name: "handlePermissionDialog",
       path: "/patrol.NativeAutomator/handlePermissionDialog",
@@ -2960,12 +2972,6 @@ internal enum Patrol_NativeAutomatorServerMetadata {
     internal static let setLocationAccuracy = GRPCMethodDescriptor(
       name: "setLocationAccuracy",
       path: "/patrol.NativeAutomator/setLocationAccuracy",
-      type: GRPCCallType.unary
-    )
-
-    internal static let tapOnNotification = GRPCMethodDescriptor(
-      name: "tapOnNotification",
-      path: "/patrol.NativeAutomator/tapOnNotification",
       type: GRPCCallType.unary
     )
 

--- a/AutomatorServer/ios/AutomatorServerUITests/contracts.grpc.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/contracts.grpc.swift
@@ -148,6 +148,11 @@ internal protocol Patrol_NativeAutomatorClientProtocol: GRPCClient {
     callOptions: CallOptions?
   ) -> UnaryCall<Patrol_Empty, Patrol_Empty>
 
+  func closeHeadsUpNotification(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Patrol_Empty, Patrol_Empty>
+
   func getNotifications(
     _ request: Patrol_GetNotificationsRequest,
     callOptions: CallOptions?
@@ -593,6 +598,24 @@ extension Patrol_NativeAutomatorClientProtocol {
     )
   }
 
+  /// Unary call to closeHeadsUpNotification
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to closeHeadsUpNotification.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  internal func closeHeadsUpNotification(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Patrol_Empty, Patrol_Empty> {
+    return self.makeUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.closeHeadsUpNotification.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makecloseHeadsUpNotificationInterceptors() ?? []
+    )
+  }
+
   /// Unary call to getNotifications
   ///
   /// - Parameters:
@@ -861,6 +884,11 @@ internal protocol Patrol_NativeAutomatorAsyncClientProtocol: GRPCClient {
   ) -> GRPCAsyncUnaryCall<Patrol_Empty, Patrol_Empty>
 
   func makeCloseNotificationsCall(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Patrol_Empty, Patrol_Empty>
+
+  func makeCloseHeadsUpNotificationCall(
     _ request: Patrol_Empty,
     callOptions: CallOptions?
   ) -> GRPCAsyncUnaryCall<Patrol_Empty, Patrol_Empty>
@@ -1174,6 +1202,18 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makecloseNotificationsInterceptors() ?? []
+    )
+  }
+
+  internal func makeCloseHeadsUpNotificationCall(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Patrol_Empty, Patrol_Empty> {
+    return self.makeAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.closeHeadsUpNotification.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makecloseHeadsUpNotificationInterceptors() ?? []
     )
   }
 
@@ -1516,6 +1556,18 @@ extension Patrol_NativeAutomatorAsyncClientProtocol {
     )
   }
 
+  internal func closeHeadsUpNotification(
+    _ request: Patrol_Empty,
+    callOptions: CallOptions? = nil
+  ) async throws -> Patrol_Empty {
+    return try await self.performAsyncUnaryCall(
+      path: Patrol_NativeAutomatorClientMetadata.Methods.closeHeadsUpNotification.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makecloseHeadsUpNotificationInterceptors() ?? []
+    )
+  }
+
   internal func getNotifications(
     _ request: Patrol_GetNotificationsRequest,
     callOptions: CallOptions? = nil
@@ -1667,6 +1719,9 @@ internal protocol Patrol_NativeAutomatorClientInterceptorFactoryProtocol: GRPCSe
   /// - Returns: Interceptors to use when invoking 'closeNotifications'.
   func makecloseNotificationsInterceptors() -> [ClientInterceptor<Patrol_Empty, Patrol_Empty>]
 
+  /// - Returns: Interceptors to use when invoking 'closeHeadsUpNotification'.
+  func makecloseHeadsUpNotificationInterceptors() -> [ClientInterceptor<Patrol_Empty, Patrol_Empty>]
+
   /// - Returns: Interceptors to use when invoking 'getNotifications'.
   func makegetNotificationsInterceptors() -> [ClientInterceptor<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse>]
 
@@ -1711,6 +1766,7 @@ internal enum Patrol_NativeAutomatorClientMetadata {
       Patrol_NativeAutomatorClientMetadata.Methods.disableDarkMode,
       Patrol_NativeAutomatorClientMetadata.Methods.openNotifications,
       Patrol_NativeAutomatorClientMetadata.Methods.closeNotifications,
+      Patrol_NativeAutomatorClientMetadata.Methods.closeHeadsUpNotification,
       Patrol_NativeAutomatorClientMetadata.Methods.getNotifications,
       Patrol_NativeAutomatorClientMetadata.Methods.tapOnNotification,
       Patrol_NativeAutomatorClientMetadata.Methods.handlePermissionDialog,
@@ -1858,6 +1914,12 @@ internal enum Patrol_NativeAutomatorClientMetadata {
       type: GRPCCallType.unary
     )
 
+    internal static let closeHeadsUpNotification = GRPCMethodDescriptor(
+      name: "closeHeadsUpNotification",
+      path: "/patrol.NativeAutomator/closeHeadsUpNotification",
+      type: GRPCCallType.unary
+    )
+
     internal static let getNotifications = GRPCMethodDescriptor(
       name: "getNotifications",
       path: "/patrol.NativeAutomator/getNotifications",
@@ -1944,6 +2006,8 @@ internal protocol Patrol_NativeAutomatorProvider: CallHandlerProvider {
   func openNotifications(request: Patrol_Empty, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 
   func closeNotifications(request: Patrol_Empty, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
+
+  func closeHeadsUpNotification(request: Patrol_Empty, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_Empty>
 
   func getNotifications(request: Patrol_GetNotificationsRequest, context: StatusOnlyCallContext) -> EventLoopFuture<Patrol_GetNotificationsResponse>
 
@@ -2176,6 +2240,15 @@ extension Patrol_NativeAutomatorProvider {
         userFunction: self.closeNotifications(request:context:)
       )
 
+    case "closeHeadsUpNotification":
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_Empty>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.makecloseHeadsUpNotificationInterceptors() ?? [],
+        userFunction: self.closeHeadsUpNotification(request:context:)
+      )
+
     case "getNotifications":
       return UnaryServerHandler(
         context: context,
@@ -2351,6 +2424,11 @@ internal protocol Patrol_NativeAutomatorAsyncProvider: CallHandlerProvider {
   ) async throws -> Patrol_Empty
 
   @Sendable func closeNotifications(
+    request: Patrol_Empty,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Patrol_Empty
+
+  @Sendable func closeHeadsUpNotification(
     request: Patrol_Empty,
     context: GRPCAsyncServerCallContext
   ) async throws -> Patrol_Empty
@@ -2608,6 +2686,15 @@ extension Patrol_NativeAutomatorAsyncProvider {
         wrapping: self.closeNotifications(request:context:)
       )
 
+    case "closeHeadsUpNotification":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Patrol_Empty>(),
+        responseSerializer: ProtobufSerializer<Patrol_Empty>(),
+        interceptors: self.interceptors?.makecloseHeadsUpNotificationInterceptors() ?? [],
+        wrapping: self.closeHeadsUpNotification(request:context:)
+      )
+
     case "getNotifications":
       return GRPCAsyncServerHandler(
         context: context,
@@ -2755,6 +2842,10 @@ internal protocol Patrol_NativeAutomatorServerInterceptorFactoryProtocol {
   ///   Defaults to calling `self.makeInterceptors()`.
   func makecloseNotificationsInterceptors() -> [ServerInterceptor<Patrol_Empty, Patrol_Empty>]
 
+  /// - Returns: Interceptors to use when handling 'closeHeadsUpNotification'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makecloseHeadsUpNotificationInterceptors() -> [ServerInterceptor<Patrol_Empty, Patrol_Empty>]
+
   /// - Returns: Interceptors to use when handling 'getNotifications'.
   ///   Defaults to calling `self.makeInterceptors()`.
   func makegetNotificationsInterceptors() -> [ServerInterceptor<Patrol_GetNotificationsRequest, Patrol_GetNotificationsResponse>]
@@ -2804,6 +2895,7 @@ internal enum Patrol_NativeAutomatorServerMetadata {
       Patrol_NativeAutomatorServerMetadata.Methods.disableDarkMode,
       Patrol_NativeAutomatorServerMetadata.Methods.openNotifications,
       Patrol_NativeAutomatorServerMetadata.Methods.closeNotifications,
+      Patrol_NativeAutomatorServerMetadata.Methods.closeHeadsUpNotification,
       Patrol_NativeAutomatorServerMetadata.Methods.getNotifications,
       Patrol_NativeAutomatorServerMetadata.Methods.tapOnNotification,
       Patrol_NativeAutomatorServerMetadata.Methods.handlePermissionDialog,
@@ -2948,6 +3040,12 @@ internal enum Patrol_NativeAutomatorServerMetadata {
     internal static let closeNotifications = GRPCMethodDescriptor(
       name: "closeNotifications",
       path: "/patrol.NativeAutomator/closeNotifications",
+      type: GRPCCallType.unary
+    )
+
+    internal static let closeHeadsUpNotification = GRPCMethodDescriptor(
+      name: "closeHeadsUpNotification",
+      path: "/patrol.NativeAutomator/closeHeadsUpNotification",
       type: GRPCCallType.unary
     )
 

--- a/AutomatorServer/ios/AutomatorServerUITests/contracts.pb.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/contracts.pb.swift
@@ -1070,7 +1070,7 @@ extension Patrol_GetNotificationsResponse: SwiftProtobuf.Message, SwiftProtobuf.
 extension Patrol_TapRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".TapRequest"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "Selector"),
+    1: .same(proto: "selector"),
     2: .same(proto: "appId"),
   ]
 

--- a/AutomatorServer/ios/AutomatorServerUITests/contracts.pb.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/contracts.pb.swift
@@ -612,6 +612,8 @@ public struct Patrol_Notification {
 
   public var content: String = String()
 
+  public var raw: String = String()
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -1507,6 +1509,7 @@ extension Patrol_Notification: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
     1: .same(proto: "appName"),
     2: .same(proto: "title"),
     3: .same(proto: "content"),
+    4: .same(proto: "raw"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1518,6 +1521,7 @@ extension Patrol_Notification: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
       case 1: try { try decoder.decodeSingularStringField(value: &self._appName) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.title) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self.content) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.raw) }()
       default: break
       }
     }
@@ -1537,6 +1541,9 @@ extension Patrol_Notification: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
     if !self.content.isEmpty {
       try visitor.visitSingularStringField(value: self.content, fieldNumber: 3)
     }
+    if !self.raw.isEmpty {
+      try visitor.visitSingularStringField(value: self.raw, fieldNumber: 4)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1544,6 +1551,7 @@ extension Patrol_Notification: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
     if lhs._appName != rhs._appName {return false}
     if lhs.title != rhs.title {return false}
     if lhs.content != rhs.content {return false}
+    if lhs.raw != rhs.raw {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/contracts.proto
+++ b/contracts.proto
@@ -78,7 +78,7 @@ message GetNotificationsRequest {}
 message GetNotificationsResponse { repeated Notification notifications = 1; }
 
 message TapRequest {
-  Selector Selector = 1;
+  Selector selector = 1;
   string appId = 2;
 }
 

--- a/contracts.proto
+++ b/contracts.proto
@@ -13,6 +13,13 @@ service NativeAutomator {
   rpc openApp(OpenAppRequest) returns (Empty) {}
   rpc openQuickSettings(OpenQuickSettingsRequest) returns (Empty) {}
 
+  // general UI interaction
+  rpc getNativeWidgets(GetNativeWidgetsRequest) returns (GetNativeWidgetsResponse) {}
+  rpc tap(TapRequest) returns (Empty) {}
+  rpc doubleTap(TapRequest) returns (Empty) {}
+  rpc enterText(EnterTextRequest) returns (Empty) {}
+  rpc swipe(SwipeRequest) returns (Empty) {}
+
   // services
   rpc enableAirplaneMode(AirplaneModeRequest) returns (Empty) {}
   rpc disableAirplaneMode(AirplaneModeRequest) returns (Empty) {}
@@ -24,13 +31,6 @@ service NativeAutomator {
   rpc disableBluetooth(BluetoothRequest) returns (Empty) {}
   rpc enableDarkMode(DarkModeRequest) returns (Empty) {}
   rpc disableDarkMode(DarkModeRequest) returns (Empty) {}
-
-  // general UI interaction
-  rpc getNativeWidgets(GetNativeWidgetsRequest) returns (GetNativeWidgetsResponse) {}
-  rpc tap(TapRequest) returns (Empty) {}
-  rpc doubleTap(TapRequest) returns (Empty) {}
-  rpc enterText(EnterTextRequest) returns (Empty) {}
-  rpc swipe(SwipeRequest) returns (Empty) {}
 
   // notifications
   rpc openNotifications(Empty) returns (Empty) {}

--- a/contracts.proto
+++ b/contracts.proto
@@ -35,6 +35,7 @@ service NativeAutomator {
   // notifications
   rpc openNotifications(Empty) returns (Empty) {}
   rpc closeNotifications(Empty) returns (Empty) {}
+  rpc closeHeadsUpNotification(Empty) returns (Empty) {}
   rpc getNotifications(GetNotificationsRequest) returns (GetNotificationsResponse) {}
   rpc tapOnNotification(TapOnNotificationRequest) returns (Empty) {}
 

--- a/contracts.proto
+++ b/contracts.proto
@@ -11,8 +11,6 @@ service NativeAutomator {
   rpc pressRecentApps(Empty) returns (Empty) {}
   rpc doublePressRecentApps(Empty) returns (Empty) {}
   rpc openApp(OpenAppRequest) returns (Empty) {}
-  rpc openNotifications(Empty) returns (Empty) {}
-  rpc closeNotifications(Empty) returns (Empty) {}
   rpc openQuickSettings(OpenQuickSettingsRequest) returns (Empty) {}
 
   // services
@@ -27,17 +25,24 @@ service NativeAutomator {
   rpc enableDarkMode(DarkModeRequest) returns (Empty) {}
   rpc disableDarkMode(DarkModeRequest) returns (Empty) {}
 
-  // UI interaction
-
+  // general UI interaction
   rpc getNativeWidgets(GetNativeWidgetsRequest) returns (GetNativeWidgetsResponse) {}
-  rpc getNotifications(GetNotificationsRequest) returns (GetNotificationsResponse) {}
   rpc tap(TapRequest) returns (Empty) {}
   rpc doubleTap(TapRequest) returns (Empty) {}
   rpc enterText(EnterTextRequest) returns (Empty) {}
   rpc swipe(SwipeRequest) returns (Empty) {}
+
+  // notifications
+  rpc openNotifications(Empty) returns (Empty) {}
+  rpc closeNotifications(Empty) returns (Empty) {}
+  rpc getNotifications(GetNotificationsRequest) returns (GetNotificationsResponse) {}
+  rpc tapOnNotification(TapOnNotificationRequest) returns (Empty) {}
+
+  // permissions
   rpc handlePermissionDialog(HandlePermissionRequest) returns (Empty) {}
   rpc setLocationAccuracy(SetLocationAccuracyRequest) returns (Empty) {}
-  rpc tapOnNotification(TapOnNotificationRequest) returns (Empty) {}
+
+  // other
 
   rpc debug(Empty) returns (Empty) {}
 }
@@ -149,4 +154,5 @@ message Notification {
   optional string appName = 1;
   string title = 2;
   string content = 3;
+  string raw = 4;
 }

--- a/packages/patrol/example/integration_test/features/notifications/notifications_multi_test.dart
+++ b/packages/patrol/example/integration_test/features/notifications/notifications_multi_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:example/main.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
@@ -18,8 +20,9 @@ void main() {
       await $(RegExp('someone liked')).tap(); // appears on top
       await $(RegExp('special offer')).tap(); // also appears on top
 
-      // wait for pop-up notification to disappear on iOS
-      // await Future<void>.delayed(Duration(seconds: 10));
+      if (Platform.isIOS) {
+        await $.native.closeHeadsUpNotification();
+      }
 
       await $.native.openNotifications();
       final notifications = await $.native.getNotifications();
@@ -28,6 +31,8 @@ void main() {
 
       expect(notifications.length, isNonZero);
       await $.native.tapOnNotificationByIndex(notifications.length - 1);
+
+      await $.native.openNotifications();
       await $.native.tapOnNotificationBySelector(
         Selector(textContains: 'Special offer'),
       );

--- a/packages/patrol/example/integration_test/features/notifications/notifications_multi_test.dart
+++ b/packages/patrol/example/integration_test/features/notifications/notifications_multi_test.dart
@@ -2,27 +2,24 @@ import 'package:example/main.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
 
-import 'config.dart';
+import '../../config.dart';
 
 void main() {
   patrolTest(
-    'sends a notification and taps on it',
+    'send 2 notifications, verifies that they are visible and taps on them',
     config: patrolConfig,
     nativeAutomation: true,
     ($) async {
-      $.log('Yay, notification_test.dart is starting!');
-
       await $.pumpWidgetAndSettle(ExampleApp());
 
       await $('Open notifications screen').tap();
-
       await $.native.grantPermissionWhenInUse();
 
       await $(RegExp('someone liked')).tap(); // appears on top
       await $(RegExp('special offer')).tap(); // also appears on top
 
       // wait for pop-up notification to disappear on iOS
-      await Future<void>.delayed(Duration(seconds: 10));
+      // await Future<void>.delayed(Duration(seconds: 10));
 
       await $.native.openNotifications();
       final notifications = await $.native.getNotifications();

--- a/packages/patrol/example/integration_test/features/notifications/notifications_single_test.dart
+++ b/packages/patrol/example/integration_test/features/notifications/notifications_single_test.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:example/main.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+
+import '../../config.dart';
+
+void main() {
+  patrolTest(
+    'sends 1 notification, verifies that it is visible and taps on it',
+    config: patrolConfig,
+    nativeAutomation: true,
+    ($) async {
+      await $.pumpWidgetAndSettle(ExampleApp());
+
+      await $('Open notifications screen').tap();
+      await $.native.grantPermissionWhenInUse();
+
+      await $(RegExp('someone liked')).tap();
+
+      if (Platform.isIOS) {
+        await $.native.closeHeadsUpNotification();
+      }
+
+      await $.native.openNotifications();
+      final notifications = await $.native.getNotifications();
+      $.log('Found ${notifications.length} notifications');
+      notifications.forEach($.log);
+
+      expect(notifications.length, equals(1));
+      await $.native.tapOnNotificationByIndex(0);
+    },
+  );
+}

--- a/packages/patrol/example/integration_test/features/services/all_test.dart
+++ b/packages/patrol/example/integration_test/features/services/all_test.dart
@@ -1,7 +1,7 @@
 import 'package:example/main.dart';
 import 'package:patrol/patrol.dart';
 
-import '../config.dart';
+import '../../config.dart';
 
 void main() {
   patrolTest(

--- a/packages/patrol/example/integration_test/features/services/cellular_test.dart
+++ b/packages/patrol/example/integration_test/features/services/cellular_test.dart
@@ -1,20 +1,20 @@
 import 'package:example/main.dart';
 import 'package:patrol/patrol.dart';
 
-import '../config.dart';
+import '../../config.dart';
 
 void main() {
   patrolTest(
-    'disables and enables dark mode twice',
+    'disables and enables cellular twice',
     config: patrolConfig,
     nativeAutomation: true,
     ($) async {
       await $.pumpWidgetAndSettle(ExampleApp());
 
-      await $.native.disableDarkMode();
-      await $.native.enableDarkMode();
-      await $.native.disableDarkMode();
-      await $.native.enableDarkMode();
+      await $.native.disableCellular();
+      await $.native.enableCellular();
+      await $.native.disableCellular();
+      await $.native.enableCellular();
     },
   );
 }

--- a/packages/patrol/example/integration_test/features/services/dark_mode_test.dart
+++ b/packages/patrol/example/integration_test/features/services/dark_mode_test.dart
@@ -1,20 +1,20 @@
 import 'package:example/main.dart';
 import 'package:patrol/patrol.dart';
 
-import '../config.dart';
+import '../../config.dart';
 
 void main() {
   patrolTest(
-    'disables and enables cellular twice',
+    'disables and enables dark mode twice',
     config: patrolConfig,
     nativeAutomation: true,
     ($) async {
       await $.pumpWidgetAndSettle(ExampleApp());
 
-      await $.native.disableCellular();
-      await $.native.enableCellular();
-      await $.native.disableCellular();
-      await $.native.enableCellular();
+      await $.native.disableDarkMode();
+      await $.native.enableDarkMode();
+      await $.native.disableDarkMode();
+      await $.native.enableDarkMode();
     },
   );
 }

--- a/packages/patrol/example/integration_test/features/services/wifi_test.dart
+++ b/packages/patrol/example/integration_test/features/services/wifi_test.dart
@@ -1,7 +1,7 @@
 import 'package:example/main.dart';
 import 'package:patrol/patrol.dart';
 
-import '../config.dart';
+import '../../config.dart';
 
 void main() {
   patrolTest(

--- a/packages/patrol/example/integration_test/notifications_test.dart
+++ b/packages/patrol/example/integration_test/notifications_test.dart
@@ -21,6 +21,10 @@ void main() {
       await $(RegExp('someone liked')).tap(); // appears on top
       await $(RegExp('special offer')).tap(); // also appears on top
 
+      // wait for pop-up notification to disappear on iOS
+      await Future<void>.delayed(Duration(seconds: 10));
+
+      await $.native.openNotifications();
       final notifications = await $.native.getNotifications();
       $.log('Found ${notifications.length} notifications');
       notifications.forEach($.log);

--- a/packages/patrol/example/lib/notifications_screen.dart
+++ b/packages/patrol/example/lib/notifications_screen.dart
@@ -48,7 +48,8 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
       id,
       title,
       '$body ID: $id',
-      const NotificationDetails(
+      NotificationDetails(
+        iOS: DarwinNotificationDetails(),
         android: AndroidNotificationDetails(
           'main',
           'Default notification channel',

--- a/packages/patrol/lib/src/native/contracts/contracts.pb.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.pb.dart
@@ -1966,6 +1966,11 @@ class Notification extends $pb.GeneratedMessage {
         const $core.bool.fromEnvironment('protobuf.omit_field_names')
             ? ''
             : 'content')
+    ..aOS(
+        4,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'raw')
     ..hasRequiredFields = false;
 
   Notification._() : super();
@@ -1973,6 +1978,7 @@ class Notification extends $pb.GeneratedMessage {
     $core.String? appName,
     $core.String? title,
     $core.String? content,
+    $core.String? raw,
   }) {
     final _result = create();
     if (appName != null) {
@@ -1983,6 +1989,9 @@ class Notification extends $pb.GeneratedMessage {
     }
     if (content != null) {
       _result.content = content;
+    }
+    if (raw != null) {
+      _result.raw = raw;
     }
     return _result;
   }
@@ -2048,4 +2057,16 @@ class Notification extends $pb.GeneratedMessage {
   $core.bool hasContent() => $_has(2);
   @$pb.TagNumber(3)
   void clearContent() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get raw => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set raw($core.String v) {
+    $_setString(3, v);
+  }
+
+  @$pb.TagNumber(4)
+  $core.bool hasRaw() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearRaw() => clearField(4);
 }

--- a/packages/patrol/lib/src/native/contracts/contracts.pb.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.pb.dart
@@ -867,8 +867,7 @@ class TapRequest extends $pb.GeneratedMessage {
         1,
         const $core.bool.fromEnvironment('protobuf.omit_field_names')
             ? ''
-            : 'Selector',
-        protoName: 'Selector',
+            : 'selector',
         subBuilder: Selector.create)
     ..aOS(
         2,

--- a/packages/patrol/lib/src/native/contracts/contracts.pbgrpc.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.pbgrpc.dart
@@ -117,6 +117,11 @@ class NativeAutomatorClient extends $grpc.Client {
       '/patrol.NativeAutomator/closeNotifications',
       ($0.Empty value) => value.writeToBuffer(),
       ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
+  static final _$closeHeadsUpNotification =
+      $grpc.ClientMethod<$0.Empty, $0.Empty>(
+          '/patrol.NativeAutomator/closeHeadsUpNotification',
+          ($0.Empty value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
   static final _$getNotifications = $grpc.ClientMethod<
           $0.GetNotificationsRequest, $0.GetNotificationsResponse>(
       '/patrol.NativeAutomator/getNotifications',
@@ -265,6 +270,12 @@ class NativeAutomatorClient extends $grpc.Client {
   $grpc.ResponseFuture<$0.Empty> closeNotifications($0.Empty request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$closeNotifications, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.Empty> closeHeadsUpNotification($0.Empty request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$closeHeadsUpNotification, request,
+        options: options);
   }
 
   $grpc.ResponseFuture<$0.GetNotificationsResponse> getNotifications(
@@ -468,6 +479,13 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
         false,
         ($core.List<$core.int> value) => $0.Empty.fromBuffer(value),
         ($0.Empty value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.Empty, $0.Empty>(
+        'closeHeadsUpNotification',
+        closeHeadsUpNotification_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.Empty.fromBuffer(value),
+        ($0.Empty value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.GetNotificationsRequest,
             $0.GetNotificationsResponse>(
         'getNotifications',
@@ -626,6 +644,11 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
     return closeNotifications(call, await request);
   }
 
+  $async.Future<$0.Empty> closeHeadsUpNotification_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.Empty> request) async {
+    return closeHeadsUpNotification(call, await request);
+  }
+
   $async.Future<$0.GetNotificationsResponse> getNotifications_Pre(
       $grpc.ServiceCall call,
       $async.Future<$0.GetNotificationsRequest> request) async {
@@ -694,6 +717,8 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
   $async.Future<$0.Empty> openNotifications(
       $grpc.ServiceCall call, $0.Empty request);
   $async.Future<$0.Empty> closeNotifications(
+      $grpc.ServiceCall call, $0.Empty request);
+  $async.Future<$0.Empty> closeHeadsUpNotification(
       $grpc.ServiceCall call, $0.Empty request);
   $async.Future<$0.GetNotificationsResponse> getNotifications(
       $grpc.ServiceCall call, $0.GetNotificationsRequest request);

--- a/packages/patrol/lib/src/native/contracts/contracts.pbgrpc.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.pbgrpc.dart
@@ -39,6 +39,28 @@ class NativeAutomatorClient extends $grpc.Client {
           '/patrol.NativeAutomator/openQuickSettings',
           ($0.OpenQuickSettingsRequest value) => value.writeToBuffer(),
           ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
+  static final _$getNativeWidgets = $grpc.ClientMethod<
+          $0.GetNativeWidgetsRequest, $0.GetNativeWidgetsResponse>(
+      '/patrol.NativeAutomator/getNativeWidgets',
+      ($0.GetNativeWidgetsRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) =>
+          $0.GetNativeWidgetsResponse.fromBuffer(value));
+  static final _$tap = $grpc.ClientMethod<$0.TapRequest, $0.Empty>(
+      '/patrol.NativeAutomator/tap',
+      ($0.TapRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
+  static final _$doubleTap = $grpc.ClientMethod<$0.TapRequest, $0.Empty>(
+      '/patrol.NativeAutomator/doubleTap',
+      ($0.TapRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
+  static final _$enterText = $grpc.ClientMethod<$0.EnterTextRequest, $0.Empty>(
+      '/patrol.NativeAutomator/enterText',
+      ($0.EnterTextRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
+  static final _$swipe = $grpc.ClientMethod<$0.SwipeRequest, $0.Empty>(
+      '/patrol.NativeAutomator/swipe',
+      ($0.SwipeRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
   static final _$enableAirplaneMode =
       $grpc.ClientMethod<$0.AirplaneModeRequest, $0.Empty>(
           '/patrol.NativeAutomator/enableAirplaneMode',
@@ -87,28 +109,6 @@ class NativeAutomatorClient extends $grpc.Client {
           '/patrol.NativeAutomator/disableDarkMode',
           ($0.DarkModeRequest value) => value.writeToBuffer(),
           ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
-  static final _$getNativeWidgets = $grpc.ClientMethod<
-          $0.GetNativeWidgetsRequest, $0.GetNativeWidgetsResponse>(
-      '/patrol.NativeAutomator/getNativeWidgets',
-      ($0.GetNativeWidgetsRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.GetNativeWidgetsResponse.fromBuffer(value));
-  static final _$tap = $grpc.ClientMethod<$0.TapRequest, $0.Empty>(
-      '/patrol.NativeAutomator/tap',
-      ($0.TapRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
-  static final _$doubleTap = $grpc.ClientMethod<$0.TapRequest, $0.Empty>(
-      '/patrol.NativeAutomator/doubleTap',
-      ($0.TapRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
-  static final _$enterText = $grpc.ClientMethod<$0.EnterTextRequest, $0.Empty>(
-      '/patrol.NativeAutomator/enterText',
-      ($0.EnterTextRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
-  static final _$swipe = $grpc.ClientMethod<$0.SwipeRequest, $0.Empty>(
-      '/patrol.NativeAutomator/swipe',
-      ($0.SwipeRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
   static final _$openNotifications = $grpc.ClientMethod<$0.Empty, $0.Empty>(
       '/patrol.NativeAutomator/openNotifications',
       ($0.Empty value) => value.writeToBuffer(),
@@ -179,6 +179,32 @@ class NativeAutomatorClient extends $grpc.Client {
     return $createUnaryCall(_$openQuickSettings, request, options: options);
   }
 
+  $grpc.ResponseFuture<$0.GetNativeWidgetsResponse> getNativeWidgets(
+      $0.GetNativeWidgetsRequest request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$getNativeWidgets, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.Empty> tap($0.TapRequest request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$tap, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.Empty> doubleTap($0.TapRequest request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$doubleTap, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.Empty> enterText($0.EnterTextRequest request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$enterText, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.Empty> swipe($0.SwipeRequest request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$swipe, request, options: options);
+  }
+
   $grpc.ResponseFuture<$0.Empty> enableAirplaneMode(
       $0.AirplaneModeRequest request,
       {$grpc.CallOptions? options}) {
@@ -229,32 +255,6 @@ class NativeAutomatorClient extends $grpc.Client {
   $grpc.ResponseFuture<$0.Empty> disableDarkMode($0.DarkModeRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$disableDarkMode, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.GetNativeWidgetsResponse> getNativeWidgets(
-      $0.GetNativeWidgetsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$getNativeWidgets, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Empty> tap($0.TapRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$tap, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Empty> doubleTap($0.TapRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$doubleTap, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Empty> enterText($0.EnterTextRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$enterText, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Empty> swipe($0.SwipeRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$swipe, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.Empty> openNotifications($0.Empty request,
@@ -345,6 +345,43 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
         ($core.List<$core.int> value) =>
             $0.OpenQuickSettingsRequest.fromBuffer(value),
         ($0.Empty value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetNativeWidgetsRequest,
+            $0.GetNativeWidgetsResponse>(
+        'getNativeWidgets',
+        getNativeWidgets_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) =>
+            $0.GetNativeWidgetsRequest.fromBuffer(value),
+        ($0.GetNativeWidgetsResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.TapRequest, $0.Empty>(
+        'tap',
+        tap_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.TapRequest.fromBuffer(value),
+        ($0.Empty value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.TapRequest, $0.Empty>(
+        'doubleTap',
+        doubleTap_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.TapRequest.fromBuffer(value),
+        ($0.Empty value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.EnterTextRequest, $0.Empty>(
+        'enterText',
+        enterText_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.EnterTextRequest.fromBuffer(value),
+        ($0.Empty value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.SwipeRequest, $0.Empty>(
+        'swipe',
+        swipe_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.SwipeRequest.fromBuffer(value),
+        ($0.Empty value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.AirplaneModeRequest, $0.Empty>(
         'enableAirplaneMode',
         enableAirplaneMode_Pre,
@@ -416,43 +453,6 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
         false,
         false,
         ($core.List<$core.int> value) => $0.DarkModeRequest.fromBuffer(value),
-        ($0.Empty value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.GetNativeWidgetsRequest,
-            $0.GetNativeWidgetsResponse>(
-        'getNativeWidgets',
-        getNativeWidgets_Pre,
-        false,
-        false,
-        ($core.List<$core.int> value) =>
-            $0.GetNativeWidgetsRequest.fromBuffer(value),
-        ($0.GetNativeWidgetsResponse value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.TapRequest, $0.Empty>(
-        'tap',
-        tap_Pre,
-        false,
-        false,
-        ($core.List<$core.int> value) => $0.TapRequest.fromBuffer(value),
-        ($0.Empty value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.TapRequest, $0.Empty>(
-        'doubleTap',
-        doubleTap_Pre,
-        false,
-        false,
-        ($core.List<$core.int> value) => $0.TapRequest.fromBuffer(value),
-        ($0.Empty value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.EnterTextRequest, $0.Empty>(
-        'enterText',
-        enterText_Pre,
-        false,
-        false,
-        ($core.List<$core.int> value) => $0.EnterTextRequest.fromBuffer(value),
-        ($0.Empty value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.SwipeRequest, $0.Empty>(
-        'swipe',
-        swipe_Pre,
-        false,
-        false,
-        ($core.List<$core.int> value) => $0.SwipeRequest.fromBuffer(value),
         ($0.Empty value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.Empty, $0.Empty>(
         'openNotifications',
@@ -540,6 +540,32 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
     return openQuickSettings(call, await request);
   }
 
+  $async.Future<$0.GetNativeWidgetsResponse> getNativeWidgets_Pre(
+      $grpc.ServiceCall call,
+      $async.Future<$0.GetNativeWidgetsRequest> request) async {
+    return getNativeWidgets(call, await request);
+  }
+
+  $async.Future<$0.Empty> tap_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.TapRequest> request) async {
+    return tap(call, await request);
+  }
+
+  $async.Future<$0.Empty> doubleTap_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.TapRequest> request) async {
+    return doubleTap(call, await request);
+  }
+
+  $async.Future<$0.Empty> enterText_Pre($grpc.ServiceCall call,
+      $async.Future<$0.EnterTextRequest> request) async {
+    return enterText(call, await request);
+  }
+
+  $async.Future<$0.Empty> swipe_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.SwipeRequest> request) async {
+    return swipe(call, await request);
+  }
+
   $async.Future<$0.Empty> enableAirplaneMode_Pre($grpc.ServiceCall call,
       $async.Future<$0.AirplaneModeRequest> request) async {
     return enableAirplaneMode(call, await request);
@@ -590,32 +616,6 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
     return disableDarkMode(call, await request);
   }
 
-  $async.Future<$0.GetNativeWidgetsResponse> getNativeWidgets_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.GetNativeWidgetsRequest> request) async {
-    return getNativeWidgets(call, await request);
-  }
-
-  $async.Future<$0.Empty> tap_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.TapRequest> request) async {
-    return tap(call, await request);
-  }
-
-  $async.Future<$0.Empty> doubleTap_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.TapRequest> request) async {
-    return doubleTap(call, await request);
-  }
-
-  $async.Future<$0.Empty> enterText_Pre($grpc.ServiceCall call,
-      $async.Future<$0.EnterTextRequest> request) async {
-    return enterText(call, await request);
-  }
-
-  $async.Future<$0.Empty> swipe_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.SwipeRequest> request) async {
-    return swipe(call, await request);
-  }
-
   $async.Future<$0.Empty> openNotifications_Pre(
       $grpc.ServiceCall call, $async.Future<$0.Empty> request) async {
     return openNotifications(call, await request);
@@ -662,6 +662,15 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
       $grpc.ServiceCall call, $0.OpenAppRequest request);
   $async.Future<$0.Empty> openQuickSettings(
       $grpc.ServiceCall call, $0.OpenQuickSettingsRequest request);
+  $async.Future<$0.GetNativeWidgetsResponse> getNativeWidgets(
+      $grpc.ServiceCall call, $0.GetNativeWidgetsRequest request);
+  $async.Future<$0.Empty> tap($grpc.ServiceCall call, $0.TapRequest request);
+  $async.Future<$0.Empty> doubleTap(
+      $grpc.ServiceCall call, $0.TapRequest request);
+  $async.Future<$0.Empty> enterText(
+      $grpc.ServiceCall call, $0.EnterTextRequest request);
+  $async.Future<$0.Empty> swipe(
+      $grpc.ServiceCall call, $0.SwipeRequest request);
   $async.Future<$0.Empty> enableAirplaneMode(
       $grpc.ServiceCall call, $0.AirplaneModeRequest request);
   $async.Future<$0.Empty> disableAirplaneMode(
@@ -682,15 +691,6 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
       $grpc.ServiceCall call, $0.DarkModeRequest request);
   $async.Future<$0.Empty> disableDarkMode(
       $grpc.ServiceCall call, $0.DarkModeRequest request);
-  $async.Future<$0.GetNativeWidgetsResponse> getNativeWidgets(
-      $grpc.ServiceCall call, $0.GetNativeWidgetsRequest request);
-  $async.Future<$0.Empty> tap($grpc.ServiceCall call, $0.TapRequest request);
-  $async.Future<$0.Empty> doubleTap(
-      $grpc.ServiceCall call, $0.TapRequest request);
-  $async.Future<$0.Empty> enterText(
-      $grpc.ServiceCall call, $0.EnterTextRequest request);
-  $async.Future<$0.Empty> swipe(
-      $grpc.ServiceCall call, $0.SwipeRequest request);
   $async.Future<$0.Empty> openNotifications(
       $grpc.ServiceCall call, $0.Empty request);
   $async.Future<$0.Empty> closeNotifications(

--- a/packages/patrol/lib/src/native/contracts/contracts.pbgrpc.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.pbgrpc.dart
@@ -34,14 +34,6 @@ class NativeAutomatorClient extends $grpc.Client {
       '/patrol.NativeAutomator/openApp',
       ($0.OpenAppRequest value) => value.writeToBuffer(),
       ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
-  static final _$openNotifications = $grpc.ClientMethod<$0.Empty, $0.Empty>(
-      '/patrol.NativeAutomator/openNotifications',
-      ($0.Empty value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
-  static final _$closeNotifications = $grpc.ClientMethod<$0.Empty, $0.Empty>(
-      '/patrol.NativeAutomator/closeNotifications',
-      ($0.Empty value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
   static final _$openQuickSettings =
       $grpc.ClientMethod<$0.OpenQuickSettingsRequest, $0.Empty>(
           '/patrol.NativeAutomator/openQuickSettings',
@@ -101,12 +93,6 @@ class NativeAutomatorClient extends $grpc.Client {
       ($0.GetNativeWidgetsRequest value) => value.writeToBuffer(),
       ($core.List<$core.int> value) =>
           $0.GetNativeWidgetsResponse.fromBuffer(value));
-  static final _$getNotifications = $grpc.ClientMethod<
-          $0.GetNotificationsRequest, $0.GetNotificationsResponse>(
-      '/patrol.NativeAutomator/getNotifications',
-      ($0.GetNotificationsRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) =>
-          $0.GetNotificationsResponse.fromBuffer(value));
   static final _$tap = $grpc.ClientMethod<$0.TapRequest, $0.Empty>(
       '/patrol.NativeAutomator/tap',
       ($0.TapRequest value) => value.writeToBuffer(),
@@ -123,6 +109,25 @@ class NativeAutomatorClient extends $grpc.Client {
       '/patrol.NativeAutomator/swipe',
       ($0.SwipeRequest value) => value.writeToBuffer(),
       ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
+  static final _$openNotifications = $grpc.ClientMethod<$0.Empty, $0.Empty>(
+      '/patrol.NativeAutomator/openNotifications',
+      ($0.Empty value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
+  static final _$closeNotifications = $grpc.ClientMethod<$0.Empty, $0.Empty>(
+      '/patrol.NativeAutomator/closeNotifications',
+      ($0.Empty value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
+  static final _$getNotifications = $grpc.ClientMethod<
+          $0.GetNotificationsRequest, $0.GetNotificationsResponse>(
+      '/patrol.NativeAutomator/getNotifications',
+      ($0.GetNotificationsRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) =>
+          $0.GetNotificationsResponse.fromBuffer(value));
+  static final _$tapOnNotification =
+      $grpc.ClientMethod<$0.TapOnNotificationRequest, $0.Empty>(
+          '/patrol.NativeAutomator/tapOnNotification',
+          ($0.TapOnNotificationRequest value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
   static final _$handlePermissionDialog =
       $grpc.ClientMethod<$0.HandlePermissionRequest, $0.Empty>(
           '/patrol.NativeAutomator/handlePermissionDialog',
@@ -132,11 +137,6 @@ class NativeAutomatorClient extends $grpc.Client {
       $grpc.ClientMethod<$0.SetLocationAccuracyRequest, $0.Empty>(
           '/patrol.NativeAutomator/setLocationAccuracy',
           ($0.SetLocationAccuracyRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
-  static final _$tapOnNotification =
-      $grpc.ClientMethod<$0.TapOnNotificationRequest, $0.Empty>(
-          '/patrol.NativeAutomator/tapOnNotification',
-          ($0.TapOnNotificationRequest value) => value.writeToBuffer(),
           ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
   static final _$debug = $grpc.ClientMethod<$0.Empty, $0.Empty>(
       '/patrol.NativeAutomator/debug',
@@ -171,16 +171,6 @@ class NativeAutomatorClient extends $grpc.Client {
   $grpc.ResponseFuture<$0.Empty> openApp($0.OpenAppRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$openApp, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Empty> openNotifications($0.Empty request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$openNotifications, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Empty> closeNotifications($0.Empty request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$closeNotifications, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.Empty> openQuickSettings(
@@ -247,12 +237,6 @@ class NativeAutomatorClient extends $grpc.Client {
     return $createUnaryCall(_$getNativeWidgets, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.GetNotificationsResponse> getNotifications(
-      $0.GetNotificationsRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$getNotifications, request, options: options);
-  }
-
   $grpc.ResponseFuture<$0.Empty> tap($0.TapRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$tap, request, options: options);
@@ -273,6 +257,28 @@ class NativeAutomatorClient extends $grpc.Client {
     return $createUnaryCall(_$swipe, request, options: options);
   }
 
+  $grpc.ResponseFuture<$0.Empty> openNotifications($0.Empty request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$openNotifications, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.Empty> closeNotifications($0.Empty request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$closeNotifications, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.GetNotificationsResponse> getNotifications(
+      $0.GetNotificationsRequest request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$getNotifications, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.Empty> tapOnNotification(
+      $0.TapOnNotificationRequest request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$tapOnNotification, request, options: options);
+  }
+
   $grpc.ResponseFuture<$0.Empty> handlePermissionDialog(
       $0.HandlePermissionRequest request,
       {$grpc.CallOptions? options}) {
@@ -284,12 +290,6 @@ class NativeAutomatorClient extends $grpc.Client {
       $0.SetLocationAccuracyRequest request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$setLocationAccuracy, request, options: options);
-  }
-
-  $grpc.ResponseFuture<$0.Empty> tapOnNotification(
-      $0.TapOnNotificationRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$tapOnNotification, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.Empty> debug($0.Empty request,
@@ -336,20 +336,6 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
         false,
         false,
         ($core.List<$core.int> value) => $0.OpenAppRequest.fromBuffer(value),
-        ($0.Empty value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.Empty, $0.Empty>(
-        'openNotifications',
-        openNotifications_Pre,
-        false,
-        false,
-        ($core.List<$core.int> value) => $0.Empty.fromBuffer(value),
-        ($0.Empty value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.Empty, $0.Empty>(
-        'closeNotifications',
-        closeNotifications_Pre,
-        false,
-        false,
-        ($core.List<$core.int> value) => $0.Empty.fromBuffer(value),
         ($0.Empty value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.OpenQuickSettingsRequest, $0.Empty>(
         'openQuickSettings',
@@ -440,15 +426,6 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
         ($core.List<$core.int> value) =>
             $0.GetNativeWidgetsRequest.fromBuffer(value),
         ($0.GetNativeWidgetsResponse value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.GetNotificationsRequest,
-            $0.GetNotificationsResponse>(
-        'getNotifications',
-        getNotifications_Pre,
-        false,
-        false,
-        ($core.List<$core.int> value) =>
-            $0.GetNotificationsRequest.fromBuffer(value),
-        ($0.GetNotificationsResponse value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.TapRequest, $0.Empty>(
         'tap',
         tap_Pre,
@@ -477,6 +454,37 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
         false,
         ($core.List<$core.int> value) => $0.SwipeRequest.fromBuffer(value),
         ($0.Empty value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.Empty, $0.Empty>(
+        'openNotifications',
+        openNotifications_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.Empty.fromBuffer(value),
+        ($0.Empty value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.Empty, $0.Empty>(
+        'closeNotifications',
+        closeNotifications_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.Empty.fromBuffer(value),
+        ($0.Empty value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetNotificationsRequest,
+            $0.GetNotificationsResponse>(
+        'getNotifications',
+        getNotifications_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) =>
+            $0.GetNotificationsRequest.fromBuffer(value),
+        ($0.GetNotificationsResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.TapOnNotificationRequest, $0.Empty>(
+        'tapOnNotification',
+        tapOnNotification_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) =>
+            $0.TapOnNotificationRequest.fromBuffer(value),
+        ($0.Empty value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.HandlePermissionRequest, $0.Empty>(
         'handlePermissionDialog',
         handlePermissionDialog_Pre,
@@ -492,14 +500,6 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
         false,
         ($core.List<$core.int> value) =>
             $0.SetLocationAccuracyRequest.fromBuffer(value),
-        ($0.Empty value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.TapOnNotificationRequest, $0.Empty>(
-        'tapOnNotification',
-        tapOnNotification_Pre,
-        false,
-        false,
-        ($core.List<$core.int> value) =>
-            $0.TapOnNotificationRequest.fromBuffer(value),
         ($0.Empty value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.Empty, $0.Empty>(
         'debug',
@@ -533,16 +533,6 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
   $async.Future<$0.Empty> openApp_Pre(
       $grpc.ServiceCall call, $async.Future<$0.OpenAppRequest> request) async {
     return openApp(call, await request);
-  }
-
-  $async.Future<$0.Empty> openNotifications_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.Empty> request) async {
-    return openNotifications(call, await request);
-  }
-
-  $async.Future<$0.Empty> closeNotifications_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.Empty> request) async {
-    return closeNotifications(call, await request);
   }
 
   $async.Future<$0.Empty> openQuickSettings_Pre($grpc.ServiceCall call,
@@ -606,12 +596,6 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
     return getNativeWidgets(call, await request);
   }
 
-  $async.Future<$0.GetNotificationsResponse> getNotifications_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.GetNotificationsRequest> request) async {
-    return getNotifications(call, await request);
-  }
-
   $async.Future<$0.Empty> tap_Pre(
       $grpc.ServiceCall call, $async.Future<$0.TapRequest> request) async {
     return tap(call, await request);
@@ -632,6 +616,27 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
     return swipe(call, await request);
   }
 
+  $async.Future<$0.Empty> openNotifications_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.Empty> request) async {
+    return openNotifications(call, await request);
+  }
+
+  $async.Future<$0.Empty> closeNotifications_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.Empty> request) async {
+    return closeNotifications(call, await request);
+  }
+
+  $async.Future<$0.GetNotificationsResponse> getNotifications_Pre(
+      $grpc.ServiceCall call,
+      $async.Future<$0.GetNotificationsRequest> request) async {
+    return getNotifications(call, await request);
+  }
+
+  $async.Future<$0.Empty> tapOnNotification_Pre($grpc.ServiceCall call,
+      $async.Future<$0.TapOnNotificationRequest> request) async {
+    return tapOnNotification(call, await request);
+  }
+
   $async.Future<$0.Empty> handlePermissionDialog_Pre($grpc.ServiceCall call,
       $async.Future<$0.HandlePermissionRequest> request) async {
     return handlePermissionDialog(call, await request);
@@ -640,11 +645,6 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
   $async.Future<$0.Empty> setLocationAccuracy_Pre($grpc.ServiceCall call,
       $async.Future<$0.SetLocationAccuracyRequest> request) async {
     return setLocationAccuracy(call, await request);
-  }
-
-  $async.Future<$0.Empty> tapOnNotification_Pre($grpc.ServiceCall call,
-      $async.Future<$0.TapOnNotificationRequest> request) async {
-    return tapOnNotification(call, await request);
   }
 
   $async.Future<$0.Empty> debug_Pre(
@@ -660,10 +660,6 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
       $grpc.ServiceCall call, $0.Empty request);
   $async.Future<$0.Empty> openApp(
       $grpc.ServiceCall call, $0.OpenAppRequest request);
-  $async.Future<$0.Empty> openNotifications(
-      $grpc.ServiceCall call, $0.Empty request);
-  $async.Future<$0.Empty> closeNotifications(
-      $grpc.ServiceCall call, $0.Empty request);
   $async.Future<$0.Empty> openQuickSettings(
       $grpc.ServiceCall call, $0.OpenQuickSettingsRequest request);
   $async.Future<$0.Empty> enableAirplaneMode(
@@ -688,8 +684,6 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
       $grpc.ServiceCall call, $0.DarkModeRequest request);
   $async.Future<$0.GetNativeWidgetsResponse> getNativeWidgets(
       $grpc.ServiceCall call, $0.GetNativeWidgetsRequest request);
-  $async.Future<$0.GetNotificationsResponse> getNotifications(
-      $grpc.ServiceCall call, $0.GetNotificationsRequest request);
   $async.Future<$0.Empty> tap($grpc.ServiceCall call, $0.TapRequest request);
   $async.Future<$0.Empty> doubleTap(
       $grpc.ServiceCall call, $0.TapRequest request);
@@ -697,11 +691,17 @@ abstract class NativeAutomatorServiceBase extends $grpc.Service {
       $grpc.ServiceCall call, $0.EnterTextRequest request);
   $async.Future<$0.Empty> swipe(
       $grpc.ServiceCall call, $0.SwipeRequest request);
+  $async.Future<$0.Empty> openNotifications(
+      $grpc.ServiceCall call, $0.Empty request);
+  $async.Future<$0.Empty> closeNotifications(
+      $grpc.ServiceCall call, $0.Empty request);
+  $async.Future<$0.GetNotificationsResponse> getNotifications(
+      $grpc.ServiceCall call, $0.GetNotificationsRequest request);
+  $async.Future<$0.Empty> tapOnNotification(
+      $grpc.ServiceCall call, $0.TapOnNotificationRequest request);
   $async.Future<$0.Empty> handlePermissionDialog(
       $grpc.ServiceCall call, $0.HandlePermissionRequest request);
   $async.Future<$0.Empty> setLocationAccuracy(
       $grpc.ServiceCall call, $0.SetLocationAccuracyRequest request);
-  $async.Future<$0.Empty> tapOnNotification(
-      $grpc.ServiceCall call, $0.TapOnNotificationRequest request);
   $async.Future<$0.Empty> debug($grpc.ServiceCall call, $0.Empty request);
 }

--- a/packages/patrol/lib/src/native/contracts/contracts.pbjson.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.pbjson.dart
@@ -186,12 +186,12 @@ const TapRequest$json = const {
   '1': 'TapRequest',
   '2': const [
     const {
-      '1': 'Selector',
+      '1': 'selector',
       '3': 1,
       '4': 1,
       '5': 11,
       '6': '.patrol.Selector',
-      '10': 'Selector'
+      '10': 'selector'
     },
     const {'1': 'appId', '3': 2, '4': 1, '5': 9, '10': 'appId'},
   ],
@@ -199,7 +199,7 @@ const TapRequest$json = const {
 
 /// Descriptor for `TapRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List tapRequestDescriptor = $convert.base64Decode(
-    'CgpUYXBSZXF1ZXN0EiwKCFNlbGVjdG9yGAEgASgLMhAucGF0cm9sLlNlbGVjdG9yUghTZWxlY3RvchIUCgVhcHBJZBgCIAEoCVIFYXBwSWQ=');
+    'CgpUYXBSZXF1ZXN0EiwKCHNlbGVjdG9yGAEgASgLMhAucGF0cm9sLlNlbGVjdG9yUghzZWxlY3RvchIUCgVhcHBJZBgCIAEoCVIFYXBwSWQ=');
 @$core.Deprecated('Use enterTextRequestDescriptor instead')
 const EnterTextRequest$json = const {
   '1': 'EnterTextRequest',

--- a/packages/patrol/lib/src/native/contracts/contracts.pbjson.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.pbjson.dart
@@ -484,6 +484,7 @@ const Notification$json = const {
     },
     const {'1': 'title', '3': 2, '4': 1, '5': 9, '10': 'title'},
     const {'1': 'content', '3': 3, '4': 1, '5': 9, '10': 'content'},
+    const {'1': 'raw', '3': 4, '4': 1, '5': 9, '10': 'raw'},
   ],
   '8': const [
     const {'1': '_appName'},
@@ -492,4 +493,4 @@ const Notification$json = const {
 
 /// Descriptor for `Notification`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List notificationDescriptor = $convert.base64Decode(
-    'CgxOb3RpZmljYXRpb24SHQoHYXBwTmFtZRgBIAEoCUgAUgdhcHBOYW1liAEBEhQKBXRpdGxlGAIgASgJUgV0aXRsZRIYCgdjb250ZW50GAMgASgJUgdjb250ZW50QgoKCF9hcHBOYW1l');
+    'CgxOb3RpZmljYXRpb24SHQoHYXBwTmFtZRgBIAEoCUgAUgdhcHBOYW1liAEBEhQKBXRpdGxlGAIgASgJUgV0aXRsZRIYCgdjb250ZW50GAMgASgJUgdjb250ZW50EhAKA3JhdxgEIAEoCVIDcmF3QgoKCF9hcHBOYW1l');

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -192,7 +192,7 @@ class NativeAutomator {
 
   /// Returns the first, topmost visible notification.
   ///
-  /// Notification shade will be opened automatically.
+  /// Notification shade has to be opened with [openNotifications].
   Future<Notification> getFirstNotification() async {
     final response = await _wrapRequest(
       'getFirstNotification',
@@ -206,7 +206,7 @@ class NativeAutomator {
 
   /// Returns notifications that are visible in the notification shade.
   ///
-  /// Notification shade will be opened automatically.
+  /// Notification shade has to be opened with [openNotifications].
   Future<List<Notification>> getNotifications() async {
     final response = await _wrapRequest(
       'getNotifications',
@@ -218,9 +218,19 @@ class NativeAutomator {
     return response.notifications;
   }
 
+  /// Closes the currently visible heads up notification (iOS only).
+  ///
+  /// If no heads up notification is visible, the behavior is undefined.
+  Future<void> closeHeadsUpNotification() async {
+    await _wrapRequest(
+      'closeHeadsUpNotification',
+      () => _client.closeHeadsUpNotification(Empty()),
+    );
+  }
+
   /// Taps on the [index]-th visible notification.
   ///
-  /// Notification shade will be opened automatically.
+  /// Notification shade has to be opened with [openNotifications].
   Future<void> tapOnNotificationByIndex(int index) async {
     await _wrapRequest(
       'tapOnNotificationByIndex',

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -231,6 +231,8 @@ class NativeAutomator {
   /// Taps on the visible notification using [selector].
   ///
   /// Notification shade will be opened automatically.
+  ///
+  /// On iOS, only [selector.textContains] is taken into account.
   Future<void> tapOnNotificationBySelector(Selector selector) async {
     await _wrapRequest(
       'tapOnNotificationBySelector',

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -242,7 +242,7 @@ class NativeAutomator {
   ///
   /// Notification shade will be opened automatically.
   ///
-  /// On iOS, only [selector.textContains] is taken into account.
+  /// On iOS, only [Selector.textContains] is taken into account.
   Future<void> tapOnNotificationBySelector(Selector selector) async {
     await _wrapRequest(
       'tapOnNotificationBySelector',


### PR DESCRIPTION
This PR:
- fixes #319
- adds new `closeHeadsUpNotification()` method (iOS only)
- refactor of directory structure in the example app