### PR TITLE
fix: which in windows platform

### DIFF
--- a/packages/patrol_cli/lib/src/features/doctor/doctor_command.dart
+++ b/packages/patrol_cli/lib/src/features/doctor/doctor_command.dart
@@ -66,7 +66,9 @@ class DoctorCommand extends Command<int> {
   }
 
   void _checkIfInstalled(String tool, [String? hint]) {
-    final result = io.Process.runSync('which', [tool]);
+    final result = io.Platform.isWindows
+        ? io.Process.runSync('where.exe', [tool])
+        : io.Process.runSync('which', [tool]);
     if (result.exitCode == 0) {
       _logger.ok('$tool found in ${result.stdOut.trim()}');
     } else {


### PR DESCRIPTION
What?
In windows which is unavailable so where.exe is used which does exactly the same thing.
```powershell
> patrol doctor
artifact path: C:\Users\Abugh\.cache\patrol (default)
✓ adb found in C:\platform-tools\adb.exe
✓ $ANDROID_HOME env var set to C:\Users\Abugh\AppData\Local\Android\Sdk
```
Fixes:
#545 