### PR TITLE
`TestFinder.findAllTests()`: improve error message

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Improve error message of `patrol test` when the `integration_test` directory
+  doesn't exist (#876)
+
 ## 0.9.0
 
 - Enable `patrol test` for physical iOS devices (#863)

--- a/packages/patrol_cli/lib/src/features/run_commons/test_finder.dart
+++ b/packages/patrol_cli/lib/src/features/run_commons/test_finder.dart
@@ -1,6 +1,5 @@
 import 'package:file/file.dart';
-
-import '../../common/tool_exit.dart';
+import 'package:patrol_cli/src/common/tool_exit.dart';
 
 class TestFinder {
   const TestFinder({
@@ -49,6 +48,10 @@ class TestFinder {
   /// ending with `_test.dart` as absolute paths.
   List<String> findAllTests({Directory? directory}) {
     directory ??= _integrationTestDirectory;
+
+    if (!directory.existsSync()) {
+      throwToolExit("Directory 'integration_test' doesn't exist");
+    }
 
     return directory
         .listSync(recursive: true, followLinks: false)

--- a/packages/patrol_cli/test/common.dart
+++ b/packages/patrol_cli/test/common.dart
@@ -1,0 +1,5 @@
+import 'package:patrol_cli/src/common/tool_exit.dart';
+import 'package:test/test.dart';
+
+final throwsToolExit = throwsA(isToolExit);
+const isToolExit = TypeMatcher<ToolExit>();

--- a/packages/patrol_cli/test/features/run_commons/test_finder_test.dart
+++ b/packages/patrol_cli/test/features/run_commons/test_finder_test.dart
@@ -5,6 +5,8 @@ import 'package:patrol_cli/src/common/tool_exit.dart';
 import 'package:patrol_cli/src/features/run_commons/test_finder.dart';
 import 'package:test/test.dart';
 
+import '../../common.dart';
+
 void main() {
   late FileSystem fs;
   late TestFinder testFinder;
@@ -169,9 +171,9 @@ void main() {
 
   group('findAllTests', () {
     test(
-      'throws FileSystemException when integration_test directory does not exist',
+      'throws ToolExit when integration_test directory does not exist',
       () {
-        expect(testFinder.findAllTests, throwsA(isA<FileSystemException>()));
+        expect(testFinder.findAllTests, throwsToolExit);
       },
     );
 


### PR DESCRIPTION
### Before

```
$ patrol test
Directory listing failed: integration_test/
PathNotFoundException: Directory listing failed, path = 'integration_test/' (OS Error: No such file or directory, errno = 2)
#0      _Directory._fillWithDirectoryListing (dart:io-patch/directory_patch.dart:42:24)
#1      _Directory.listSync (dart:io/directory_impl.dart:233:5)
#2      ForwardingDirectory.listSync (package:file/src/forwarding/forwarding_directory.dart:43:12)
#3      TestFinder.findAllTests (package:patrol_cli/src/features/run_commons/test_finder.dart:54:10)
#4      TestCommand.configure (package:patrol_cli/src/features/test/test_command.dart:161:23)
#5      StagedCommand.run (package:patrol_cli/src/common/staged_command.dart:21:26)
#6      CommandRunner.runCommand (package:args/command_runner.dart:212:27)
#7      PatrolCommandRunner.runCommand (package:patrol_cli/src/command_runner.dart:329:30)
<asynchronous suspension>
#8      PatrolCommandRunner.run (package:patrol_cli/src/command_runner.dart:264:18)
<asynchronous suspension>
#9      patrolCommandRunner (package:patrol_cli/src/command_runner.dart:51:20)
<asynchronous suspension>
#10     main (file:///Users/bartek/.pub-cache/hosted/pub.dev/patrol_cli-0.9.0/bin/main.dart:6:20)
<asynchronous suspension>
```

### After

```
$ patrol test
Error: Directory 'integration_test' doesn't exist
```