### PR TITLE
More documentation updates

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -35,6 +35,7 @@
         ["devices", "/cli-commands/devices"],
         ["doctor", "/cli-commands/doctor"],
         ["drive", "/cli-commands/drive"],
+        ["test", "/cli-commands/test"],
         ["update", "/cli-commands/update"]
       ]
     ],

--- a/docs.json
+++ b/docs.json
@@ -9,7 +9,6 @@
   "sidebar": [
     ["About", "/"],
     ["Getting started", "/getting-started"],
-    ["Comparison with other testing frameworks", "/comparison"],
     [
       "Custom finders",
       [
@@ -19,7 +18,7 @@
       ]
     ],
     [
-      "Native",
+      "Native automation",
       [
         ["Overview", "/native/overview"],
         ["Setup", "/native/setup"],
@@ -41,6 +40,7 @@
     ],
     ["Patrol and CI", "/ci"],
     ["Effective Patrol", "/effective-patrol"],
-    ["Tips and tricks", "/tips-and-tricks"]
+    ["Tips and tricks", "/tips-and-tricks"],
+    ["Competition", "/comparison"]
   ]
 }

--- a/docs.json
+++ b/docs.json
@@ -30,13 +30,13 @@
     [
       "CLI commands",
       [
-        ["bootstrap", "/cli-commands/bootstrap"],
-        ["clean", "/cli-commands/clean"],
+        ["test", "/cli-commands/test"],
         ["devices", "/cli-commands/devices"],
         ["doctor", "/cli-commands/doctor"],
-        ["drive", "/cli-commands/drive"],
-        ["test", "/cli-commands/test"],
-        ["update", "/cli-commands/update"]
+        ["update", "/cli-commands/update"],
+        ["clean [DEPRECATED]", "/cli-commands/clean"],
+        ["drive [DEPRECATED]", "/cli-commands/drive"],
+        ["bootstrap [DEPRECATED]", "/cli-commands/bootstrap"]
       ]
     ],
     ["Patrol and CI", "/ci"],

--- a/docs/ci.mdx
+++ b/docs/ci.mdx
@@ -26,13 +26,13 @@ Farm][aws_device_farm] or [BrowserStack][browserstack].
 
     - the normal apk (often called the "app under test"). To build it, run:
 
-      ```bash
+      ```
       ./gradlew :app:assembleDebug -Ptarget="$(pwd)/../integration_test/example_test.dart"
       ```
 
     - the intrumentation apk. To build it, run:
 
-      ```bash
+      ```
       ./gradlew :app:assembleDebugAndroidTest
       ```
 
@@ -42,7 +42,7 @@ Farm][aws_device_farm] or [BrowserStack][browserstack].
     Once you have built the apks, use the [gcloud] tool to run them on Firebase
     Test Lab:
 
-    ```bash
+    ```
     gcloud firebase test android run --type instrumentation \
         --app build/app/outputs/apk/debug/app-debug.apk \
         --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk\
@@ -61,14 +61,14 @@ Farm][aws_device_farm] or [BrowserStack][browserstack].
 
     First, build your Flutter app, choosing the integration test file as target:
 
-    ```bash
+    ```
     flutter build ios --target integration_test/example_test.dart --debug # or --release
     ```
 
     Then, build the UI testing target by running `xcodebuild` in the `ios`
     directory:
 
-    ```bash
+    ```
     xcodebuild build-for-testing \
       -workspace Runner.xcworkspace \
       -scheme Runner \
@@ -82,7 +82,7 @@ Farm][aws_device_farm] or [BrowserStack][browserstack].
     If you want to test a debug version of your app, replace `xcconfig` and
     `configuration`:
 
-    ```bash
+    ```
     xcodebuild build-for-testing \
       -workspace Runner.xcworkspace \
       -scheme Runner \
@@ -96,25 +96,24 @@ Farm][aws_device_farm] or [BrowserStack][browserstack].
     Now, go to your project's root directory, and from there go to the build
     outputs:
 
-    ```bash
+    ```
     cd build/ios_integ/Build/Products
     ```
 
     Create a zip archive named `ios_test.zip`. It will contain both your app
     under test (`Runner` target) and UI test runner (`RunnerUITests` target).
 
-    ```bash
+    ```
     zip -r "ios_tests.zip" "Release-iphoneos" "Runner_iphoneos15.7-arm64.xctestrun"
     ```
 
     And finally, upload the `ios_test.zip` to Firebase Test Lab for execution:
 
 
-    ```bash
+    ```
     exec gcloud firebase test ios run \
       --test "build/ios_integ/Build/Products/ios_tests.zip" \
       --device model=iphone8,version=15.7,locale=en_US,orientation=portrait
-
     ```
 
     If your `.xctestrun` file has different iOS version in its name than the

--- a/docs/ci.mdx
+++ b/docs/ci.mdx
@@ -129,7 +129,7 @@ Farm][aws_device_farm] or [BrowserStack][browserstack].
   </TabItem>
 </Tabs>
 
-[native_setup]: /native/setup
+[native setup]: /native/setup
 [gcloud]: https://cloud.google.com/sdk/gcloud
 [example_android_script]: https://github.com/leancodepl/patrol/blob/master/packages/patrol/example/run_android_testlab
 [example_iod_script]: https://github.com/leancodepl/patrol/blob/master/packages/patrol/example/run_ios_testlab

--- a/docs/cli-commands/bootstrap.mdx
+++ b/docs/cli-commands/bootstrap.mdx
@@ -4,8 +4,8 @@
 
 Bootstraps the Flutter project to use Patrol.
 
-```bash
-$ patrol bootstrap
+```
+patrol bootstrap
 ```
 
 To learn more about this command, run `patrol bootstrap --help`.

--- a/docs/cli-commands/bootstrap.mdx
+++ b/docs/cli-commands/bootstrap.mdx
@@ -1,5 +1,10 @@
 # bootstrap
 
+<Warning>
+  This command is deprecated and is scheduled for removal in Patrol 1.0.
+  Instead, set up the project manually for [patrol test].
+</Warning>
+
 ### Synopsis
 
 Bootstraps the Flutter project to use Patrol.
@@ -24,3 +29,5 @@ Bootstrap does the following:
 
 After `patrol bootstrap`, you should be able to `patrol drive` and an example
 app should show up on your device.
+
+[patrol test]: /cli-commands/test

--- a/docs/cli-commands/clean.mdx
+++ b/docs/cli-commands/clean.mdx
@@ -4,8 +4,8 @@
 
 Removes the directory where artifacts are stored.
 
-```bash
-$ patrol clean
+```
+patrol clean
 ```
 
 To learn more about this command, run `patrol clean --help`.

--- a/docs/cli-commands/clean.mdx
+++ b/docs/cli-commands/clean.mdx
@@ -1,5 +1,10 @@
 # clean
 
+<Warning>
+  This command is deprecated and is scheduled for removal in Patrol 1.0. It's
+  not needed anymore when using [patrol test].
+</Warning>
+
 ### Synopsis
 
 Removes the directory where artifacts are stored.
@@ -13,3 +18,5 @@ To learn more about this command, run `patrol clean --help`.
 ### Description
 
 To see where the artifacts are stored, run `patrol doctor`.
+
+[patrol test]: /cli-commands/test

--- a/docs/cli-commands/devices.mdx
+++ b/docs/cli-commands/devices.mdx
@@ -4,8 +4,8 @@
 
 Prints attached devices.
 
-```bash
-$ patrol devices
+```
+patrol devices
 ```
 
 To learn more about this command, run `patrol devices --help`.

--- a/docs/cli-commands/doctor.mdx
+++ b/docs/cli-commands/doctor.mdx
@@ -4,8 +4,8 @@
 
 Prints the path where the artifacts are stored.
 
-```bash
-$ patrol doctor
+```
+patrol doctor
 ```
 
 To learn more about this command, run `patrol doctor --help`.

--- a/docs/cli-commands/drive.mdx
+++ b/docs/cli-commands/drive.mdx
@@ -1,5 +1,10 @@
 # drive
 
+<Warning>
+  This command is deprecated and is scheduled for removal in Patrol 1.0. Use
+  [patrol test] instead.
+</Warning>
+
 ### Synopsis
 
 Runs tests on devices.
@@ -40,3 +45,5 @@ Test files must end with `_test.dart`. Otherwise the file is not considered a
 test and is not run.
 
 There's no difference between `--target` and `--targets`.
+
+[patrol test]: /cli-commands/test

--- a/docs/cli-commands/drive.mdx
+++ b/docs/cli-commands/drive.mdx
@@ -4,8 +4,8 @@
 
 Runs tests on devices.
 
-```bash
-$ patrol drive
+```
+patrol drive
 ```
 
 To learn more about this command, run `patrol drive --help`.
@@ -24,16 +24,16 @@ By default, `patrol drive` runs all integration tests (files ending with
 
 To run a single test, use `--target`:
 
-```bash
-$ patrol drive --target integration_test/login_test.dart
+```
+patrol drive --target integration_test/login_test.dart
 ```
 
 You can use `--target` more than once to run multiple tests:
 
-```bash
-$ patrol drive \
-    --target integration_test/login_test.dart \
-    --target integration_test/change_profile_picture_test.dart
+```
+patrol drive \
+  --target integration_test/login_test.dart \
+  --target integration_test/change_profile_picture_test.dart
 ```
 
 Test files must end with `_test.dart`. Otherwise the file is not considered a

--- a/docs/cli-commands/test.mdx
+++ b/docs/cli-commands/test.mdx
@@ -1,11 +1,11 @@
-# drive
+# test
 
 ### Synopsis
 
-Runs tests on devices.
+Runs Flutter integration tests as native tests on devices.
 
 ```
-patrol drive
+patrol test
 ```
 
 To learn more about this command, run `patrol drive --help`.
@@ -14,12 +14,17 @@ To learn more about this command, run `patrol drive --help`.
 
 This command is the one use you'll be using most often.
 
-It does all the low-level things required to enable interacting with native OS,
-such as tapping on permission dialogs, notifications, and controlling Wi-Fi.
+It:
+
+1. Builds the app under test (AUT) and the instrumentation app
+2. Installs the AUT and the instrumentation on the selected device
+3. Runs the tests natively, and reports results back in native format.
+
+Under the hood, it calls Gradle on Android and `xcodebuild` on iOS
 
 ### Discussion
 
-By default, `patrol drive` runs all integration tests (files ending with
+By default, `patrol test` runs all integration tests (files ending with
 `_test.dart` located in the `integration_test` directory).
 
 To run a single test, use `--target`:

--- a/docs/cli-commands/update.mdx
+++ b/docs/cli-commands/update.mdx
@@ -4,6 +4,6 @@
 
 Updates the Patrol CLI. If no new version is available, it does nothing.
 
-```bash
-$ patrol update
+```
+patrol update
 ```

--- a/docs/custom-finders/overview.mdx
+++ b/docs/custom-finders/overview.mdx
@@ -56,13 +56,17 @@ patrolTest('signs up', (PatrolTester $) async {
 
 ### Set up
 
-Starting using custom finders is easy, because they depend only on Flutter. All
-you have to do is to add package `patrol` to `dev_dependencies` in your
+All you have to do is to add package `patrol` to `dev_dependencies` in your
 project's `pubspec.yaml`.
 
 ```
 flutter pub add patrol --dev
 ```
+
+<Success>
+  Our custom finders depend only on Flutter itself. This means you can use them
+  no matter if you're writing a mobile, web, desktop, or embedded app!
+</Success>
 
 ### Writing
 

--- a/docs/custom-finders/overview.mdx
+++ b/docs/custom-finders/overview.mdx
@@ -60,8 +60,8 @@ Starting using custom finders is easy, because they depend only on Flutter. All
 you have to do is to add package `patrol` to `dev_dependencies` in your
 project's `pubspec.yaml`.
 
-```bash
-$ flutter pub add patrol --dev
+```
+flutter pub add patrol --dev
 ```
 
 ### Writing
@@ -89,10 +89,10 @@ patrolTest('sign in', (PatrolTester $) async {
 ### Usage
 
 You run widget tests using Patrol's custom finders the same way as you run
-normal widget tests.
+normal widget tests:
 
-```bash
-$ flutter test
+```
+flutter test
 ```
 
 [widgettester]: https://api.flutter.dev/flutter/flutter_test/WidgetTester-class.html

--- a/docs/effective-patrol.mdx
+++ b/docs/effective-patrol.mdx
@@ -4,7 +4,7 @@ Over the past months, we've written many Patrol tests and often learned the hard
 way what works well and what doesn't. We're sharing our findings hoping that
 they'll help you write robust tests.
 
-> This document follows [RFC 2119][rfc2119].
+<Info>This document follows [RFC 2119][rfc2119].</Info>
 
 ### PREFER using keys to find widgets
 
@@ -82,7 +82,7 @@ The number of keys will get bigger as your app grows and you write more tests.
 To keep track of them, it's a good idea to keep all keys in, say,
 `lib/keys.dart` file.
 
-```dart
+```dart title="lib/keys.dart"
 import 'package:flutter/foundation.dart';
 
 typedef K = Keys;
@@ -100,17 +100,30 @@ class Keys {
 
 Then you can use it in your app's and tests' code:
 
-```dart
-// somehwere in app
-TextField(
-  key: K.usernameTextField,
-  // more properties
-)
+```dart title="In app UI code"
+@override
+Widget build(BuildContext context) {
+  return Column(
+    children: [
+      /// some widgets
+      TextField(
+        key: K.usernameTextField,
+        // some other TextField properties
+      ),
+      // more widgets
+    ],
+  );
+}
 ```
 
-```dart
-// in test
-await $(K.usernameTextField).enterText('CoolGuy');
+```dart title="In app test code"
+void main() {
+  patrolTest('logs in', (PatrolTester $) {
+    // some code
+    await $(K.usernameTextField).enterText('CoolGuy');
+    // more code
+  });
+}
 ```
 
 This is a good way to make sure that the same keys are used in app and tests. No
@@ -147,10 +160,10 @@ void main() {
     ($) async {
       await $.pumpWidgetAndSettle(AwesomeApp());
 
-      await $(#phoneNumber).enterText("800-555-0199");
+      await $(#phoneNumber).enterText('800-555-0199');
       await $(#loginButton).tap();
 
-      // lots of lines
+      // more code
     },
   );
 }
@@ -165,10 +178,10 @@ void main() {
     ($) async {
       await $.pumpWidgetAndSettle(AwesomeApp());
 
-      await $(#phoneNumber).enterText("800-555-0199");
+      await $(#phoneNumber).enterText('800-555-0199');
       await $(#loginButton).tap();
 
-      // lots of lines
+      // more code
     },
   );
 }

--- a/docs/native/advanced.mdx
+++ b/docs/native/advanced.mdx
@@ -9,9 +9,7 @@ This is useful if, for any reason, you have to use Flutter's default
 [testWidgets()][test_widgets] function rather than Patrol's
 [patrolTest()][patrol_test].
 
-```dart
-// integration_test/app_test.dart
-
+```dart title="integration_test/app_test.dart"
 Future<void> main() async {
   final automator = NativeAutomator(
     packageName: 'your.app.id.on.android',

--- a/docs/native/advanced.mdx
+++ b/docs/native/advanced.mdx
@@ -42,7 +42,7 @@ does under the hood anyway.
 
 Execute the below Gradle command in your app's `android` directory:
 
-```bash
+```
 ./gradlew :app:connectedDebugAndroidTest -Ptarget=$(pwd)/../integration_test/example_test.dart
 ```
 
@@ -52,7 +52,7 @@ Execute these 2 commands in your app's `ios` directory:
 
 First,
 
-```bash
+```
 flutter build ios --target integration_test/example_test.dart --config-only --debug
 ```
 
@@ -72,7 +72,7 @@ Of course, replace the device name with the name of your device.
 
 Execute these 2 commands in your app's `ios` directory:
 
-```bash
+```
 flutter build ios --target integration_test/example_test.dart --config-only --debug --simulator
 ```
 

--- a/docs/native/overview.mdx
+++ b/docs/native/overview.mdx
@@ -1,4 +1,4 @@
-# Overview
+# Native automation overview
 
 Flutter's [integration_test][integration_test] does a good job at providing
 basic support for integration testing Flutter apps. What it can't do is
@@ -11,7 +11,9 @@ to test many critical business features:
   mode
 - granting runtime permissions
 
-Patrol's native capabilities solve these problems.
+Patrol's native automation feature solve these problems.
+
+<Info>Native automation is currently available only on Android and iOS.</Info>
 
 <Tweet id="1592464714227142658" />
 

--- a/docs/native/setup.mdx
+++ b/docs/native/setup.mdx
@@ -11,7 +11,7 @@ We believe that the poweful features you'll get will make up for it!
 If you haven't already, add a dependency on the `patrol` package in the
 `dev_dependencies` section of `pubspec.yaml`.
 
-```bash
+```
 flutter pub add patrol --dev
 ```
 
@@ -25,19 +25,19 @@ platform-specific tool.
 
 1. Install `patrol` executable:
 
-   ```bash
+   ```
    dart pub global activate patrol_cli
    ```
 
 2. Verify that installation was successful:
 
-   ```bash
+   ```
    patrol --version
    ```
 
 Also make sure to update Patrol CLI from time to time:
 
-```bash
+```
 patrol update
 ```
 
@@ -135,7 +135,7 @@ Psst... Android is a bit easier to set up, so we recommend starting with it!
       To run `integration_test/example_test.dart` on a local Android device
       (emulated or physical):
 
-      ```bash
+      ```
       patrol test --target integration_test/example_test.dart
       ```
 
@@ -175,7 +175,7 @@ Psst... Android is a bit easier to set up, so we recommend starting with it!
 
       To build `integration_test/example_test.dart` from the command line, run:
 
-      ```bash
+      ```
       $ flutter build ios --config-only integration_test/example_test.dart
       ```
 
@@ -202,19 +202,19 @@ Psst... Android is a bit easier to set up, so we recommend starting with it!
 
       Paste this code into the first `xcode_backend build` Build Phase:
 
-      ```bash
+      ```
       /bin/sh "$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh" build
       ```
 
       Paste this code into the second `xcode_backend embed_and_thin` Build Phase:
 
-      ```bash
+      ```
       /bin/sh "$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh" embed_and_thin
       ```
 
       To run the test on a local iOS device (simulated or physical):
 
-      ```bash
+      ```
       patrol test --target integration_test/example_test.dart
       ```
 

--- a/docs/native/setup.mdx
+++ b/docs/native/setup.mdx
@@ -48,7 +48,7 @@ that Patrol is correctly set up.
 
 Paste the following code into `integration_test/example_test.dart`:
 
-```dart
+```dart title="integration_test/example_test.dart"
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
@@ -118,7 +118,7 @@ Psst... Android is a bit easier to set up, so we recommend starting with it!
 
       Next, update your **app-level build.gradle**:
 
-      ```groovy
+      ```groovy title="android/app/build.gradle"
       android {
         // ...
         defaultConfig {
@@ -152,21 +152,21 @@ Psst... Android is a bit easier to set up, so we recommend starting with it!
 
       Add the new test target to `ios/Podfile` by embedding in the existing `Runner` target.
 
-      ```ruby
+      ```ruby title="ios/Podfile"
       target 'Runner' do
-      # Do not change existing lines.
-      ...
+        # Do not change existing lines.
+        ...
 
-      target 'RunnerUITests' do
-         inherit! :complete
-      end
+        target 'RunnerUITests' do
+          inherit! :complete
+        end
       end
       ```
 
       In Xcode, add a test file called `RunnerUITests.m` (or any name of your choice)
       to the new target and replace the file with the following:
 
-      ```objective-c
+      ```objective-c title="ios/RunnerUITests/RunnerUITests.m"
       @import XCTest;
       @import patrol;
 

--- a/docs/tips-and-tricks.mdx
+++ b/docs/tips-and-tricks.mdx
@@ -34,14 +34,14 @@ properties of the view you want to act on.
 
 First, perform a native view hierarchy dump using `adb`:
 
-```bash
-$ adb shell uiautomator dump
+```
+adb shell uiautomator dump
 ```
 
 Then, copy the dump file from the device to your machine:
 
-```bash
-$ adb pull /sdcard/window_dump.xml .
+```
+adb pull /sdcard/window_dump.xml .
 ```
 
 **iOS**
@@ -51,8 +51,8 @@ The easiest way to perform the native view hierarchy dumb on iOS is to use the
 
 Once you have [idb] installed, perform a dump:
 
-```bash
-$ idb ui describe-all
+```
+idb ui describe-all
 ```
 
 ### Avoiding hardcoding credentials in tests
@@ -77,8 +77,8 @@ await $(#passwordTextField).enterText(const String.fromEnvironment('PASSWORD'));
 
 To set `USERNAME` and `PASSWORD`, use `--dart-define`:
 
-```bash
-$ patrol drive --dart-define 'USERNAME=Bartek' --dart-define 'PASSWORD=ny4ncat'
+```
+patrol drive --dart-define 'USERNAME=Bartek' --dart-define 'PASSWORD=ny4ncat'
 ```
 
 Alternatively you can create a `.patrol.env` file in your project's root. Here's
@@ -210,8 +210,8 @@ Let's say that you have 2 tests: `add_comment_test.dart` and
 
 Now you can run the `bundled_test.dart`:
 
-```bash
-$ patrol drive --target integration_test/bundled_test.dart
+```
+patrol drive --target integration_test/bundled_test.dart
 ```
 
 This builds the application binary once, saving you some time.


### PR DESCRIPTION
- docs(ci): fix broken link
- docs: remove `bash` syntax and remove the leading `$`
- move comparison to the bottom
- add docs about `patrol test`
- deprecate `drive`, `bootstrap`, and `clean`
- add callouts
- add titles to code snippets
