### PR TITLE
PatrolTester.native: improve assertion message when it's null

### DIFF
--- a/packages/patrol/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_tester.dart
@@ -120,7 +120,12 @@ class PatrolTester {
   /// Shorthand for [nativeAutomator]. Throws if [nativeAutomator] is null,
   /// which is the case if it wasn't initialized.
   NativeAutomator get native {
-    assert(nativeAutomator != null, 'native automator is null');
+    assert(
+      nativeAutomator != null,
+      'NativeAutomator is not initialized. Make sure you passed '
+      "`nativeAutomation: true` to patrolTest(), and that you're *not* "
+      'initializing any bindings in your test.',
+    );
     return nativeAutomator!;
   }
 

--- a/packages/patrol/test/patrol_tester_test.dart
+++ b/packages/patrol/test/patrol_tester_test.dart
@@ -7,6 +7,13 @@ import 'package:patrol/src/custom_finders/exceptions.dart';
 
 void main() {
   group('PatrolTester', () {
+    patrolTest(
+      'fires assertion when NativeAutomator is accessed, but it is null',
+      ($) async {
+        expect(() => $.native, throwsAssertionError);
+      },
+    );
+
     group('tap()', () {
       patrolTest(
         'throws exception when no widget to tap on is found',


### PR DESCRIPTION
Fixes #854
