### PR TITLE
Add support for using --use-application-binary in drive command.

### DIFF
--- a/packages/patrol_cli/lib/src/features/drive/drive_command.dart
+++ b/packages/patrol_cli/lib/src/features/drive/drive_command.dart
@@ -124,9 +124,10 @@ class DriveCommand extends StagedCommand<DriveCommandConfig> {
         'use-application-binary',
         help:
             'Specify a pre-built application binary to use when running. For Android applications, '
-            'this must be the path to an APK. For iOS applications, the path to an IPA. Other device types '
-            'do not yet support prebuilt application binaries.',
-        valueHelp: 'path/to/app.apk',
+            'this must be the path to an APK. For iOS applications, the path to a .app or an IPA. '
+            'Other device types do not yet support prebuilt application binaries. '
+            'See `flutter drive --help` on for more information.',
+        valueHelp: 'path/to/app.apk|path/to/iphonesimulator/app.app',
       );
   }
 

--- a/packages/patrol_cli/lib/src/features/drive/drive_command.dart
+++ b/packages/patrol_cli/lib/src/features/drive/drive_command.dart
@@ -30,6 +30,7 @@ class DriveCommandConfig with _$DriveCommandConfig {
     required String? packageName,
     required String? bundleId,
     required int repeat,
+    required String? useApplicationBinary,
   }) = _DriveCommandConfig;
 }
 
@@ -118,6 +119,14 @@ class DriveCommand extends StagedCommand<DriveCommandConfig> {
         abbr: 'n',
         help: 'Repeat the test n times.',
         defaultsTo: '$_defaultRepeats',
+      )
+      ..addOption(
+        'use-application-binary',
+        help:
+            'Specify a pre-built application binary to use when running. For Android applications, '
+            'this must be the path to an APK. For iOS applications, the path to an IPA. Other device types '
+            'do not yet support prebuilt application binaries.',
+        valueHelp: 'path/to/app.apk',
       );
   }
 
@@ -188,6 +197,9 @@ class DriveCommand extends StagedCommand<DriveCommandConfig> {
       throw const FormatException('`repeat` argument is not an int');
     }
 
+    final useApplicationBinary =
+        argResults?['use-application-binary'] as String?;
+
     if (repeat < 1) {
       throwToolExit('repeat count must not be smaller than 1');
     }
@@ -215,6 +227,7 @@ class DriveCommand extends StagedCommand<DriveCommandConfig> {
       packageName: packageName,
       bundleId: bundleId,
       repeat: repeat,
+      useApplicationBinary: useApplicationBinary,
     );
   }
 
@@ -230,6 +243,7 @@ class DriveCommand extends StagedCommand<DriveCommandConfig> {
 
     _testRunner
       ..repeats = config.repeat
+      ..useApplicationBinary = config.useApplicationBinary
       ..builder = (target, device) async {
         try {
           await _flutterTool.build(target, device);
@@ -244,7 +258,7 @@ class DriveCommand extends StagedCommand<DriveCommandConfig> {
       }
       ..executor = (target, device) async {
         try {
-          await _flutterTool.drive(target, device);
+          await _flutterTool.drive(target, device, config.useApplicationBinary);
         } catch (err) {
           _logger
             ..err('$err')

--- a/packages/patrol_cli/lib/src/features/drive/drive_command.freezed.dart
+++ b/packages/patrol_cli/lib/src/features/drive/drive_command.freezed.dart
@@ -26,6 +26,7 @@ mixin _$DriveCommandConfig {
   String? get packageName => throw _privateConstructorUsedError;
   String? get bundleId => throw _privateConstructorUsedError;
   int get repeat => throw _privateConstructorUsedError;
+  String? get useApplicationBinary => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $DriveCommandConfigCopyWith<DriveCommandConfig> get copyWith =>
@@ -47,7 +48,8 @@ abstract class $DriveCommandConfigCopyWith<$Res> {
       Map<String, String> dartDefines,
       String? packageName,
       String? bundleId,
-      int repeat});
+      int repeat,
+      String? useApplicationBinary});
 }
 
 /// @nodoc
@@ -71,6 +73,7 @@ class _$DriveCommandConfigCopyWithImpl<$Res>
     Object? packageName = freezed,
     Object? bundleId = freezed,
     Object? repeat = freezed,
+    Object? useApplicationBinary = freezed,
   }) {
     return _then(_value.copyWith(
       devices: devices == freezed
@@ -113,6 +116,10 @@ class _$DriveCommandConfigCopyWithImpl<$Res>
           ? _value.repeat
           : repeat // ignore: cast_nullable_to_non_nullable
               as int,
+      useApplicationBinary: useApplicationBinary == freezed
+          ? _value.useApplicationBinary
+          : useApplicationBinary // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -134,7 +141,8 @@ abstract class _$$_DriveCommandConfigCopyWith<$Res>
       Map<String, String> dartDefines,
       String? packageName,
       String? bundleId,
-      int repeat});
+      int repeat,
+      String? useApplicationBinary});
 }
 
 /// @nodoc
@@ -160,6 +168,7 @@ class __$$_DriveCommandConfigCopyWithImpl<$Res>
     Object? packageName = freezed,
     Object? bundleId = freezed,
     Object? repeat = freezed,
+    Object? useApplicationBinary = freezed,
   }) {
     return _then(_$_DriveCommandConfig(
       devices: devices == freezed
@@ -202,6 +211,10 @@ class __$$_DriveCommandConfigCopyWithImpl<$Res>
           ? _value.repeat
           : repeat // ignore: cast_nullable_to_non_nullable
               as int,
+      useApplicationBinary: useApplicationBinary == freezed
+          ? _value.useApplicationBinary
+          : useApplicationBinary // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -219,7 +232,8 @@ class _$_DriveCommandConfig implements _DriveCommandConfig {
       required final Map<String, String> dartDefines,
       required this.packageName,
       required this.bundleId,
-      required this.repeat})
+      required this.repeat,
+      required this.useApplicationBinary})
       : _devices = devices,
         _targets = targets,
         _dartDefines = dartDefines;
@@ -259,10 +273,12 @@ class _$_DriveCommandConfig implements _DriveCommandConfig {
   final String? bundleId;
   @override
   final int repeat;
+  @override
+  final String? useApplicationBinary;
 
   @override
   String toString() {
-    return 'DriveCommandConfig(devices: $devices, targets: $targets, host: $host, port: $port, driver: $driver, flavor: $flavor, dartDefines: $dartDefines, packageName: $packageName, bundleId: $bundleId, repeat: $repeat)';
+    return 'DriveCommandConfig(devices: $devices, targets: $targets, host: $host, port: $port, driver: $driver, flavor: $flavor, dartDefines: $dartDefines, packageName: $packageName, bundleId: $bundleId, repeat: $repeat, useApplicationBinary: $useApplicationBinary)';
   }
 
   @override
@@ -281,7 +297,9 @@ class _$_DriveCommandConfig implements _DriveCommandConfig {
             const DeepCollectionEquality()
                 .equals(other.packageName, packageName) &&
             const DeepCollectionEquality().equals(other.bundleId, bundleId) &&
-            const DeepCollectionEquality().equals(other.repeat, repeat));
+            const DeepCollectionEquality().equals(other.repeat, repeat) &&
+            const DeepCollectionEquality()
+                .equals(other.useApplicationBinary, useApplicationBinary));
   }
 
   @override
@@ -296,7 +314,8 @@ class _$_DriveCommandConfig implements _DriveCommandConfig {
       const DeepCollectionEquality().hash(_dartDefines),
       const DeepCollectionEquality().hash(packageName),
       const DeepCollectionEquality().hash(bundleId),
-      const DeepCollectionEquality().hash(repeat));
+      const DeepCollectionEquality().hash(repeat),
+      const DeepCollectionEquality().hash(useApplicationBinary));
 
   @JsonKey(ignore: true)
   @override
@@ -316,7 +335,8 @@ abstract class _DriveCommandConfig implements DriveCommandConfig {
       required final Map<String, String> dartDefines,
       required final String? packageName,
       required final String? bundleId,
-      required final int repeat}) = _$_DriveCommandConfig;
+      required final int repeat,
+      required final String? useApplicationBinary}) = _$_DriveCommandConfig;
 
   @override
   List<Device> get devices;
@@ -338,6 +358,8 @@ abstract class _DriveCommandConfig implements DriveCommandConfig {
   String? get bundleId;
   @override
   int get repeat;
+  @override
+  String? get useApplicationBinary;
   @override
   @JsonKey(ignore: true)
   _$$_DriveCommandConfigCopyWith<_$_DriveCommandConfig> get copyWith =>

--- a/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
@@ -161,7 +161,11 @@ class FlutterTool {
   /// Runs [target] on [device] and waits until the test completes.
   ///
   /// Prints stdout and stderr of "flutter drive".
-  Future<void> drive(String target, Device device) async {
+  Future<void> drive(
+    String target,
+    Device device,
+    String? useApplicationBinary,
+  ) async {
     final deviceName = device.resolvedName;
     final targetName = basename(target);
 
@@ -179,6 +183,7 @@ class FlutterTool {
           flavor: _flavor,
           platform: device.targetPlatform,
           simulator: !device.real,
+          useApplicationBinary: useApplicationBinary,
         ),
       ],
       environment: {
@@ -263,8 +268,12 @@ class FlutterTool {
     required String? flavor,
     required TargetPlatform platform,
     required bool simulator,
+    required String? useApplicationBinary,
   }) {
     String getApplicationBinaryPath() {
+      if (useApplicationBinary != null) {
+        return useApplicationBinary;
+      }
       if (platform == TargetPlatform.android) {
         final prefix = join(
           _fs.currentDirectory.path,

--- a/packages/patrol_cli/lib/src/features/drive/test_runner.dart
+++ b/packages/patrol_cli/lib/src/features/drive/test_runner.dart
@@ -83,6 +83,15 @@ class TestRunner extends Disposable {
     _repeats = newValue;
   }
 
+  String? _useApplicationBinary;
+  set useApplicationBinary(String? newValue) {
+    if (_running) {
+      throw StateError('repeats cannot be changed while running');
+    }
+
+    _useApplicationBinary = newValue;
+  }
+
   _Callback? _builder;
 
   /// Sets the builder callback that is called once for every test target.
@@ -175,11 +184,13 @@ class TestRunner extends Disposable {
             continue;
           }
 
-          try {
-            await builder(target, device);
-          } catch (_) {
-            targetRuns.add(TargetRunStatus.failedToBuild);
-            continue;
+          if (_useApplicationBinary == null) {
+            try {
+              await builder(target, device);
+            } catch (_) {
+              targetRuns.add(TargetRunStatus.failedToBuild);
+              continue;
+            }
           }
 
           for (var i = 0; i < _repeats; i++) {

--- a/packages/patrol_cli/lib/src/features/drive/test_runner.dart
+++ b/packages/patrol_cli/lib/src/features/drive/test_runner.dart
@@ -86,7 +86,7 @@ class TestRunner extends Disposable {
   String? _useApplicationBinary;
   set useApplicationBinary(String? newValue) {
     if (_running) {
-      throw StateError('repeats cannot be changed while running');
+      throw StateError('application binary cannot be changed while running');
     }
 
     _useApplicationBinary = newValue;

--- a/packages/patrol_cli/test/features/drive/drive_command_test.dart
+++ b/packages/patrol_cli/test/features/drive/drive_command_test.dart
@@ -24,6 +24,7 @@ const _defaultConfig = DriveCommandConfig(
   packageName: null,
   bundleId: null,
   repeat: 1,
+  useApplicationBinary: null,
 );
 
 void main() {
@@ -123,7 +124,8 @@ void main() {
 
       final config = await driveCommand.parseInput();
 
-      when(() => flutterTool.drive(any(), any())).thenAnswer((_) async {});
+      when(() => flutterTool.drive(any(), any(), null))
+          .thenAnswer((_) async {});
 
       final exitCode = await driveCommand.execute(config);
       expect(exitCode, isZero);
@@ -135,7 +137,7 @@ void main() {
 
       final config = await driveCommand.parseInput();
 
-      when(() => flutterTool.drive(any(), any())).thenThrow(
+      when(() => flutterTool.drive(any(), any(), null)).thenThrow(
         FlutterDriverFailedException(1),
       );
 

--- a/packages/patrol_cli/test/features/drive/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/features/drive/flutter_tool_test.dart
@@ -140,6 +140,7 @@ void main() {
         await flutterTool.drive(
           'integration_test/app_test.dart',
           androidDevice,
+          null,
         );
 
         verify(() => logger.task('Running app_test.dart on emulator-5554'))
@@ -154,6 +155,7 @@ void main() {
           () async => flutterTool.drive(
             'integration_test/app_test.dart',
             androidDevice,
+            null,
           ),
           throwsA(
             isA<FlutterDriverFailedException>()


### PR DESCRIPTION
### Add support for using --use-application-binary in drive command.

As `flutter drive` already supports this, so this commit added a new command line argument `--use-application-binary` in `patrol drive` and pass that to `flutter drive` command.

Directly relates to #65 .