### PR TITLE
Add android.permission.QUERY_ALL_PACKAGES to example app's manifest

### DIFF
--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAutomator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAutomator.kt
@@ -86,7 +86,7 @@ class PatrolAutomator private constructor() {
 
     fun openApp(packageName: String) {
         val intent = targetContext.packageManager!!.getLaunchIntentForPackage(packageName)
-            ?: throw Exception("intent for launching $packageName is null")
+            ?: throw Exception("intent for launching $packageName is null. Make sure you have android.permission.QUERY_ALL_PACKAGES in AndroidManifest.xml")
         // intent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK) // clear out any previous task, i.e., make sure it starts on the initial screen
         targetContext.startActivity(intent) // starts the app
         delay()

--- a/packages/patrol/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/patrol/example/android/app/src/main/AndroidManifest.xml
@@ -1,15 +1,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="pl.leancode.patrol.example">
+          xmlns:tools="http://schemas.android.com/tools" package="pl.leancode.patrol.example">
 
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.READ_CONTACTS" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.READ_CONTACTS"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:ignore="QueryAllPackagesPermission"/>
 
-   <application
+    <application
         android:label="example"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
@@ -26,9 +27,9 @@
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme"
+            />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
@@ -38,6 +39,6 @@
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data
             android:name="flutterEmbedding"
-            android:value="2" />
+            android:value="2"/>
     </application>
 </manifest>


### PR DESCRIPTION
Should fix failing tests. It's also quite easy to remove for release flavor.

slack-skip