### PR TITLE
Bump minimum Flutter version to 3.3.0

### DIFF
--- a/.github/workflows/patrol-prepare.yaml
+++ b/.github/workflows/patrol-prepare.yaml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - version: 3.3.0
           - channel: stable
-          #- version: 3.0.0
-          #- channel: beta
+          - channel: beta
 
     defaults:
       run:

--- a/.github/workflows/patrol_cli-prepare.yaml
+++ b/.github/workflows/patrol_cli-prepare.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - version: 3.0.0
+          - version: 3.3.0
           - channel: stable
           - channel: beta
 

--- a/packages/patrol/example/pubspec.yaml
+++ b/packages/patrol/example/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0 <4.0.0"
+  sdk: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.0 <4.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.5

--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -8,8 +8,8 @@ repository: https://github.com/leancodepl/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0 <4.0.0"
+  sdk: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.0 <4.0.0"
 
 dependencies:
   fixnum: ^1.0.1


### PR DESCRIPTION
It's not possible to use 3.0.x anyway, because of `vm_service` and `integration_test` conflicts. It's been like this for many months and nobody complained.