### PR TITLE
Fix disparity between tapping on notifications on iOS.

### DIFF
--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/NativeAutomatorServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/NativeAutomatorServer.kt
@@ -54,6 +54,11 @@ class NativeAutomatorServer : NativeAutomatorGrpcKt.NativeAutomatorCoroutineImpl
         return empty { }
     }
 
+    override suspend fun closeNotifications(request: Contracts.Empty): Contracts.Empty {
+        automation.closeNotifications()
+        return empty { }
+    }
+
     override suspend fun openQuickSettings(request: Contracts.OpenQuickSettingsRequest): Empty {
         automation.openQuickSettings()
         return empty { }

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAutomator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAutomator.kt
@@ -313,8 +313,6 @@ class PatrolAutomator private constructor() {
     fun tapOnNotification(index: Int) {
         Logger.d("tapOnNotification($index)")
 
-        openNotifications()
-
         try {
             val query = Contracts.Selector.newBuilder().setResourceId("android:id/status_bar_latest_event_content")
                 .setInstance(index).build()
@@ -329,8 +327,6 @@ class PatrolAutomator private constructor() {
 
     fun tapOnNotification(selector: UiSelector) {
         Logger.d("tapOnNotification()")
-
-        openNotifications()
 
         val obj = uiDevice.findObject(selector)
         obj.click()

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAutomator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAutomator.kt
@@ -247,6 +247,15 @@ class PatrolAutomator private constructor() {
         delay()
     }
 
+    fun closeNotifications() {
+        Logger.d("closeNotifications()")
+        val success = uiDevice.pressBack()
+        if (!success) {
+            throw PatrolException("Could not close notifications")
+        }
+        delay()
+    }
+
     fun openQuickSettings() {
         Logger.d("openNotifications()")
         val success = uiDevice.openQuickSettings()

--- a/packages/patrol/example/integration_test/notifications_test.dart
+++ b/packages/patrol/example/integration_test/notifications_test.dart
@@ -34,6 +34,19 @@ void main() {
     },
   );
 
+  patrol(
+    'opens and closes notification shade',
+    ($) async {
+      await $.pumpWidgetAndSettle(ExampleApp());
+
+      await $.native.openNotifications();
+      await $.native.closeNotifications();
+
+      await $.native.openNotifications();
+      await $.native.closeNotifications();
+    },
+  );
+
   // Disabled because the first notification is often about Android device setup
   // patrol(
   //   'sends a notification, verifies that it is visible and taps on it by index',

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -250,6 +250,16 @@ class NativeAutomator {
     );
   }
 
+  /// Closes the notification shade.
+  ///
+  /// It must be visible, otherwise the behavior is undefined.
+  Future<void> closeNotifications() async {
+    await _wrapRequest(
+      'closeNotifications',
+      () => _client.closeNotifications(Empty()),
+    );
+  }
+
   /// Opens the quick settings shade.
   ///
   /// See also:
@@ -302,7 +312,7 @@ class NativeAutomator {
 
   /// Taps on the [index]-th visible notification.
   ///
-  /// Notification shade has to be opened with [openNotifications].
+  /// Notification shade has to be opened first with [openNotifications].
   Future<void> tapOnNotificationByIndex(int index) async {
     await _wrapRequest(
       'tapOnNotificationByIndex',
@@ -312,7 +322,7 @@ class NativeAutomator {
 
   /// Taps on the visible notification using [selector].
   ///
-  /// Notification shade will be opened automatically.
+  /// Notification shade has to be opened first with [openNotifications].
   ///
   /// On iOS, only [Selector.textContains] is taken into account.
   Future<void> tapOnNotificationBySelector(Selector selector) async {


### PR DESCRIPTION
On Android, notification shade was always opened before taping.

On iOS, notification shade was not opened before tapping.

Now, the iOS behavior is common, to make tests more explicit. Users are welcome to write their own test helper functions.

Fixes #800