### PR TITLE
Fix `denyPermission()` not working on iOS

### DIFF
--- a/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/PatrolAutomation.swift
@@ -314,7 +314,7 @@ class PatrolAutomation {
   func denyPermission() {
     runAction("denying permission") {
       let systemAlerts = self.springboard.alerts
-      let denyButton = systemAlerts.buttons["Don't Allow"]
+      let denyButton = systemAlerts.buttons["Don’t Allow"] // not "Don't Allow"!
       if denyButton.exists {
         denyButton.tap()
       }


### PR DESCRIPTION
Reported by @iasiu in the customer project.