### PR TITLE
fix FlutterTool.build() having Unix-style path on Windows

### DIFF
--- a/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
@@ -234,7 +234,7 @@ class FlutterTool {
   }) {
     String getApplicationBinaryPath() {
       if (platform == TargetPlatform.android) {
-        const prefix = 'build/app/outputs/flutter-apk';
+        final prefix = join('build', 'app', 'outputs', 'flutter-apk');
         if (flavor != null) {
           return join(prefix, 'app-${flavor.toLowerCase()}-debug.apk');
         } else {


### PR DESCRIPTION
Fix for #573

Will close #573 once the user confirms the fix works.