### PR TITLE
adb: explicitly specify device when waiting for `package` service

### DIFF
--- a/packages/adb/CHANGELOG.md
+++ b/packages/adb/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.3
+
+- Fix infinite waiting for `package` service when more than a single device
+  device is attached (#553)
+
 ## 0.2.2
 
 - Wait for the `package` service before installing apk (#539)

--- a/packages/adb/lib/src/adb.dart
+++ b/packages/adb/lib/src/adb.dart
@@ -36,7 +36,7 @@ class Adb {
     String? device,
   }) async {
     await _ensureServerRunning();
-    await _ensurePackageServiceRunning();
+    await _ensurePackageServiceRunning(device: device);
 
     final result = await io.Process.run(
       'adb',
@@ -72,7 +72,7 @@ class Adb {
     String? device,
   }) async {
     await _ensureServerRunning();
-    await _ensurePackageServiceRunning();
+    await _ensurePackageServiceRunning(device: device);
 
     final result = await io.Process.run(
       'adb',
@@ -178,10 +178,7 @@ class Adb {
     final process = await io.Process.start(
       'adb',
       [
-        if (device != null) ...[
-          '-s',
-          device,
-        ],
+        if (device != null) ...['-s', device],
         'shell',
         'am',
         'instrument',
@@ -241,11 +238,16 @@ class Adb {
     }
   }
 
-  Future<void> _ensurePackageServiceRunning() async {
+  Future<void> _ensurePackageServiceRunning({required String? device}) async {
     while (true) {
       final result = await io.Process.run(
         'adb',
-        ['shell', 'service', 'list'],
+        [
+          if (device != null) ...['-s', device],
+          'shell',
+          'service',
+          'list',
+        ],
         runInShell: true,
       );
 

--- a/packages/adb/pubspec.yaml
+++ b/packages/adb/pubspec.yaml
@@ -1,6 +1,6 @@
 name: adb
 description: Simple Dart wrapper around Android Debug Bridge.
-version: 0.2.2
+version: 0.2.3
 repository: https://github.com/leancodepl/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues
 


### PR DESCRIPTION
should fix #549