### PR TITLE
POC: Debugging of tests and REPL in VS Code

### DIFF
--- a/packages/patrol/example/.gitignore
+++ b/packages/patrol/example/.gitignore
@@ -18,7 +18,6 @@
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-#.vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/

--- a/packages/patrol/example/integration_test/example_test.dart
+++ b/packages/patrol/example/integration_test/example_test.dart
@@ -10,6 +10,7 @@ void main() {
     'counter state is the same after going to Home and switching apps',
     config: patrolConfig,
     nativeAutomation: true,
+    binding: Binding.integrationTest,
     ($) async {
       await $.pumpWidgetAndSettle(ExampleApp());
 

--- a/packages/patrol/example/integration_test/features/open_app_test.dart
+++ b/packages/patrol/example/integration_test/features/open_app_test.dart
@@ -19,10 +19,12 @@ Future<void> main() async {
     'counter state is the same after switching apps',
     config: patrolConfig,
     nativeAutomation: true,
+    binding: Binding.integrationTest,
     ($) async {
       await $.pumpWidgetAndSettle(ExampleApp());
 
       expect($(#counterText).text, '0');
+      await $(FloatingActionButton).tap();
 
       await $(FloatingActionButton).tap();
 

--- a/packages/patrol/example/integration_test/permissions_test.dart
+++ b/packages/patrol/example/integration_test/permissions_test.dart
@@ -51,6 +51,7 @@ void main() {
     'grants various permissions',
     config: patrolConfig,
     nativeAutomation: true,
+    binding: Binding.integrationTest,
     ($) async {
       await $.pumpWidgetAndSettle(ExampleApp());
 

--- a/packages/patrol/example/test/widget_test.dart
+++ b/packages/patrol/example/test/widget_test.dart
@@ -1,0 +1,10 @@
+import 'package:example/main.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('is displayed', (tester) async {
+    await tester.pumpWidget(ExampleApp());
+
+    expect(find.text('Add'), findsWidgets);
+  });
+}


### PR DESCRIPTION
### Demo

https://user-images.githubusercontent.com/40357511/193605139-0c16fef7-6ca0-40dd-99e2-4923eae70783.mov


https://user-images.githubusercontent.com/40357511/193612155-4afcd2e4-5175-4005-9d10-e06ac4f8b629.mov


https://user-images.githubusercontent.com/40357511/193612692-20559b17-9cb5-48b3-afa4-a28b7df61c27.mov




### Problems

- No bindings can be initialized in the test. If `IntegrationTestWidgetsFlutterBinding.ensureInitialized()` or `PatrolBinding.ensureInitialized()` is called, tests crash when run inside of VSCode.
  
  Possible cause: when doing `flutter run`, the default `WidgetsFlutterBinding.ensureInitialized()` is called before we enter the test. When the integration tests starts, the bindings are already initialized, but we try to initialize our custom bindings again, hence the crash.