### PR TITLE
Add `andSettle` param to `PatrolFinder.scrollTo()`

### DIFF
--- a/packages/patrol/lib/src/custom_finders/patrol_finder.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_finder.dart
@@ -257,6 +257,7 @@ class PatrolFinder extends MatchFinder {
     double step = defaultScrollDelta,
     int maxScrolls = defaultScrollMaxIteration,
     Duration duration = const Duration(milliseconds: 50),
+    bool? andSettle,
   }) {
     return tester.scrollUntilVisible(
       finder: finder,
@@ -264,6 +265,7 @@ class PatrolFinder extends MatchFinder {
       delta: step,
       maxScrolls: maxScrolls,
       duration: duration,
+      andSettle: andSettle,
     );
   }
 

--- a/packages/patrol/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_tester.dart
@@ -453,6 +453,7 @@ class PatrolTester {
     double delta = defaultScrollDelta,
     int maxScrolls = defaultScrollMaxIteration,
     Duration duration = const Duration(milliseconds: 50),
+    bool? andSettle,
   }) async {
     assert(maxScrolls > 0, 'maxScrolls must be positive number');
     scrollable ??= find.byType(Scrollable);
@@ -485,6 +486,7 @@ class PatrolTester {
         moveStep: moveStep,
         maxIteration: maxScrolls,
         duration: duration,
+        andSettle: andSettle,
       );
 
       return resolvedFinder;

--- a/packages/patrol/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_tester.dart
@@ -401,6 +401,7 @@ class PatrolTester {
     double delta = defaultScrollDelta,
     int maxScrolls = defaultScrollMaxIteration,
     Duration duration = const Duration(milliseconds: 50),
+    bool? andSettle,
   }) async {
     assert(maxScrolls > 0, 'maxScrolls must be positive number');
     scrollable ??= find.byType(Scrollable);
@@ -433,6 +434,7 @@ class PatrolTester {
         moveStep: moveStep,
         maxIteration: maxScrolls,
         duration: duration,
+        andSettle: andSettle,
       );
 
       return resolvedFinder;


### PR DESCRIPTION
Fixes #500 