### PR TITLE
Add support for optional file with `--dart-define`s

### DIFF
--- a/docs/tips-and-tricks.mdx
+++ b/docs/tips-and-tricks.mdx
@@ -74,6 +74,16 @@ To set `USERNAME` and `PASSWORD`, use `--dart-define`:
 $ patrol drive --dart-define 'USERNAME=Bartek' --dart-define 'PASSWORD=ny4ncat'
 ```
 
+Alternatively you can create a `.patrol.env` file in your project's root. Here's
+an example:
+
+```
+$ cat .patrol.env
+EMAIL=user@example.com
+PASSWORD=ny4ncat
+DISABLE_ANALYTICS=true
+```
+
 ## Granting sensitive permission through the Settings app
 
 Some particularly sensitive permissions (such as access to background location

--- a/docs/tips-and-tricks.mdx
+++ b/docs/tips-and-tricks.mdx
@@ -2,8 +2,15 @@
 
 ## Running a test many times
 
-Sometimes, you might want to run a test many times. In such case, we've got
-these one-liners for you:
+Sometimes, you might want to run a test many times. Patrol makes this easy:
+
+```bash
+$ patrol drive --target integration_test/my_test.dart --repeat 10
+```
+
+You can also use the one-liners below, but keep in mind that they build
+and test the app 10 times, while `patrol drive --repeat 10` would build every
+test target only once and run it 10 times.
 
 **Bash**
 

--- a/packages/patrol/example/lib/main.dart
+++ b/packages/patrol/example/lib/main.dart
@@ -215,6 +215,7 @@ class _ExampleHomePageState extends State<ExampleHomePage> {
             ),
             child: const Text('Open permissions screen'),
           ),
+          Text('EXAMPLE_KEY: ${const String.fromEnvironment('EXAMPLE_KEY')}'),
         ],
       ),
       floatingActionButton: FloatingActionButton(

--- a/packages/patrol_cli/lib/src/command_runner.dart
+++ b/packages/patrol_cli/lib/src/command_runner.dart
@@ -15,6 +15,7 @@ import 'package:patrol_cli/src/features/clean/clean_command.dart';
 import 'package:patrol_cli/src/features/devices/device_finder.dart';
 import 'package:patrol_cli/src/features/devices/devices_command.dart';
 import 'package:patrol_cli/src/features/doctor/doctor_command.dart';
+import 'package:patrol_cli/src/features/drive/dart_defines_reader.dart';
 import 'package:patrol_cli/src/features/drive/drive_command.dart';
 import 'package:patrol_cli/src/features/drive/flutter_tool.dart';
 import 'package:patrol_cli/src/features/drive/platform/android_driver.dart';
@@ -80,6 +81,7 @@ class PatrolCommandRunner extends CommandRunner<int> {
           integrationTestDir: _fs.directory('integration_test'),
           fs: _fs,
         ),
+        testRunner: TestRunner(),
         androidDriver: AndroidDriver(
           parentDisposeScope: _disposeScope,
           artifactsRepository: _artifactsRepository,
@@ -94,7 +96,10 @@ class PatrolCommandRunner extends CommandRunner<int> {
           parentDisposeScope: _disposeScope,
           logger: _logger,
         ),
-        testRunner: TestRunner(),
+        dartDefinesReader: DartDefinesReader(
+          projectRoot: _fs.currentDirectory,
+          fs: _fs,
+        ),
         logger: _logger,
       ),
     );

--- a/packages/patrol_cli/lib/src/common/extensions/core.dart
+++ b/packages/patrol_cli/lib/src/common/extensions/core.dart
@@ -1,0 +1,18 @@
+extension MapX<K, V> on Map<K, V?> {
+  Map<K, V> withNullsRemoved() {
+    return {
+      for (final entry in entries)
+        if (entry.value != null) entry.key: entry.value as V,
+    };
+  }
+}
+
+extension StringX on String {
+  /// Adapted from https://stackoverflow.com/a/60404614/7009800
+  List<String> splitFirst(String sep) {
+    final index = indexOf(sep);
+    final parts = [substring(0, index).trim(), substring(index + 1).trim()];
+
+    return parts;
+  }
+}

--- a/packages/patrol_cli/lib/src/common/extensions/map.dart
+++ b/packages/patrol_cli/lib/src/common/extensions/map.dart
@@ -1,8 +1,0 @@
-extension MapX<K, V> on Map<K, V?> {
-  Map<K, V> withNullsRemoved() {
-    return {
-      for (final entry in entries)
-        if (entry.value != null) entry.key: entry.value as V,
-    };
-  }
-}

--- a/packages/patrol_cli/lib/src/features/drive/dart_defines_reader.dart
+++ b/packages/patrol_cli/lib/src/features/drive/dart_defines_reader.dart
@@ -1,0 +1,45 @@
+import 'package:file/file.dart';
+import 'package:path/path.dart' show join;
+import 'package:patrol_cli/src/common/extensions/core.dart';
+
+class DartDefinesReader {
+  const DartDefinesReader({
+    required Directory projectRoot,
+    required FileSystem fs,
+  })  : _projectRoot = projectRoot,
+        _fs = fs;
+
+  final Directory _projectRoot;
+  final FileSystem _fs;
+
+  Map<String, String> fromCli({required List<String> args}) {
+    final map = <String, String>{};
+    for (final arg in args) {
+      final parts = arg.splitFirst('=');
+      final key = parts.first;
+      final value = parts.elementAt(1);
+      map[key] = value;
+    }
+
+    return map;
+  }
+
+  Map<String, String> fromFile() {
+    final filePath = join(_projectRoot.path, '.patrol.env');
+    final file = _fs.file(filePath);
+
+    if (!file.existsSync()) {
+      return {};
+    }
+
+    final map = <String, String>{};
+    for (final line in file.readAsLinesSync()) {
+      final parts = line.splitFirst('=');
+      final key = parts.first;
+      final value = parts.elementAt(1);
+      map[key] = value;
+    }
+
+    return map;
+  }
+}

--- a/packages/patrol_cli/lib/src/features/drive/dart_defines_reader.dart
+++ b/packages/patrol_cli/lib/src/features/drive/dart_defines_reader.dart
@@ -12,17 +12,7 @@ class DartDefinesReader {
   final Directory _projectRoot;
   final FileSystem _fs;
 
-  Map<String, String> fromCli({required List<String> args}) {
-    final map = <String, String>{};
-    for (final arg in args) {
-      final parts = arg.splitFirst('=');
-      final key = parts.first;
-      final value = parts.elementAt(1);
-      map[key] = value;
-    }
-
-    return map;
-  }
+  Map<String, String> fromCli({required List<String> args}) => _parse(args);
 
   Map<String, String> fromFile() {
     final filePath = join(_projectRoot.path, '.patrol.env');
@@ -32,10 +22,20 @@ class DartDefinesReader {
       return {};
     }
 
+    final lines = file.readAsLinesSync()
+      ..removeWhere((line) => line.trim().isEmpty);
+    return _parse(lines);
+  }
+
+  Map<String, String> _parse(List<String> args) {
     final map = <String, String>{};
-    for (final line in file.readAsLinesSync()) {
-      final parts = line.splitFirst('=');
+    for (final arg in args) {
+      final parts = arg.splitFirst('=');
       final key = parts.first;
+      if (key.contains(' ')) {
+        throw FormatException('key "$key" contains whitespace');
+      }
+
       final value = parts.elementAt(1);
       map[key] = value;
     }

--- a/packages/patrol_cli/lib/src/features/drive/drive_command.dart
+++ b/packages/patrol_cli/lib/src/features/drive/drive_command.dart
@@ -164,7 +164,7 @@ class DriveCommand extends StagedCommand<DriveCommandConfig> {
     };
 
     for (final dartDefine in dartDefines.entries) {
-      _logger.info('Got --dart-define: ${dartDefine.key}=${dartDefine.value}');
+      _logger.info('Got --dart-define ${dartDefine.key}=${dartDefine.value}');
     }
 
     final dynamic packageName = argResults?['package-name'];

--- a/packages/patrol_cli/lib/src/features/drive/drive_command.dart
+++ b/packages/patrol_cli/lib/src/features/drive/drive_command.dart
@@ -164,7 +164,7 @@ class DriveCommand extends StagedCommand<DriveCommandConfig> {
     };
 
     for (final dartDefine in dartDefines.entries) {
-      _logger.info('Got --dart-define ${dartDefine.key}=${dartDefine.value}');
+      _logger.info('Got --dart-define ${dartDefine.key}');
     }
 
     final dynamic packageName = argResults?['package-name'];

--- a/packages/patrol_cli/lib/src/features/drive/drive_command.dart
+++ b/packages/patrol_cli/lib/src/features/drive/drive_command.dart
@@ -157,10 +157,10 @@ class DriveCommand extends StagedCommand<DriveCommandConfig> {
     final devices = argResults?['device'] as List<String>? ?? [];
 
     final dartDefines = {
+      ..._dartDefinesReader.fromFile(),
       ..._dartDefinesReader.fromCli(
         args: argResults?['dart-define'] as List<String>? ?? [],
       ),
-      ..._dartDefinesReader.fromFile(),
     };
 
     for (final dartDefine in dartDefines.entries) {

--- a/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
@@ -101,7 +101,7 @@ class FlutterTool {
           if (device.real) '--no-simulator' else '--simulator',
         for (final dartDefine in {...env, ...dartDefines}.entries) ...[
           '--dart-define',
-          '${dartDefine.key}=${dartDefine.value}',
+          "${dartDefine.key}='${dartDefine.value}'",
         ]
       ],
       runInShell: true,
@@ -268,9 +268,7 @@ class FlutterTool {
       final value = dartDefine.value;
 
       if (key.contains(' ') || key.contains('=')) {
-        throw FormatException(
-          '--dart-define key "$value" contains whitespace or "="',
-        );
+        throw FormatException('--dart-define key "$value" contains whitespace');
       }
 
       if (value.contains(' ') || value.contains('=')) {

--- a/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
@@ -72,7 +72,6 @@ class FlutterTool {
     this.port = port;
     this.flavor = flavor;
     this.dartDefines = dartDefines;
-    _assertDartDefines(dartDefines);
 
     env = {
       envHostKey: host,
@@ -260,22 +259,5 @@ class FlutterTool {
       if (device != null) ...['--device-id', device],
       if (flavor != null) ...['--flavor', flavor],
     ];
-  }
-
-  static void _assertDartDefines(Map<String, String> dartDefines) {
-    for (final dartDefine in dartDefines.entries) {
-      final key = dartDefine.key;
-      final value = dartDefine.value;
-
-      if (key.contains(' ') || key.contains('=')) {
-        throw FormatException('--dart-define key "$value" contains whitespace');
-      }
-
-      if (value.contains(' ') || value.contains('=')) {
-        throw FormatException(
-          '--dart-define value "$value" contains whitespace or "="',
-        );
-      }
-    }
   }
 }

--- a/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
@@ -4,7 +4,7 @@ import 'package:dispose_scope/dispose_scope.dart';
 import 'package:logging/logging.dart';
 import 'package:mason_logger/mason_logger.dart' show green, red;
 import 'package:path/path.dart' show absolute, basename, join;
-import 'package:patrol_cli/src/common/extensions/map.dart';
+import 'package:patrol_cli/src/common/extensions/core.dart';
 import 'package:patrol_cli/src/features/drive/constants.dart';
 import 'package:patrol_cli/src/features/drive/device.dart';
 

--- a/packages/patrol_cli/lib/src/features/drive/test_finder.dart
+++ b/packages/patrol_cli/lib/src/features/drive/test_finder.dart
@@ -3,7 +3,7 @@ import 'package:file/file.dart';
 import '../../common/tool_exit.dart';
 
 class TestFinder {
-  TestFinder({
+  const TestFinder({
     required Directory integrationTestDir,
     required FileSystem fs,
   })  : _integrationTestDirectory = integrationTestDir,

--- a/packages/patrol_cli/pubspec.lock
+++ b/packages/patrol_cli/pubspec.lock
@@ -519,6 +519,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  tuple:
+    dependency: "direct main"
+    description:
+      name: tuple
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   typed_data:
     dependency: transitive
     description:

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   path: ^1.8.2
   platform: ^3.1.0
   pub_updater: ^0.2.2
+  tuple: ^2.0.1
   yaml: ^3.1.1
 dev_dependencies:
   build_runner: ^2.2.1

--- a/packages/patrol_cli/test/features/drive/dart_defines_reader_test.dart
+++ b/packages/patrol_cli/test/features/drive/dart_defines_reader_test.dart
@@ -1,0 +1,74 @@
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:patrol_cli/src/features/drive/dart_defines_reader.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late FileSystem fs;
+
+  group('DartDefinesReader', () {
+    late DartDefinesReader reader;
+
+    setUp(() {
+      fs = MemoryFileSystem.test();
+      final wd = fs.directory('/projects/awesome_app')
+        ..createSync(recursive: true);
+      fs.currentDirectory = wd;
+      reader = DartDefinesReader(fs: fs, projectRoot: fs.currentDirectory);
+    });
+
+    group('fromCli()', () {
+      test('reads correct simple input', () {
+        final args = [
+          'EMAIL=email@example.com',
+          'PASSWORD=ny4ncat',
+        ];
+
+        expect(
+          reader.fromCli(args: args),
+          equals({'EMAIL': 'email@example.com', 'PASSWORD': 'ny4ncat'}),
+        );
+      });
+
+      test('reads correct complex input', () {
+        final args = [
+          'EMAIL=email@wrong=domain.com',
+          r'PASSWORD="ny4ncat\n"',
+        ];
+
+        expect(
+          reader.fromCli(args: args),
+          equals({
+            'EMAIL': 'email@wrong=domain.com',
+            'PASSWORD': r'"ny4ncat\n"',
+          }),
+        );
+      });
+    });
+
+    group('fromFile()', () {
+      late File file;
+      setUp(() {
+        file = fs.file('.patrol.env');
+      });
+
+      test('reads correct simple input', () {
+        file.writeAsString('EMAIL=email@example.com\nPASSWORD=ny4ncat\n');
+
+        expect(
+          reader.fromFile(),
+          equals({'EMAIL': 'email@example.com', 'PASSWORD': 'ny4ncat'}),
+        );
+      });
+
+      test('reads correct simple input with empty lines', () {
+        file.writeAsString('EMAIL=email@example.com\n\nPASSWORD=ny4ncat\n');
+
+        expect(
+          reader.fromFile(),
+          equals({'EMAIL': 'email@example.com', 'PASSWORD': 'ny4ncat'}),
+        );
+      });
+    });
+  });
+}

--- a/packages/patrol_cli/test/features/drive/drive_command_test.dart
+++ b/packages/patrol_cli/test/features/drive/drive_command_test.dart
@@ -5,6 +5,7 @@ import 'package:logging/logging.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:patrol_cli/src/common/artifacts_repository.dart';
 import 'package:patrol_cli/src/features/devices/device_finder.dart';
+import 'package:patrol_cli/src/features/drive/dart_defines_reader.dart';
 import 'package:patrol_cli/src/features/drive/drive_command.dart';
 import 'package:patrol_cli/src/features/drive/flutter_tool.dart';
 import 'package:patrol_cli/src/features/drive/platform/android_driver.dart';
@@ -87,6 +88,10 @@ void main() {
         androidDriver: androidDriver,
         flutterTool: flutterTool,
         testRunner: TestRunner(),
+        dartDefinesReader: DartDefinesReader(
+          fs: fs,
+          projectRoot: fs.currentDirectory,
+        ),
         logger: Logger(''),
       );
     });


### PR DESCRIPTION
This PR:
- fixes #578

### Usage

The `.patrol.env` file should not be checked into git.

```console
$ pwd
/Users/bartek/dev/leancode/budowa/mobile
$ cat .patrol.env
EMAIL=awesome_tester@leancode.pl
PASSWORD=doge=kool
EXAMPLE_KEY='Al8=//\\'
$ patrol drive
Got --dart-define: EMAIL=awesome_tester@leancode.pl
Got --dart-define: PASSWORD=doge=kool
Got --dart-define: EXAMPLE_KEY='Al8=//\\'
<...>
```