### PR TITLE
Display test name over the running app

### DIFF
--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -4,6 +4,7 @@ import 'dart:io' as io;
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/common.dart';
@@ -204,4 +205,30 @@ Thrown by PatrolBinding.
   /// [PatrolBinding.ensureInitialized].
   static PatrolBinding get instance => BindingBase.checkInstance(_instance);
   static PatrolBinding? _instance;
+
+  @override
+  void attachRootWidget(Widget rootWidget) {
+    const testLabel = String.fromEnvironment('PATROL_TEST_LABEL');
+
+    super.attachRootWidget(
+      Stack(
+        textDirection: TextDirection.ltr,
+        children: [
+          RepaintBoundary(child: rootWidget),
+          if (testLabel.isNotEmpty)
+            Padding(
+              padding: EdgeInsets.only(
+                top: MediaQueryData.fromWindow(window).padding.top + 4,
+                left: 4,
+              ),
+              child: const Text(
+                testLabel,
+                textDirection: TextDirection.ltr,
+                style: TextStyle(color: Colors.red),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
 }

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -207,23 +207,26 @@ Thrown by PatrolBinding.
   void attachRootWidget(Widget rootWidget) {
     const testLabel = String.fromEnvironment('PATROL_TEST_LABEL');
 
+    if (testLabel.isEmpty) {
+      super.attachRootWidget(RepaintBoundary(child: rootWidget));
+    }
+
     super.attachRootWidget(
       Stack(
         textDirection: TextDirection.ltr,
         children: [
           RepaintBoundary(child: rootWidget),
-          if (testLabel.isNotEmpty)
-            Padding(
-              padding: EdgeInsets.only(
-                top: MediaQueryData.fromWindow(window).padding.top + 4,
-                left: 4,
-              ),
-              child: const Text(
-                testLabel,
-                textDirection: TextDirection.ltr,
-                style: TextStyle(color: Colors.red),
-              ),
+          Padding(
+            padding: EdgeInsets.only(
+              top: MediaQueryData.fromWindow(window).padding.top + 4,
+              left: 4,
             ),
+            child: const Text(
+              testLabel,
+              textDirection: TextDirection.ltr,
+              style: TextStyle(color: Colors.red),
+            ),
+          ),
         ],
       ),
     );

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -64,10 +64,7 @@ class PatrolBinding extends IntegrationTestWidgetsFlutterBinding {
     };
 
     if (!_shouldReportResultsToNative) {
-      debugPrint('Tests results will not be reported natively');
       return;
-    } else {
-      debugPrint('Tests results will be reported natively');
     }
 
     tearDownAll(() async {

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -41,10 +41,11 @@ const bool _shouldReportResultsToNative = bool.fromEnvironment(
   defaultValue: true,
 );
 
-/// The method channel used to report the results of the tests to the
-/// underlying platform's testing framework.
+/// The method channel used to report the results of the tests to the underlying
+/// platform's testing framework.
 ///
-/// On Android, this is relevant when running instrumented tests with UIAutomator.
+/// On Android, this is relevant when running instrumented tests with
+/// UIAutomator.
 ///
 /// On iOS, this is relevant when running UI tests with XCUITest.
 const patrolChannel = MethodChannel('pl.leancode.patrol/main');

--- a/packages/patrol_cli/lib/src/features/drive/drive_command.dart
+++ b/packages/patrol_cli/lib/src/features/drive/drive_command.dart
@@ -31,6 +31,7 @@ class DriveCommandConfig with _$DriveCommandConfig {
     required String? bundleId,
     required int repeat,
     required String? useApplicationBinary,
+    required bool displayLabel,
   }) = _DriveCommandConfig;
 }
 
@@ -128,6 +129,11 @@ class DriveCommand extends StagedCommand<DriveCommandConfig> {
             'Other device types do not yet support prebuilt application binaries. '
             'See `flutter drive --help` on for more information.',
         valueHelp: 'path/to/app.apk|path/to/iphonesimulator/app.app',
+      )
+      ..addFlag(
+        'label',
+        help: 'Display the label over the application under test.',
+        defaultsTo: true,
       );
   }
 
@@ -201,6 +207,8 @@ class DriveCommand extends StagedCommand<DriveCommandConfig> {
     final useApplicationBinary =
         argResults?['use-application-binary'] as String?;
 
+    final displayLabel = argResults?['label'] as bool?;
+
     if (repeat < 1) {
       throwToolExit('repeat count must not be smaller than 1');
     }
@@ -229,6 +237,7 @@ class DriveCommand extends StagedCommand<DriveCommandConfig> {
       bundleId: bundleId,
       repeat: repeat,
       useApplicationBinary: useApplicationBinary,
+      displayLabel: displayLabel ?? true,
     );
   }
 
@@ -240,6 +249,7 @@ class DriveCommand extends StagedCommand<DriveCommandConfig> {
       port: config.port,
       flavor: config.flavor,
       dartDefines: config.dartDefines,
+      displayLabel: config.displayLabel,
     );
 
     _testRunner

--- a/packages/patrol_cli/lib/src/features/drive/drive_command.freezed.dart
+++ b/packages/patrol_cli/lib/src/features/drive/drive_command.freezed.dart
@@ -27,6 +27,7 @@ mixin _$DriveCommandConfig {
   String? get bundleId => throw _privateConstructorUsedError;
   int get repeat => throw _privateConstructorUsedError;
   String? get useApplicationBinary => throw _privateConstructorUsedError;
+  bool get displayLabel => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $DriveCommandConfigCopyWith<DriveCommandConfig> get copyWith =>
@@ -49,7 +50,8 @@ abstract class $DriveCommandConfigCopyWith<$Res> {
       String? packageName,
       String? bundleId,
       int repeat,
-      String? useApplicationBinary});
+      String? useApplicationBinary,
+      bool displayLabel});
 }
 
 /// @nodoc
@@ -74,6 +76,7 @@ class _$DriveCommandConfigCopyWithImpl<$Res>
     Object? bundleId = freezed,
     Object? repeat = freezed,
     Object? useApplicationBinary = freezed,
+    Object? displayLabel = freezed,
   }) {
     return _then(_value.copyWith(
       devices: devices == freezed
@@ -120,6 +123,10 @@ class _$DriveCommandConfigCopyWithImpl<$Res>
           ? _value.useApplicationBinary
           : useApplicationBinary // ignore: cast_nullable_to_non_nullable
               as String?,
+      displayLabel: displayLabel == freezed
+          ? _value.displayLabel
+          : displayLabel // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -142,7 +149,8 @@ abstract class _$$_DriveCommandConfigCopyWith<$Res>
       String? packageName,
       String? bundleId,
       int repeat,
-      String? useApplicationBinary});
+      String? useApplicationBinary,
+      bool displayLabel});
 }
 
 /// @nodoc
@@ -169,6 +177,7 @@ class __$$_DriveCommandConfigCopyWithImpl<$Res>
     Object? bundleId = freezed,
     Object? repeat = freezed,
     Object? useApplicationBinary = freezed,
+    Object? displayLabel = freezed,
   }) {
     return _then(_$_DriveCommandConfig(
       devices: devices == freezed
@@ -215,6 +224,10 @@ class __$$_DriveCommandConfigCopyWithImpl<$Res>
           ? _value.useApplicationBinary
           : useApplicationBinary // ignore: cast_nullable_to_non_nullable
               as String?,
+      displayLabel: displayLabel == freezed
+          ? _value.displayLabel
+          : displayLabel // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -233,7 +246,8 @@ class _$_DriveCommandConfig implements _DriveCommandConfig {
       required this.packageName,
       required this.bundleId,
       required this.repeat,
-      required this.useApplicationBinary})
+      required this.useApplicationBinary,
+      required this.displayLabel})
       : _devices = devices,
         _targets = targets,
         _dartDefines = dartDefines;
@@ -275,10 +289,12 @@ class _$_DriveCommandConfig implements _DriveCommandConfig {
   final int repeat;
   @override
   final String? useApplicationBinary;
+  @override
+  final bool displayLabel;
 
   @override
   String toString() {
-    return 'DriveCommandConfig(devices: $devices, targets: $targets, host: $host, port: $port, driver: $driver, flavor: $flavor, dartDefines: $dartDefines, packageName: $packageName, bundleId: $bundleId, repeat: $repeat, useApplicationBinary: $useApplicationBinary)';
+    return 'DriveCommandConfig(devices: $devices, targets: $targets, host: $host, port: $port, driver: $driver, flavor: $flavor, dartDefines: $dartDefines, packageName: $packageName, bundleId: $bundleId, repeat: $repeat, useApplicationBinary: $useApplicationBinary, displayLabel: $displayLabel)';
   }
 
   @override
@@ -299,7 +315,9 @@ class _$_DriveCommandConfig implements _DriveCommandConfig {
             const DeepCollectionEquality().equals(other.bundleId, bundleId) &&
             const DeepCollectionEquality().equals(other.repeat, repeat) &&
             const DeepCollectionEquality()
-                .equals(other.useApplicationBinary, useApplicationBinary));
+                .equals(other.useApplicationBinary, useApplicationBinary) &&
+            const DeepCollectionEquality()
+                .equals(other.displayLabel, displayLabel));
   }
 
   @override
@@ -315,7 +333,8 @@ class _$_DriveCommandConfig implements _DriveCommandConfig {
       const DeepCollectionEquality().hash(packageName),
       const DeepCollectionEquality().hash(bundleId),
       const DeepCollectionEquality().hash(repeat),
-      const DeepCollectionEquality().hash(useApplicationBinary));
+      const DeepCollectionEquality().hash(useApplicationBinary),
+      const DeepCollectionEquality().hash(displayLabel));
 
   @JsonKey(ignore: true)
   @override
@@ -336,7 +355,8 @@ abstract class _DriveCommandConfig implements DriveCommandConfig {
       required final String? packageName,
       required final String? bundleId,
       required final int repeat,
-      required final String? useApplicationBinary}) = _$_DriveCommandConfig;
+      required final String? useApplicationBinary,
+      required final bool displayLabel}) = _$_DriveCommandConfig;
 
   @override
   List<Device> get devices;
@@ -360,6 +380,8 @@ abstract class _DriveCommandConfig implements DriveCommandConfig {
   int get repeat;
   @override
   String? get useApplicationBinary;
+  @override
+  bool get displayLabel;
   @override
   @JsonKey(ignore: true)
   _$$_DriveCommandConfigCopyWith<_$_DriveCommandConfig> get copyWith =>

--- a/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
@@ -71,6 +71,7 @@ class FlutterTool {
   String? _flavor;
   late Map<String, String> _dartDefines;
   late Map<String, String> _env;
+  late bool _displayLabel;
 
   final ProcessManager _processManager;
   final FileSystem _fs;
@@ -83,10 +84,12 @@ class FlutterTool {
     required String? port,
     required String? flavor,
     required Map<String, String> dartDefines,
+    required bool displayLabel,
   }) {
     _driver = driver;
     _flavor = flavor;
     _dartDefines = dartDefines;
+    _displayLabel = displayLabel;
 
     _env = {
       envHostKey: host,
@@ -121,7 +124,7 @@ class FlutterTool {
           '--dart-define',
           'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE=false',
         ],
-        ...[
+        if (_displayLabel) ...[
           '--dart-define',
           'PATROL_TEST_LABEL=$targetName',
         ],

--- a/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/features/drive/flutter_tool.dart
@@ -119,7 +119,11 @@ class FlutterTool {
         ],
         ...[
           '--dart-define',
-          'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE=false'
+          'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE=false',
+        ],
+        ...[
+          '--dart-define',
+          'PATROL_TEST_LABEL=$targetName',
         ],
       ],
       runInShell: true,

--- a/packages/patrol_cli/test/features/drive/drive_command_test.dart
+++ b/packages/patrol_cli/test/features/drive/drive_command_test.dart
@@ -25,6 +25,7 @@ const _defaultConfig = DriveCommandConfig(
   bundleId: null,
   repeat: 1,
   useApplicationBinary: null,
+  displayLabel: true,
 );
 
 void main() {

--- a/packages/patrol_cli/test/features/drive/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/features/drive/flutter_tool_test.dart
@@ -54,6 +54,7 @@ void main() {
           port: '8081',
           flavor: null,
           dartDefines: const {},
+          displayLabel: true,
         );
     });
 
@@ -69,6 +70,11 @@ void main() {
               ...['--target', 'integration_test/app_test.dart'],
               ...['--dart-define', 'PATROL_HOST=localhost'],
               ...['--dart-define', 'PATROL_PORT=8081'],
+              ...[
+                '--dart-define',
+                'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE=false',
+              ],
+              ...['--dart-define', 'PATROL_TEST_LABEL=app_test.dart'],
             ],
             runInShell: any(named: 'runInShell', that: equals(true)),
           ),


### PR DESCRIPTION
- reformat markdown code
- PatrolBinding: print PATROL_TEST_LABEL in attachRootWidget()
- CLI: embed current test name in apk
- remove redundant logs
- add support for --no-display-label flag
