### PR TITLE
Added docs about granting initial permissions

### DIFF
--- a/docs/tips-and-tricks.mdx
+++ b/docs/tips-and-tricks.mdx
@@ -152,6 +152,42 @@ if (exceptionCount != 0) {
 }
 ```
 
+## Granting permissions when starting the app
+
+Sometimes your app may need to request system permissions before calling
+`pumpWidgetAndSettle`:
+```dart
+/// the test will stuck at first line, because it will wait for granting
+/// the permissions
+final permission = await Geolocator.requestPermission();
+final position = await Geolocator.getCurrentPosition(
+    desiredAccuracy: LocationAccuracy.medium,
+);
+await $.pumpWidgetAndSettle(MyApp(position: position));
+```
+In such case, call the request method first without awaiting it at first
+and grant the permissions, then await the request:
+```dart
+// 1. request the permission
+final permissionRequestFuture = Geolocator.requestPermission();
+// 2. grant the permission
+await $.native.grantPermissionWhenInUse();
+// 3. wait for permission being granted
+final permissionRequestResult = await permissionRequestFuture;
+expect(permissionRequestResult, equals(LocationPermission.whileInUse));
+final position = await Geolocator.getCurrentPosition(
+    desiredAccuracy: LocationAccuracy.medium,
+);
+await $.pumpWidgetAndSettle(MyApp(position: position));
+```
+The same can be achieved if you request your permissions in app's `main()` method:
+```dart
+app.main();
+await $.pumpAndSettle();
+await $.native.grantPermissionWhenInUse();
+await $.pumpAndSettle(Duration(seconds: 30));
+```
+
 [idb]: https://github.com/facebook/idb
 [settings_screenshot]: https://user-images.githubusercontent.com/10289319/194897313-849b8b84-df7a-4bf3-9b06-bb2782876d03.png
 [take_exception]: https://api.flutter.dev/flutter/flutter_test/WidgetTester/takeException.html

--- a/docs/tips-and-tricks.mdx
+++ b/docs/tips-and-tricks.mdx
@@ -161,7 +161,7 @@ Sometimes your app may need to request system permissions before calling
 /// the permissions
 final permission = await Geolocator.requestPermission();
 final position = await Geolocator.getCurrentPosition(
-    desiredAccuracy: LocationAccuracy.medium,
+  desiredAccuracy: LocationAccuracy.medium,
 );
 await $.pumpWidgetAndSettle(MyApp(position: position));
 ```
@@ -176,7 +176,7 @@ await $.native.grantPermissionWhenInUse();
 final permissionRequestResult = await permissionRequestFuture;
 expect(permissionRequestResult, equals(LocationPermission.whileInUse));
 final position = await Geolocator.getCurrentPosition(
-    desiredAccuracy: LocationAccuracy.medium,
+  desiredAccuracy: LocationAccuracy.medium,
 );
 await $.pumpWidgetAndSettle(MyApp(position: position));
 ```


### PR DESCRIPTION
Relates to #628
Added a description of use case with granting system permissions while starting the app (before `runApp`/`pumpWidgetAndSettle`)