### PR TITLE
fix `PatrolTester.dragUntilVisible()` not calling `first` on its `view` param

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,6 +1,12 @@
+## Unreleased
+
+- Fix `PatrolTester.dragUntilVisible()` not calling `first` on its `Finder view`
+  parameter (#656)
+
 ## 0.7.6
 
-- Make it possible to configure loggers of `NativeAutomator` and `HostAutomator` (#644)
+- Make it possible to configure loggers of `NativeAutomator` and `HostAutomator`
+  (#644)
 - Throw `PatrolFinderException` when `PatrolFinder.text` fails (#644)
 
 ## 0.7.5
@@ -239,7 +245,8 @@ Native:
 - Improve selector engine:
 
   - Make it possible to pass a `Key` as `matching` to
-    `MaestroTester.call(dynamic matching)` and `MaestroFinder.$(dynamic matching)`
+    `MaestroTester.call(dynamic matching)` and `MaestroFinder.$(dynamic
+matching)`
 
 - Add `sleep` parameter for `maestroTest` method
 - Make `WidgetTester`'s forwarded methods in `MaestroTester` accept less
@@ -251,7 +258,8 @@ Native:
 - Improve selector engine:
 
   - Make it possible to pass a `MaestroFinder` as `matching` to
-    `MaestroTester.call(dynamic matching)` and `MaestroFinder.$(dynamic matching)`
+    `MaestroTester.call(dynamic matching)` and `MaestroFinder.$(dynamic
+matching)`
   - Fix a bug which caused chaining `MaestroFinder`s (e.g
     `$(Scaffold).$(Container).$(#someText)`) to not work.
 

--- a/packages/patrol/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_tester.dart
@@ -425,6 +425,9 @@ class PatrolTester {
   ///
   ///  * waits until [view] is visible
   ///
+  ///  * if the [view] finder finds more than 1 view, it scrolls the first one
+  ///    instead of throwing a [StateError]
+  ///
   ///  * uses [WidgetController.firstElement] instead of
   ///    [WidgetController.element], which avoids [StateError] being thrown in
   ///    situations when [finder] finds more than 1 visible widget
@@ -437,12 +440,13 @@ class PatrolTester {
     bool? andSettle,
   }) {
     return TestAsyncUtils.guard(() async {
-      final viewPatrolFinder = PatrolFinder(finder: view, tester: this);
+      var viewPatrolFinder = PatrolFinder(finder: view, tester: this);
       await viewPatrolFinder.waitUntilVisible();
+      viewPatrolFinder = viewPatrolFinder.first;
 
       var iterationsLeft = maxIteration;
       while (iterationsLeft > 0 && finder.hitTestable().evaluate().isEmpty) {
-        await tester.drag(view, moveStep);
+        await tester.drag(viewPatrolFinder, moveStep);
         await tester.pump(duration);
         iterationsLeft -= 1;
       }

--- a/packages/patrol/test/patrol_tester_test.dart
+++ b/packages/patrol/test/patrol_tester_test.dart
@@ -562,7 +562,7 @@ void main() {
     );
 
     patrolTest(
-      'drags to non-existent and visible widget in the first Scrollable',
+      'drags to non-existent and non-visible widget in the first Scrollable',
       (tester) async {
         await tester.pumpWidget(
           MaterialApp(
@@ -574,11 +574,13 @@ void main() {
                 }
 
                 return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     SingleChildScrollView(
                       scrollDirection: Axis.horizontal,
                       child: Column(
                         children: const [
+                          SizedBox(width: 2000),
                           Text('text 1'),
                           Text('text 1'),
                         ],
@@ -587,7 +589,10 @@ void main() {
                     SingleChildScrollView(
                       scrollDirection: Axis.horizontal,
                       child: Column(
-                        children: const [Text('text 2')],
+                        children: const [
+                          SizedBox(width: 2000),
+                          Text('text 2'),
+                        ],
                       ),
                     ),
                   ],
@@ -600,6 +605,7 @@ void main() {
         expect(find.text('text 1').hitTestable(), findsNothing);
         expect(find.text('text 2').hitTestable(), findsNothing);
 
+        // scroll the first scrollable
         await tester.dragUntilVisible(
           finder: find.text('text 1'),
           view: find.byType(Scrollable),
@@ -607,11 +613,15 @@ void main() {
         );
 
         expect(find.text('text 1').hitTestable(), findsNWidgets(2));
-        expect(find.text('text 2').hitTestable(), findsOneWidget);
+        expect(
+          find.text('text 2').hitTestable(),
+          findsNothing, // not scrolled yet
+        );
 
+        // scroll the second scrollable
         await tester.dragUntilVisible(
           finder: find.text('text 2'),
-          view: find.byType(Scrollable),
+          view: find.byType(Scrollable).at(1),
           moveStep: const Offset(0, 16),
         );
 


### PR DESCRIPTION
Fixes #654
