### PR TITLE
AutomatorServer: migrate from Netty to OkHttp

### DIFF
--- a/AutomatorServer/android/app/build.gradle
+++ b/AutomatorServer/android/app/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     androidTestImplementation "io.grpc:grpc-protobuf:1.49.2"
     androidTestImplementation "io.grpc:grpc-stub:1.49.2"
     androidTestImplementation "io.grpc:grpc-kotlin-stub:1.3.0"
-    androidTestImplementation "io.grpc:grpc-netty:1.49.2"
+    androidTestImplementation "io.grpc:grpc-okhttp:1.49.2"
     androidTestImplementation "javax.annotation:javax.annotation-api:1.3.2"
 
     androidTestImplementation "androidx.test.ext:junit:1.1.3"

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/PatrolServer.kt
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/PatrolServer.kt
@@ -1,8 +1,9 @@
 package pl.leancode.automatorserver
 
 import androidx.test.platform.app.InstrumentationRegistry
+import io.grpc.InsecureServerCredentials
 import io.grpc.Server
-import io.grpc.netty.NettyServerBuilder
+import io.grpc.okhttp.OkHttpServerBuilder
 
 class PatrolServer {
     private val envPortKey = "PATROL_PORT"
@@ -11,8 +12,8 @@ class PatrolServer {
 
     init {
         port = arguments.getString(envPortKey)?.toInt() ?: 8081
-        server = NettyServerBuilder
-            .forPort(port)
+        server = OkHttpServerBuilder
+            .forPort(port, InsecureServerCredentials.create())
             .intercept(LoggerInterceptor())
             .addService(NativeAutomatorServer())
             .build()


### PR DESCRIPTION
A very nice man (may his name be blessed forever) [implemented](https://github.com/grpc/grpc-java/pull/9177) OkHttp for GRPC on Android. This means we can migrate to it from the Netty server, [which is slow and unstable on Android](https://github.com/grpc/grpc-java/issues/4407#issuecomment-1100284463).