### PR TITLE
Delete PatrolTester.log and PatrolTesterConfig.appName

### DIFF
--- a/packages/patrol/example/integration_test/common.dart
+++ b/packages/patrol/example/integration_test/common.dart
@@ -11,7 +11,6 @@ void patrol(
 ) {
   patrolTest(
     description,
-    config: patrolTesterConfig,
     nativeAutomatorConfig: nativeAutomatorConfig,
     nativeAutomation: true,
     ($) async {
@@ -23,7 +22,7 @@ void patrol(
   );
 }
 
-const patrolTesterConfig = PatrolTesterConfig(appName: 'Example App');
+const patrolTesterConfig = PatrolTesterConfig();
 
 final nativeAutomatorConfig = NativeAutomatorConfig(
   packageName: 'pl.leancode.patrol.example',

--- a/packages/patrol/example/integration_test/features/notifications/notifications_multi_test.dart
+++ b/packages/patrol/example/integration_test/features/notifications/notifications_multi_test.dart
@@ -26,8 +26,8 @@ void main() {
 
       await $.native.openNotifications();
       final notifications = await $.native.getNotifications();
-      $.log('Found ${notifications.length} notifications');
-      notifications.forEach($.log);
+      print('Found ${notifications.length} notifications');
+      notifications.forEach(print);
 
       expect(notifications.length, isNonZero);
       await $.native.tapOnNotificationByIndex(1);

--- a/packages/patrol/example/integration_test/features/notifications/notifications_single_test.dart
+++ b/packages/patrol/example/integration_test/features/notifications/notifications_single_test.dart
@@ -24,8 +24,8 @@ void main() {
 
       await $.native.openNotifications();
       final notifications = await $.native.getNotifications();
-      $.log('Found ${notifications.length} notifications');
-      notifications.forEach($.log);
+      print('Found ${notifications.length} notifications');
+      notifications.forEach(print);
 
       expect(notifications.length, equals(1));
       await $.native.tapOnNotificationByIndex(0);

--- a/packages/patrol/lib/src/common.dart
+++ b/packages/patrol/lib/src/common.dart
@@ -89,12 +89,7 @@ void patrolTest(
       final waitSeconds = const int.fromEnvironment('PATROL_WAIT');
       final waitDuration = Duration(seconds: waitSeconds);
       if (waitDuration > Duration.zero) {
-        patrolTester.log(
-          'sleeping for $waitSeconds seconds',
-          name: 'patrolTest',
-        );
         await Future<void>.delayed(waitDuration);
-        patrolTester.log('done sleeping', name: 'patrolTest');
       }
     },
   );

--- a/packages/patrol/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_tester.dart
@@ -142,22 +142,6 @@ class PatrolTester {
     return hostAutomator!;
   }
 
-  /// Makes it simple to log. No need to use `print` or depend on
-  /// `package:logging`.
-  void log(Object? object, {String? name}) {
-    final log = StringBuffer();
-
-    final tag = name ?? config.appName;
-    if (tag != null) {
-      log.write('$tag: ');
-    }
-
-    log.write(object);
-
-    // ignore: avoid_print
-    print(log);
-  }
-
   /// Returns a [PatrolFinder] that matches [matching].
   ///
   /// See also:

--- a/packages/patrol/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_tester.dart
@@ -10,7 +10,6 @@ class PatrolTesterConfig {
     this.visibleTimeout = const Duration(seconds: 10),
     this.settleTimeout = const Duration(seconds: 10),
     this.andSettle = true,
-    this.appName,
   });
 
   /// Time after which [PatrolFinder.waitUntilExists] fails if it doesn't finds
@@ -33,11 +32,6 @@ class PatrolTesterConfig {
   /// is called.
   final bool andSettle;
 
-  /// Name of the application under test.
-  ///
-  /// Used in [PatrolTester.log].
-  final String? appName;
-
   /// Creates a copy of this config but with the given fields replaced with the
   /// new values.
   PatrolTesterConfig copyWith({
@@ -54,7 +48,6 @@ class PatrolTesterConfig {
       visibleTimeout: visibleTimeout ?? this.visibleTimeout,
       settleTimeout: settleTimeout ?? this.settleTimeout,
       andSettle: andSettle ?? this.andSettle,
-      appName: appName ?? this.appName,
     );
   }
 }

--- a/packages/patrol_cli/lib/src/features/bootstrap/file_contents.dart
+++ b/packages/patrol_cli/lib/src/features/bootstrap/file_contents.dart
@@ -165,10 +165,9 @@ Future<void> main() => integrationDriver();
 const configFileContent = '''
 import 'package:patrol/patrol.dart';
 
+const patrolConfig = PatrolTesterConfig();
+
 // TODO: Replace with values specific to your app.
-
-const patrolConfig = PatrolTesterConfig(appName: 'Example App');
-
 const nativeAutomatorConfig = NativeAutomatorConfig(
   packageName: 'pl.leancode.patrol.example',
   bundleId: 'pl.leancode.patrol.Example',


### PR DESCRIPTION
- delete $.log() - it is rarely used and not needed
- delete appName
- patrol_cli: update `bootstrap` to not use removed `appName`
