### PR TITLE
Re-add progress animations

### DIFF
--- a/packages/patrol_cli/lib/src/common/logging.dart
+++ b/packages/patrol_cli/lib/src/common/logging.dart
@@ -6,39 +6,12 @@ import 'package:ansi_styles/ansi_styles.dart';
 import 'package:logging/logging.dart';
 import 'package:mason_logger/mason_logger.dart' as mason_logger;
 
-// Workaround for https://github.com/felangel/mason/issues/527.
-class Progress implements mason_logger.Progress {
-  Progress._({required this.logger, required String firstMessage}) {
-    logger.info('$firstMessage...');
-  }
-
-  final Logger logger;
-
-  @override
-  void cancel() {
-    throw UnimplementedError();
-  }
-
-  @override
-  void complete([String? update]) {
-    logger.info(update);
-  }
-
-  @override
-  void fail([String? update]) {
-    logger.severe(update);
-  }
-
-  @override
-  void update(String update) {
-    logger.info(update);
-  }
-}
-
 extension LoggerX on Logger {
+  static final _logger = mason_logger.Logger();
+
   /// Writes progress message to stdout.
-  Progress progress(String message) {
-    return Progress._(firstMessage: message, logger: this);
+  mason_logger.Progress progress(String message) {
+    return _logger.progress(message);
   }
 
   set verbose(bool newValue) => _verbose = newValue;

--- a/packages/patrol_cli/pubspec.lock
+++ b/packages/patrol_cli/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: adb
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+2"
+    version: "0.2.2"
   analyzer:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.2"
   build_runner_core:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.3.0"
   collection:
     dependency: "direct main"
     description:
@@ -224,7 +224,7 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.1.0"
   glob:
     dependency: transitive
     description:
@@ -308,7 +308,7 @@ packages:
       name: mason_logger
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   matcher:
     dependency: transitive
     description:
@@ -497,21 +497,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.7"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.15"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.19"
   timing:
     dependency: transitive
     description:
@@ -562,4 +562,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/packages/patrol_cli/pubspec.lock
+++ b/packages/patrol_cli/pubspec.lock
@@ -301,14 +301,14 @@ packages:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   mason_logger:
     dependency: "direct main"
     description:
       name: mason_logger
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.1"
   matcher:
     dependency: transitive
     description:

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -19,8 +19,8 @@ dependencies:
   file: ^6.1.4
   freezed_annotation: ^2.1.0
   http: ^0.13.5
-  logging: ^1.0.2
-  mason_logger: ^0.1.3
+  logging: ^1.1.0
+  mason_logger: ^0.2.1
   meta: ^1.8.0
   path: ^1.8.2
   platform: ^3.1.0

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   pub_updater: ^0.2.2
   yaml: ^3.1.1
 dev_dependencies:
-  build_runner: ^2.3.2
+  build_runner: ^2.2.1
   fake_async: ^1.3.1
   freezed: ^2.1.0+1
   leancode_lint: ^2.0.0+1

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -20,14 +20,14 @@ dependencies:
   freezed_annotation: ^2.1.0
   http: ^0.13.5
   logging: ^1.1.0
-  mason_logger: ^0.2.1
+  mason_logger: ^0.2.2
   meta: ^1.8.0
   path: ^1.8.2
   platform: ^3.1.0
   pub_updater: ^0.2.2
   yaml: ^3.1.1
 dev_dependencies:
-  build_runner: ^2.2.1
+  build_runner: ^2.3.2
   fake_async: ^1.3.1
   freezed: ^2.1.0+1
   leancode_lint: ^2.0.0+1


### PR DESCRIPTION
The bug in `mason_logger` was fixed in https://github.com/felangel/mason/pull/549, so I'm bringing the animations back.

Animations were removed in #498.
