### PR TITLE
remove openNotifications() from example_test.dart

### DIFF
--- a/packages/patrol/example/integration_test/example_test.dart
+++ b/packages/patrol/example/integration_test/example_test.dart
@@ -24,9 +24,6 @@ void main() {
       expect($(#counterText).text, '1');
       await $(FloatingActionButton).tap();
       expect($(#counterText).text, '2');
-
-      await $.native.openNotifications();
-      await $.native.pressBack();
     },
   );
 }


### PR DESCRIPTION
`openNotifications` and `pressBack()` often result in infinite wait:

Logs:
```
Patrol (native): openNotifications() succeeded
Patrol (native): pressBack() started
VMServiceFlutterDriver: request_data message is taking a long time to complete...
<timeout occurs>
```

First reported by @jakubfijalkowski.