### PR TITLE
Improve output of `patrol doctor` command

### DIFF
--- a/packages/patrol_cli/lib/src/command_runner.dart
+++ b/packages/patrol_cli/lib/src/command_runner.dart
@@ -108,6 +108,7 @@ class PatrolCommandRunner extends CommandRunner<int> {
       DoctorCommand(
         logger: _logger,
         artifactsRepository: _artifactsRepository,
+        platform: const LocalPlatform(),
       ),
     );
     addCommand(

--- a/packages/patrol_cli/lib/src/common/logging.dart
+++ b/packages/patrol_cli/lib/src/common/logging.dart
@@ -42,6 +42,14 @@ extension LoggerX on Logger {
   }
 
   set verbose(bool newValue) => _verbose = newValue;
+
+  void ok(String msg) {
+    info('${mason_logger.green.wrap("✓")} $msg');
+  }
+
+  void err(String msg) {
+    info('${mason_logger.red.wrap("✗")} $msg');
+  }
 }
 
 bool _verbose = false;

--- a/packages/patrol_cli/pubspec.lock
+++ b/packages/patrol_cli/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: adb
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+2"
+    version: "0.2.2"
   analyzer:
     dependency: transitive
     description:

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  adb: ^0.2.1+2
+  adb: ^0.2.2
   ansi_styles: ^0.3.2+1
   archive: ^3.3.1
   args: ^2.3.1


### PR DESCRIPTION
Fixes #175.

Before:

```
$ patrol doctor
artifact path: /Users/bartek/.cache/patrol (default)
```

After:

```
$ patrol doctor
artifact path: /Users/bartek/.cache/patrol (default)
✓ adb found in /Users/bartek/androidsdk/platform-tools/adb
✓ $ANDROID_HOME env var set to /Users/bartek/androidsdk
✓ xcodebuild found in /usr/bin/xcodebuild
✓ iproxy found in /opt/homebrew/bin/iproxy
✓ stdbuf found in /opt/homebrew/bin/stdbuf
✓ ideviceinstaller found in /opt/homebrew/bin/ideviceinstaller
```