### PR TITLE
Fix `--dart-defines` not being encoded correctly on Android when `patrol test`-ing

### DIFF
--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -206,7 +206,6 @@ Thrown by PatrolBinding.
   @override
   void attachRootWidget(Widget rootWidget) {
     const testLabel = String.fromEnvironment('PATROL_TEST_LABEL');
-
     if (testLabel.isEmpty) {
       super.attachRootWidget(RepaintBoundary(child: rootWidget));
     }

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Improve error message of `patrol test` when the `integration_test` directory
   doesn't exist (#876)
 - Make `patrol test` run tests in a more predictable, `ls`-like order (#882)
+- Fix `patrol test` incorrectly encoding `--dart-define` when running on Android
+  (#885)
+- Display name of currently running test file in top-left corner (#885)
 
 ## 0.9.0
 

--- a/packages/patrol_cli/lib/src/features/test/android_test_backend.dart
+++ b/packages/patrol_cli/lib/src/features/test/android_test_backend.dart
@@ -74,16 +74,16 @@ class AndroidAppOptions extends AppOptions {
     // Add Dart defines encoded in base64
     if (dartDefines.isNotEmpty) {
       final dartDefinesString = StringBuffer();
-      for (var i = 0; i < this.dartDefines.length; i++) {
-        final entry = this.dartDefines.entries.toList()[i];
-        dartDefinesString.write('${entry.key}=${entry.value}');
-        if (i != this.dartDefines.length - 1) {
+      for (var i = 0; i < dartDefines.length; i++) {
+        final entry = dartDefines.entries.elementAt(i);
+        final pair = utf8.encode('${entry.key}=${entry.value}');
+        dartDefinesString.write(base64Encode(pair));
+        if (i != dartDefines.length - 1) {
           dartDefinesString.write(',');
         }
       }
 
-      final dartDefines = utf8.encode(dartDefinesString.toString());
-      cmd.add('-Pdart-defines=${base64Encode(dartDefines)}');
+      cmd.add('-Pdart-defines=$dartDefinesString');
     }
 
     return cmd;

--- a/packages/patrol_cli/lib/src/features/test/ios_test_backend.dart
+++ b/packages/patrol_cli/lib/src/features/test/ios_test_backend.dart
@@ -46,7 +46,6 @@ class IOSAppOptions extends AppOptions {
         '--dart-define',
         '${dartDefine.key}=${dartDefine.value}',
       ],
-      // TODO: Add support for test label
     ];
 
     return cmd;

--- a/packages/patrol_cli/test/features/test/android_test_backend_test.dart
+++ b/packages/patrol_cli/test/features/test/android_test_backend_test.dart
@@ -67,7 +67,7 @@ void main() {
             'gradlew.bat',
             ':app:assembleDevDebugAndroidTest',
             r'-Ptarget=C:\Users\john\app\integration_test\app_test.dart',
-            '-Pdart-defines=RU1BSUw9dXNlckBleGFtcGxlLmNvbSxQQVNTV09SRD1ueTRuY2F0LGZvbz1iYXI='
+            '-Pdart-defines=RU1BSUw9dXNlckBleGFtcGxlLmNvbQ==,UEFTU1dPUkQ9bnk0bmNhdA==,Zm9vPWJhcg=='
           ]),
         );
       });
@@ -87,7 +87,7 @@ void main() {
             './gradlew',
             ':app:assembleDevDebugAndroidTest',
             '-Ptarget=/Users/john/app/integration_test/app_test.dart',
-            '-Pdart-defines=RU1BSUw9dXNlckBleGFtcGxlLmNvbSxQQVNTV09SRD1ueTRuY2F0LGZvbz1iYXI='
+            '-Pdart-defines=RU1BSUw9dXNlckBleGFtcGxlLmNvbQ==,UEFTU1dPUkQ9bnk0bmNhdA==,Zm9vPWJhcg=='
           ]),
         );
       });


### PR DESCRIPTION
Also, add support for `PATROL_TEST_LABEL`. It was present in `patrol drive`, but not backported to `patrol test` - until this PR.