### PR TITLE
chore/native class cleanup

### DIFF
--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/Automator.kt
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/Automator.kt
@@ -47,7 +47,7 @@ private fun fromUiObject2(obj: UiObject2): Contracts.NativeView {
     }
 }
 
-class PatrolAutomator private constructor() {
+class Automator private constructor() {
     private var timeoutMillis: Long = 10_000
 
     fun configure(waitForSelectorTimeout: Long) {
@@ -444,6 +444,6 @@ class PatrolAutomator private constructor() {
     }
 
     companion object {
-        val instance = PatrolAutomator()
+        val instance = Automator()
     }
 }

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/AutomatorServer.kt
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/AutomatorServer.kt
@@ -16,8 +16,8 @@ import pl.leancode.automatorserver.contracts.permissionDialogVisibleResponse
 
 typealias Empty = Contracts.Empty
 
-class NativeAutomatorServer : NativeAutomatorGrpcKt.NativeAutomatorCoroutineImplBase() {
-    private val automation = PatrolAutomator.instance
+class AutomatorServer : NativeAutomatorGrpcKt.NativeAutomatorCoroutineImplBase() {
+    private val automation = Automator.instance
 
     override suspend fun configure(request: Contracts.ConfigureRequest): Empty {
         automation.configure(waitForSelectorTimeout = request.findTimeoutMillis)

--- a/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/PatrolServer.kt
+++ b/AutomatorServer/android/app/src/androidTest/java/pl/leancode/automatorserver/PatrolServer.kt
@@ -15,7 +15,7 @@ class PatrolServer {
         server = OkHttpServerBuilder
             .forPort(port, InsecureServerCredentials.create())
             .intercept(LoggerInterceptor())
-            .addService(NativeAutomatorServer())
+            .addService(AutomatorServer())
             .build()
     }
 

--- a/AutomatorServer/ios/AutomatorServer.xcodeproj/project.pbxproj
+++ b/AutomatorServer/ios/AutomatorServer.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		9816533F28DDF4BA00C2BB4C /* GRPC in Frameworks */ = {isa = PBXBuildFile; productRef = 9816533E28DDF4BA00C2BB4C /* GRPC */; };
-		9816534328DE35D800C2BB4C /* NativeAutomatorServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9816534228DE35D800C2BB4C /* NativeAutomatorServer.swift */; };
+		9816534328DE35D800C2BB4C /* AutomatorServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9816534228DE35D800C2BB4C /* AutomatorServer.swift */; };
 		98245C1728E8C9FA000501D5 /* contracts.grpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98245C1528E8C9FA000501D5 /* contracts.grpc.swift */; };
 		98245C1828E8C9FA000501D5 /* contracts.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98245C1628E8C9FA000501D5 /* contracts.pb.swift */; };
 		983049FA2899206400C87527 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983049F92899206400C87527 /* Logger.swift */; };
@@ -36,7 +36,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		9816534228DE35D800C2BB4C /* NativeAutomatorServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAutomatorServer.swift; sourceTree = "<group>"; };
+		9816534228DE35D800C2BB4C /* AutomatorServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomatorServer.swift; sourceTree = "<group>"; };
 		98245C1528E8C9FA000501D5 /* contracts.grpc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = contracts.grpc.swift; sourceTree = "<group>"; };
 		98245C1628E8C9FA000501D5 /* contracts.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = contracts.pb.swift; sourceTree = "<group>"; };
 		983049F92899206400C87527 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
@@ -78,14 +78,14 @@
 		98B3653A28903325008B5B8B /* AutomatorServerUITests */ = {
 			isa = PBXGroup;
 			children = (
+				98B3654828903360008B5B8B /* Automator.swift */,
+				9816534228DE35D800C2BB4C /* AutomatorServer.swift */,
 				98245C1528E8C9FA000501D5 /* contracts.grpc.swift */,
 				98245C1628E8C9FA000501D5 /* contracts.pb.swift */,
-				98B365442890333D008B5B8B /* ServerLoop.swift */,
 				98B3654628903353008B5B8B /* PatrolServer.swift */,
-				98B3654828903360008B5B8B /* Automator.swift */,
+				98B365442890333D008B5B8B /* ServerLoop.swift */,
 				983049F92899206400C87527 /* Logger.swift */,
 				988FE74B28A5138800EA2141 /* Errors.swift */,
-				9816534228DE35D800C2BB4C /* NativeAutomatorServer.swift */,
 			);
 			path = AutomatorServerUITests;
 			sourceTree = "<group>";
@@ -238,7 +238,7 @@
 				98B3654728903353008B5B8B /* PatrolServer.swift in Sources */,
 				98245C1728E8C9FA000501D5 /* contracts.grpc.swift in Sources */,
 				98B365452890333D008B5B8B /* ServerLoop.swift in Sources */,
-				9816534328DE35D800C2BB4C /* NativeAutomatorServer.swift in Sources */,
+				9816534328DE35D800C2BB4C /* AutomatorServer.swift in Sources */,
 				983049FA2899206400C87527 /* Logger.swift in Sources */,
 				98245C1828E8C9FA000501D5 /* contracts.pb.swift in Sources */,
 				988FE74C28A5138800EA2141 /* Errors.swift in Sources */,

--- a/AutomatorServer/ios/AutomatorServerUITests/AutomatorServer.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/AutomatorServer.swift
@@ -4,7 +4,7 @@ import GRPC
 typealias Empty = Patrol_Empty
 typealias DefaultResponse = Patrol_Empty
 
-final class NativeAutomatorServer: Patrol_NativeAutomatorAsyncProvider {
+final class AutomatorServer: Patrol_NativeAutomatorAsyncProvider {
   private let automator: Automator
 
   init(automator: Automator) {

--- a/AutomatorServer/ios/AutomatorServerUITests/PatrolServer.swift
+++ b/AutomatorServer/ios/AutomatorServerUITests/PatrolServer.swift
@@ -28,7 +28,7 @@ class PatrolServer {
   func start() async throws {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
-    let provider = NativeAutomatorServer(automator: automator)
+    let provider = AutomatorServer(automator: automator)
 
     let server = try await Server.insecure(group: group).withServiceProviders([provider]).bind(
       host: "0.0.0.0", port: port


### PR DESCRIPTION
- rename `PatrolAutomator` to `Automator`
- rename some iOS classes as well
