### PR TITLE
PatrolTester: make `pump()` and `pumpAndSettle()` have named parameters

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,6 +1,12 @@
+## Unreleased
+
+- **Breaking:** Change signature of `PatrolTester.pumpAndSettle()` method to use
+  named arguments (#657)
+
 ## 0.7.6
 
-- Make it possible to configure loggers of `NativeAutomator` and `HostAutomator` (#644)
+- Make it possible to configure loggers of `NativeAutomator` and `HostAutomator`
+  (#644)
 - Throw `PatrolFinderException` when `PatrolFinder.text` fails (#644)
 
 ## 0.7.5
@@ -239,7 +245,8 @@ Native:
 - Improve selector engine:
 
   - Make it possible to pass a `Key` as `matching` to
-    `MaestroTester.call(dynamic matching)` and `MaestroFinder.$(dynamic matching)`
+    `MaestroTester.call(dynamic matching)` and `MaestroFinder.$(dynamic
+matching)`
 
 - Add `sleep` parameter for `maestroTest` method
 - Make `WidgetTester`'s forwarded methods in `MaestroTester` accept less
@@ -251,7 +258,8 @@ Native:
 - Improve selector engine:
 
   - Make it possible to pass a `MaestroFinder` as `matching` to
-    `MaestroTester.call(dynamic matching)` and `MaestroFinder.$(dynamic matching)`
+    `MaestroTester.call(dynamic matching)` and `MaestroFinder.$(dynamic
+matching)`
   - Fix a bug which caused chaining `MaestroFinder`s (e.g
     `$(Scaffold).$(Container).$(#someText)`) to not work.
 

--- a/packages/patrol/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_tester.dart
@@ -193,7 +193,8 @@ class PatrolTester {
     EnginePhase phase = EnginePhase.sendSemanticsUpdate,
     Duration? timeout,
   }) async {
-    await tester.pumpAndSettle(duration, phase, config.settleTimeout);
+    await tester.pumpAndSettle(
+        duration, phase, timeout ?? config.settleTimeout);
   }
 
   /// Pumps [widget] and then calls [WidgetTester.pumpAndSettle].

--- a/packages/patrol/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_tester.dart
@@ -188,12 +188,12 @@ class PatrolTester {
   }
 
   /// See [WidgetTester.pumpAndSettle].
-  Future<void> pumpAndSettle([
+  Future<void> pumpAndSettle({
     Duration duration = const Duration(milliseconds: 100),
     EnginePhase phase = EnginePhase.sendSemanticsUpdate,
-    Duration timeout = const Duration(minutes: 10),
-  ]) async {
-    await tester.pumpAndSettle(duration, phase, timeout);
+    Duration? timeout,
+  }) async {
+    await tester.pumpAndSettle(duration, phase, config.settleTimeout);
   }
 
   /// Pumps [widget] and then calls [WidgetTester.pumpAndSettle].


### PR DESCRIPTION
**This is a breaking change**.

I've lost (and seen others) way too much time on a stupid mistake:

```dart
await $.pumpAndSettle(Duration(seconds: 5));
```

My intent was always to set the timeout to 5 seconds, but the first argument of [pumpAndSettle](https://api.flutter.dev/flutter/flutter_test/WidgetTester/pumpAndSettle.html) is duration. To achieve what I want, I have to copy all the positional arguments:

```dart
await $.pumpAndSettle(Duration(milliseconds: 100), EnginePhase.sendSemanticsUpdate, Duration(seconds: 5));
```

But well, no more!