### PR TITLE
Glue `PubspecReader` with `TestCommand` and app-side config

### DIFF
--- a/packages/patrol/example/integration_test/common.dart
+++ b/packages/patrol/example/integration_test/common.dart
@@ -5,21 +5,18 @@ export 'package:example/main.dart';
 export 'package:flutter_test/flutter_test.dart';
 export 'package:patrol/patrol.dart';
 
+final _patrolTesterConfig = PatrolTesterConfig();
+final _nativeAutomatorConfig = NativeAutomatorConfig();
+
 void patrol(
   String description,
   Future<void> Function(PatrolTester) callback,
 ) {
   patrolTest(
     description,
-    nativeAutomatorConfig: nativeAutomatorConfig,
+    config: _patrolTesterConfig,
+    nativeAutomatorConfig: _nativeAutomatorConfig,
     nativeAutomation: true,
     callback,
   );
 }
-
-final patrolTesterConfig = PatrolTesterConfig();
-
-final nativeAutomatorConfig = NativeAutomatorConfig(
-  packageName: 'pl.leancode.patrol.example',
-  bundleId: 'pl.leancode.patrol.Example',
-);

--- a/packages/patrol/example/integration_test/example_test.dart
+++ b/packages/patrol/example/integration_test/example_test.dart
@@ -3,11 +3,8 @@ import 'package:flutter/material.dart';
 import 'common.dart';
 
 void main() {
-  patrolTest(
+  patrol(
     'counter state is the same after going to Home and switching apps',
-    config: patrolTesterConfig,
-    nativeAutomatorConfig: nativeAutomatorConfig,
-    nativeAutomation: true,
     ($) async {
       await $.pumpWidget(ExampleApp());
 
@@ -20,8 +17,6 @@ void main() {
       expect($(#counterText).text, '1');
       await $(FloatingActionButton).tap();
       expect($(#counterText).text, '2');
-
-      print('EXAMPLE APP: TEST END!');
     },
   );
 }

--- a/packages/patrol/example/pubspec.yaml
+++ b/packages/patrol/example/pubspec.yaml
@@ -29,9 +29,8 @@ flutter:
   uses-material-design: true
 
 patrol:
+  app_name: Patrol example
   android:
     package_name: pl.leancode.patrol.example
-    app_name: Patrol example
   ios:
     bundle_id: pl.leancode.patrol.Example
-    app_name: Patrol example

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -52,6 +52,7 @@ class NativeAutomatorConfig {
     ),
     this.packageName = const String.fromEnvironment('PATROL_APP_PACKAGE_NAME'),
     this.bundleId = const String.fromEnvironment('PATROL_APP_BUNDLE_ID'),
+    this.appName = const String.fromEnvironment('PATROL_APP_NAME'),
     this.connectionTimeout = const Duration(seconds: 60),
     this.findTimeout = const Duration(seconds: 10),
     this.logger = _defaultPrintLogger,
@@ -81,6 +82,9 @@ class NativeAutomatorConfig {
   /// iOS only.
   final String bundleId;
 
+  /// Name of the application under test.
+  final String appName;
+
   /// Called when a native action is performed.
   final void Function(String) logger;
 
@@ -91,6 +95,7 @@ class NativeAutomatorConfig {
     String? port,
     String? packageName,
     String? bundleId,
+    String? appName,
     Duration? connectionTimeout,
     Duration? findTimeout,
     void Function(String)? logger,
@@ -100,6 +105,7 @@ class NativeAutomatorConfig {
       port: port ?? this.port,
       packageName: packageName ?? this.packageName,
       bundleId: bundleId ?? this.bundleId,
+      appName: appName ?? this.appName,
       connectionTimeout: connectionTimeout ?? this.connectionTimeout,
       findTimeout: findTimeout ?? this.findTimeout,
       logger: logger ?? this.logger,

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -52,7 +52,9 @@ class NativeAutomatorConfig {
     ),
     this.packageName = const String.fromEnvironment('PATROL_APP_PACKAGE_NAME'),
     this.bundleId = const String.fromEnvironment('PATROL_APP_BUNDLE_ID'),
-    this.appName = const String.fromEnvironment('PATROL_APP_NAME'),
+    this.androidAppName =
+        const String.fromEnvironment('PATROL_ANDROID_APP_NAME'),
+    this.iosAppName = const String.fromEnvironment('PATROL_IOS_APP_NAME'),
     this.connectionTimeout = const Duration(seconds: 60),
     this.findTimeout = const Duration(seconds: 10),
     this.logger = _defaultPrintLogger,
@@ -82,8 +84,24 @@ class NativeAutomatorConfig {
   /// iOS only.
   final String bundleId;
 
+  /// Name of the application under test on Android.
+  final String androidAppName;
+
+  /// Name of the application under test on iOS.
+  final String iosAppName;
+
   /// Name of the application under test.
-  final String appName;
+  ///
+  /// Returns [androidAppName] on Android and [iosAppName] on iOS.
+  String get appName {
+    if (io.Platform.isAndroid) {
+      return androidAppName;
+    } else if (io.Platform.isIOS) {
+      return iosAppName;
+    } else {
+      throw StateError('Unsupported platform');
+    }
+  }
 
   /// Called when a native action is performed.
   final void Function(String) logger;
@@ -95,7 +113,8 @@ class NativeAutomatorConfig {
     String? port,
     String? packageName,
     String? bundleId,
-    String? appName,
+    String? androidAppName,
+    String? iosAppName,
     Duration? connectionTimeout,
     Duration? findTimeout,
     void Function(String)? logger,
@@ -105,7 +124,8 @@ class NativeAutomatorConfig {
       port: port ?? this.port,
       packageName: packageName ?? this.packageName,
       bundleId: bundleId ?? this.bundleId,
-      appName: appName ?? this.appName,
+      androidAppName: androidAppName ?? this.androidAppName,
+      iosAppName: iosAppName ?? this.iosAppName,
       connectionTimeout: connectionTimeout ?? this.connectionTimeout,
       findTimeout: findTimeout ?? this.findTimeout,
       logger: logger ?? this.logger,
@@ -127,15 +147,20 @@ class NativeAutomator {
         ),
         _config = config {
     if (_config.packageName.isEmpty && io.Platform.isAndroid) {
-      config.logger("packageName is not set. It's recommended to set it.");
+      _config.logger("packageName is not set. It's recommended to set it.");
     }
     if (_config.bundleId.isEmpty && io.Platform.isIOS) {
-      config.logger("bundleId is not set. It's recommended to set it.");
+      _config.logger("bundleId is not set. It's recommended to set it.");
     }
 
+    _config.logger('Android app name: ${_config.androidAppName}');
+    _config.logger('iOS app name: ${_config.iosAppName}');
+    _config.logger('Android package name: ${_config.packageName}');
+    _config.logger('iOS bundle identifier: ${_config.bundleId}');
+
     final channel = ClientChannel(
-      config.host,
-      port: int.parse(config.port),
+      _config.host,
+      port: int.parse(_config.port),
       options: const ChannelOptions(
         credentials: ChannelCredentials.insecure(),
       ),

--- a/packages/patrol_cli/lib/src/command_runner.dart
+++ b/packages/patrol_cli/lib/src/command_runner.dart
@@ -131,10 +131,7 @@ class PatrolCommandRunner extends CommandRunner<int> {
           projectRoot: _fs.currentDirectory,
           fs: _fs,
         ),
-        pubspecReader: PubspecReader(
-          projectRoot: _fs.currentDirectory,
-          fs: _fs,
-        ),
+        pubspecReader: PubspecReader(projectRoot: _fs.currentDirectory),
         androidTestBackend: AndroidTestBackend(
           adb: Adb(),
           processManager: LoggingLocalProcessManager(logger: _logger),

--- a/packages/patrol_cli/lib/src/command_runner.dart
+++ b/packages/patrol_cli/lib/src/command_runner.dart
@@ -115,47 +115,46 @@ class PatrolCommandRunner extends CommandRunner<int> {
     );
     addCommand(driveCommand);
 
-    addCommand(
-      TestCommand(
-        deviceFinder: DeviceFinder(
-          processManager: LoggingLocalProcessManager(logger: logger),
+    testCommand = TestCommand(
+      deviceFinder: DeviceFinder(
+        processManager: LoggingLocalProcessManager(logger: logger),
+        parentDisposeScope: _disposeScope,
+        logger: _logger,
+      ),
+      testFinder: TestFinder(
+        integrationTestDir: _fs.directory('integration_test'),
+        fs: _fs,
+      ),
+      testRunner: NativeTestRunner(),
+      dartDefinesReader: DartDefinesReader(
+        projectRoot: _fs.currentDirectory,
+        fs: _fs,
+      ),
+      pubspecReader: PubspecReader(projectRoot: _fs.currentDirectory),
+      androidTestBackend: AndroidTestBackend(
+        adb: Adb(),
+        processManager: LoggingLocalProcessManager(logger: _logger),
+        platform: const LocalPlatform(),
+        fs: _fs,
+        parentDisposeScope: _disposeScope,
+        logger: _logger,
+      ),
+      iosTestBackend: IOSTestBackend(
+        processManager: LoggingLocalProcessManager(logger: _logger),
+        fs: _fs,
+        iosDeploy: IOSDeploy(
+          processManager: const LocalProcessManager(),
           parentDisposeScope: _disposeScope,
-          logger: _logger,
-        ),
-        testFinder: TestFinder(
-          integrationTestDir: _fs.directory('integration_test'),
           fs: _fs,
-        ),
-        testRunner: NativeTestRunner(),
-        dartDefinesReader: DartDefinesReader(
-          projectRoot: _fs.currentDirectory,
-          fs: _fs,
-        ),
-        pubspecReader: PubspecReader(projectRoot: _fs.currentDirectory),
-        androidTestBackend: AndroidTestBackend(
-          adb: Adb(),
-          processManager: LoggingLocalProcessManager(logger: _logger),
-          platform: const LocalPlatform(),
-          fs: _fs,
-          parentDisposeScope: _disposeScope,
-          logger: _logger,
-        ),
-        iosTestBackend: IOSTestBackend(
-          processManager: LoggingLocalProcessManager(logger: _logger),
-          fs: _fs,
-          iosDeploy: IOSDeploy(
-            processManager: const LocalProcessManager(),
-            parentDisposeScope: _disposeScope,
-            fs: _fs,
-            logger: _logger,
-          ),
-          parentDisposeScope: _disposeScope,
           logger: _logger,
         ),
         parentDisposeScope: _disposeScope,
         logger: _logger,
       ),
+      parentDisposeScope: _disposeScope,
+      logger: _logger,
     );
+    addCommand(testCommand);
 
     addCommand(
       DevicesCommand(
@@ -216,6 +215,7 @@ class PatrolCommandRunner extends CommandRunner<int> {
   final Logger _logger;
 
   late DriveCommand driveCommand;
+  late TestCommand testCommand;
 
   Future<void> dispose() async {
     try {
@@ -246,6 +246,7 @@ Ask questions, get support at https://github.com/leancodepl/patrol/discussions''
       debug = topLevelResults['debug'] == true;
 
       driveCommand.verbose = verbose;
+      testCommand.verbose = verbose;
 
       if (verbose) {
         _logger

--- a/packages/patrol_cli/lib/src/features/test/pubspec_reader.dart
+++ b/packages/patrol_cli/lib/src/features/test/pubspec_reader.dart
@@ -13,6 +13,7 @@ class AndroidPubspecConfig {
   AndroidPubspecConfig({this.packageName, this.appName});
   String? packageName;
   String? appName;
+  String? flavor;
 }
 
 class IOSPubspecConfig {
@@ -20,6 +21,7 @@ class IOSPubspecConfig {
 
   String? bundleId;
   String? appName;
+  String? flavor;
 }
 
 /// Reads Patrol CLI configuration block from pubspec.yaml.

--- a/packages/patrol_cli/lib/src/features/test/pubspec_reader.dart
+++ b/packages/patrol_cli/lib/src/features/test/pubspec_reader.dart
@@ -4,7 +4,7 @@ import 'package:path/path.dart' show join;
 import 'package:yaml/yaml.dart';
 
 class PatrolPubspecConfig with EquatableMixin {
-  PatrolPubspecConfig({required this.android, required this.ios});
+  PatrolPubspecConfig({this.flavor, required this.android, required this.ios});
 
   PatrolPubspecConfig.empty()
       : this(
@@ -12,11 +12,12 @@ class PatrolPubspecConfig with EquatableMixin {
           ios: IOSPubspecConfig.empty(),
         );
 
+  String? flavor;
   AndroidPubspecConfig android;
   IOSPubspecConfig ios;
 
   @override
-  List<Object?> get props => [android, ios];
+  List<Object?> get props => [flavor, android, ios];
 }
 
 class AndroidPubspecConfig with EquatableMixin {
@@ -26,10 +27,9 @@ class AndroidPubspecConfig with EquatableMixin {
 
   String? packageName;
   String? appName;
-  String? flavor;
 
   @override
-  List<Object?> get props => [packageName, appName, flavor];
+  List<Object?> get props => [packageName, appName];
 }
 
 class IOSPubspecConfig with EquatableMixin {
@@ -39,10 +39,9 @@ class IOSPubspecConfig with EquatableMixin {
 
   String? bundleId;
   String? appName;
-  String? flavor;
 
   @override
-  List<Object?> get props => [bundleId, appName, flavor];
+  List<Object?> get props => [bundleId, appName];
 }
 
 /// Reads Patrol CLI configuration block from pubspec.yaml.
@@ -82,8 +81,7 @@ class PubspecReader {
     }
     final dynamic flavor = patrol['flavor'];
     if (flavor != null && flavor is String?) {
-      androidConfig.flavor = flavor;
-      iosConfig.flavor = flavor;
+      config.flavor = flavor;
     }
 
     final android = patrol['android'] as Map?;

--- a/packages/patrol_cli/lib/src/features/test/pubspec_reader.dart
+++ b/packages/patrol_cli/lib/src/features/test/pubspec_reader.dart
@@ -3,10 +3,10 @@ import 'package:path/path.dart' show join;
 import 'package:yaml/yaml.dart';
 
 class PatrolPubspecConfig {
-  PatrolPubspecConfig({this.android, this.ios});
+  PatrolPubspecConfig({required this.android, required this.ios});
 
-  AndroidPubspecConfig? android;
-  IOSPubspecConfig? ios;
+  AndroidPubspecConfig android;
+  IOSPubspecConfig ios;
 }
 
 class AndroidPubspecConfig {
@@ -26,11 +26,10 @@ class IOSPubspecConfig {
 
 /// Reads Patrol CLI configuration block from pubspec.yaml.
 class PubspecReader {
-  const PubspecReader({
+  PubspecReader({
     required Directory projectRoot,
-    required FileSystem fs,
   })  : _projectRoot = projectRoot,
-        _fs = fs;
+        _fs = projectRoot.fileSystem;
 
   final Directory _projectRoot;
   final FileSystem _fs;
@@ -46,38 +45,47 @@ class PubspecReader {
     final contents = file.readAsStringSync();
     final yaml = loadYaml(contents) as Map;
 
-    final config = PatrolPubspecConfig();
+    final androidConfig = AndroidPubspecConfig();
+    final iosConfig = IOSPubspecConfig();
+    final config = PatrolPubspecConfig(android: androidConfig, ios: iosConfig);
+
     final patrol = yaml['patrol'] as Map?;
-    if (patrol != null) {
-      final patrol = yaml['patrol'] as Map;
-      final android = patrol['android'] as Map?;
-      if (android != null) {
-        final androidConfig = AndroidPubspecConfig();
-        config.android = androidConfig;
+    if (patrol == null) {
+      return config;
+    }
 
-        final dynamic packageName = android['package_name'];
-        if (packageName != null && packageName is String?) {
-          androidConfig.packageName = packageName;
-        }
-        final dynamic appName = android['app_name'];
-        if (appName != null && appName is String?) {
-          androidConfig.appName = appName;
-        }
+    final dynamic appName = patrol['app_name'];
+    if (appName != null && appName is String?) {
+      androidConfig.appName = appName;
+      iosConfig.appName = appName;
+    }
+    
+
+    final android = patrol['android'] as Map?;
+    if (android != null) {
+      config.android = androidConfig;
+
+      final dynamic packageName = android['package_name'];
+      if (packageName != null && packageName is String?) {
+        androidConfig.packageName = packageName;
       }
+      final dynamic appName = android['app_name'];
+      if (appName != null && appName is String?) {
+        androidConfig.appName = appName;
+      }
+    }
 
-      final ios = patrol['ios'] as Map?;
-      if (ios != null) {
-        final iosConfig = IOSPubspecConfig();
-        config.ios = iosConfig;
+    final ios = patrol['ios'] as Map?;
+    if (ios != null) {
+      config.ios = iosConfig;
 
-        final dynamic bundleId = ios['bundle_id'];
-        if (bundleId != null && bundleId is String?) {
-          iosConfig.bundleId = bundleId;
-        }
-        final dynamic appName = ios['app_name'];
-        if (appName != null && appName is String?) {
-          iosConfig.appName = appName;
-        }
+      final dynamic bundleId = ios['bundle_id'];
+      if (bundleId != null && bundleId is String?) {
+        iosConfig.bundleId = bundleId;
+      }
+      final dynamic appName = ios['app_name'];
+      if (appName != null && appName is String?) {
+        iosConfig.appName = appName;
       }
     }
 

--- a/packages/patrol_cli/lib/src/features/test/pubspec_reader.dart
+++ b/packages/patrol_cli/lib/src/features/test/pubspec_reader.dart
@@ -1,27 +1,48 @@
+import 'package:equatable/equatable.dart';
 import 'package:file/file.dart';
 import 'package:path/path.dart' show join;
 import 'package:yaml/yaml.dart';
 
-class PatrolPubspecConfig {
+class PatrolPubspecConfig with EquatableMixin {
   PatrolPubspecConfig({required this.android, required this.ios});
+
+  PatrolPubspecConfig.empty()
+      : this(
+          android: AndroidPubspecConfig.empty(),
+          ios: IOSPubspecConfig.empty(),
+        );
 
   AndroidPubspecConfig android;
   IOSPubspecConfig ios;
+
+  @override
+  List<Object?> get props => [android, ios];
 }
 
-class AndroidPubspecConfig {
+class AndroidPubspecConfig with EquatableMixin {
   AndroidPubspecConfig({this.packageName, this.appName});
+
+  AndroidPubspecConfig.empty() : this(packageName: null, appName: null);
+
   String? packageName;
   String? appName;
   String? flavor;
+
+  @override
+  List<Object?> get props => [packageName, appName, flavor];
 }
 
-class IOSPubspecConfig {
+class IOSPubspecConfig with EquatableMixin {
   IOSPubspecConfig({this.bundleId, this.appName});
+
+  IOSPubspecConfig.empty() : this(bundleId: null, appName: null);
 
   String? bundleId;
   String? appName;
   String? flavor;
+
+  @override
+  List<Object?> get props => [bundleId, appName, flavor];
 }
 
 /// Reads Patrol CLI configuration block from pubspec.yaml.
@@ -59,7 +80,11 @@ class PubspecReader {
       androidConfig.appName = appName;
       iosConfig.appName = appName;
     }
-    
+    final dynamic flavor = patrol['flavor'];
+    if (flavor != null && flavor is String?) {
+      androidConfig.flavor = flavor;
+      iosConfig.flavor = flavor;
+    }
 
     final android = patrol['android'] as Map?;
     if (android != null) {

--- a/packages/patrol_cli/lib/src/features/test/test_command.dart
+++ b/packages/patrol_cli/lib/src/features/test/test_command.dart
@@ -180,7 +180,7 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
       _logger.detail('Received device: ${device.resolvedName}');
     }
 
-    final userDartDefines = {
+    final customDartDefines = {
       ..._dartDefinesReader.fromFile(),
       ..._dartDefinesReader.fromCli(
         args: argResults?['dart-define'] as List<String>? ?? [],
@@ -189,15 +189,9 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
 
     var packageName = argResults?['package-name'] as String?;
     packageName ??= pubspecConfig.android.packageName;
-    if (packageName != null) {
-      _logger.detail('Received Android app package name: $packageName');
-    }
 
     var bundleId = argResults?['bundle-id'] as String?;
     bundleId ??= pubspecConfig.ios.bundleId;
-    if (bundleId != null) {
-      _logger.detail('Received iOS app bundle identifier: $bundleId');
-    }
 
     final dynamic wait = argResults?['wait'];
     if (wait != null && int.tryParse(wait as String) == null) {
@@ -222,8 +216,7 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
       _logger.info('Every test target will be run $repeat times');
     }
 
-    final effectiveDartDefines = <String, String?>{
-      ...userDartDefines,
+    final internalDartDefines = {
       'PATROL_WAIT': wait as String? ?? '0',
       'PATROL_VERBOSE': '$verbose',
       'PATROL_APP_PACKAGE_NAME': packageName,
@@ -232,10 +225,18 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
       'PATROL_IOS_APP_NAME': pubspecConfig.ios.appName,
     }.withNullsRemoved();
 
-    _logger.detail('Received ${effectiveDartDefines.length} --dart-define(s)');
-    for (final dartDefine in effectiveDartDefines.entries) {
+    final effectiveDartDefines = {...customDartDefines, ...internalDartDefines};
+
+    _logger.detail(
+      'Received ${effectiveDartDefines.length} --dart-define(s) '
+      '(${customDartDefines.length} custom, ${internalDartDefines.length} internal)',
+    );
+    for (final dartDefine in customDartDefines.entries) {
+      _logger.detail('Received custom --dart-define: ${dartDefine.key}');
+    }
+    for (final dartDefine in internalDartDefines.entries) {
       _logger.detail(
-        'Received --dart-define: ${dartDefine.key}=${dartDefine.value}',
+        'Received internal --dart-define: ${dartDefine.key}=${dartDefine.value}',
       );
     }
 

--- a/packages/patrol_cli/lib/src/features/test/test_command.dart
+++ b/packages/patrol_cli/lib/src/features/test/test_command.dart
@@ -165,11 +165,20 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
       _logger.detail('Received test target: $t');
     }
 
-    final flavor = argResults?['flavor'] as String?;
     final pubspecConfig = _pubspecReader.read();
 
+    var flavor = argResults?['flavor'] as String?;
+    flavor ??= pubspecConfig.flavor;
+    if (flavor != null) {
+      _logger.detail('Received flavor: $flavor');
+    }
+
     final devices = argResults?['device'] as List<String>? ?? [];
-    final attachedDevices = await _deviceFinder.find(devices);
+    final devicesToUse = await _deviceFinder.find(devices);
+    _logger.detail('Received ${devicesToUse.length} device(s) to run on');
+    for (final device in devicesToUse) {
+      _logger.detail('Received device: ${device.resolvedName}');
+    }
 
     final userDartDefines = {
       ..._dartDefinesReader.fromFile(),
@@ -184,10 +193,16 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
     }
 
     var packageName = argResults?['package-name'] as String?;
-    packageName ??= pubspecConfig.android?.packageName;
+    packageName ??= pubspecConfig.android.packageName;
+    if (packageName != null) {
+      _logger.detail('Received Android package name: $packageName');
+    }
 
     var bundleId = argResults?['bundle-id'] as String?;
-    bundleId ??= pubspecConfig.ios?.bundleId;
+    bundleId ??= pubspecConfig.ios.bundleId;
+    if (bundleId != null) {
+      _logger.detail('Received iOS bundle identifier: $bundleId');
+    }
 
     final dynamic wait = argResults?['wait'];
     if (wait != null && int.tryParse(wait as String) == null) {
@@ -213,7 +228,7 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
     }
 
     return TestCommandConfig(
-      devices: attachedDevices,
+      devices: devicesToUse,
       targets: targets,
       flavor: flavor,
       scheme: argResults?['scheme'] as String? ?? _defaultScheme,

--- a/packages/patrol_cli/test/features/test/android_test_backend_test.dart
+++ b/packages/patrol_cli/test/features/test/android_test_backend_test.dart
@@ -18,7 +18,7 @@ void main() {
         expect(
           invocation,
           equals([
-            'gradlew.bat',
+            r'.\gradlew.bat',
             ':app:assembleDebugAndroidTest',
             r'-Ptarget=C:\Users\john\app\integration_test\app_test.dart',
           ]),
@@ -64,7 +64,7 @@ void main() {
         expect(
           invocation,
           equals([
-            'gradlew.bat',
+            r'.\gradlew.bat',
             ':app:assembleDevDebugAndroidTest',
             r'-Ptarget=C:\Users\john\app\integration_test\app_test.dart',
             '-Pdart-defines=RU1BSUw9dXNlckBleGFtcGxlLmNvbQ==,UEFTU1dPUkQ9bnk0bmNhdA==,Zm9vPWJhcg=='

--- a/packages/patrol_cli/test/features/test/pubspec_reader_test.dart
+++ b/packages/patrol_cli/test/features/test/pubspec_reader_test.dart
@@ -1,0 +1,52 @@
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:patrol_cli/src/features/test/pubspec_reader.dart';
+import 'package:test/test.dart';
+
+const _pubspecBase = '''
+name: example
+description: A new Flutter project.
+publish_to: none
+version: 1.0.0+1
+''';
+
+Directory _initTestFs() {
+  final fs = MemoryFileSystem.test();
+  final wd = fs.directory('/projects/awesome_app')..createSync(recursive: true);
+  fs.currentDirectory = wd;
+  return wd;
+}
+
+void main() {
+  group('PubspecReader', () {
+    late PubspecReader reader;
+    late FileSystem fs;
+
+    setUp(() {
+      final projectRoot = _initTestFs();
+      fs = projectRoot.fileSystem;
+
+      reader = PubspecReader(projectRoot: projectRoot);
+    });
+
+    group('read()', () {
+      test('returns empty config when `patrol` block does not exist', () {
+        fs.file('pubspec.yaml').writeAsStringSync(_pubspecBase);
+
+        expect(reader.read().android, equals(null));
+        expect(reader.read().ios, equals(null));
+      });
+
+      test('reads top-level app name', () {
+        fs.file('pubspec.yaml').writeAsStringSync('''
+$_pubspecBase
+patrol:
+  app_name: Example
+''');
+
+        expect(reader.read().android.appName, equals('Example'));
+        expect(reader.read().ios.appName, equals('Example'));
+      });
+    });
+  });
+}

--- a/packages/patrol_cli/test/features/test/pubspec_reader_test.dart
+++ b/packages/patrol_cli/test/features/test/pubspec_reader_test.dart
@@ -33,19 +33,21 @@ void main() {
       test('returns empty config when `patrol` block does not exist', () {
         fs.file('pubspec.yaml').writeAsStringSync(_pubspecBase);
 
-        expect(reader.read().android, equals(null));
-        expect(reader.read().ios, equals(null));
+        expect(reader.read(), equals(PatrolPubspecConfig.empty()));
       });
 
-      test('reads top-level app name', () {
+      test('reads top-level arguments', () {
         fs.file('pubspec.yaml').writeAsStringSync('''
 $_pubspecBase
 patrol:
   app_name: Example
+  flavor: dev
 ''');
 
         expect(reader.read().android.appName, equals('Example'));
         expect(reader.read().ios.appName, equals('Example'));
+        expect(reader.read().android.flavor, equals('dev'));
+        expect(reader.read().ios.flavor, equals('dev'));
       });
     });
   });

--- a/packages/patrol_cli/test/features/test/pubspec_reader_test.dart
+++ b/packages/patrol_cli/test/features/test/pubspec_reader_test.dart
@@ -46,8 +46,7 @@ patrol:
 
         expect(reader.read().android.appName, equals('Example'));
         expect(reader.read().ios.appName, equals('Example'));
-        expect(reader.read().android.flavor, equals('dev'));
-        expect(reader.read().ios.flavor, equals('dev'));
+        expect(reader.read().flavor, equals('dev'));
       });
 
       test('reads `android` block', () {
@@ -92,10 +91,9 @@ patrol:
 
       expect(reader.read().android.appName, equals('Example'));
       expect(reader.read().android.packageName, equals('com.example.app'));
-      expect(reader.read().android.flavor, equals('dev'));
+      expect(reader.read().flavor, equals('dev'));
       expect(reader.read().ios.appName, equals('The Example'));
       expect(reader.read().ios.bundleId, equals('com.example.ExampleApp'));
-      expect(reader.read().ios.flavor, equals('dev'));
     });
   });
 }

--- a/packages/patrol_cli/test/features/test/pubspec_reader_test.dart
+++ b/packages/patrol_cli/test/features/test/pubspec_reader_test.dart
@@ -49,6 +49,53 @@ patrol:
         expect(reader.read().android.flavor, equals('dev'));
         expect(reader.read().ios.flavor, equals('dev'));
       });
+
+      test('reads `android` block', () {
+        fs.file('pubspec.yaml').writeAsStringSync('''
+$_pubspecBase
+patrol:
+  android:
+    app_name: Example
+    package_name: com.example.app
+''');
+
+        expect(reader.read().android.appName, equals('Example'));
+        expect(reader.read().android.packageName, equals('com.example.app'));
+      });
+
+      test('reads `ios` block', () {
+        fs.file('pubspec.yaml').writeAsStringSync('''
+$_pubspecBase
+patrol:
+  ios:
+    app_name: The Example
+    bundle_id: com.example.ExampleApp
+''');
+
+        expect(reader.read().ios.appName, equals('The Example'));
+        expect(reader.read().ios.bundleId, equals('com.example.ExampleApp'));
+      });
+    });
+
+    test('overrides global values with platform-specific ones', () {
+      fs.file('pubspec.yaml').writeAsStringSync('''
+$_pubspecBase
+patrol:
+  app_name: Example
+  flavor: dev
+  android:
+    package_name: com.example.app
+  ios:
+    app_name: The Example
+    bundle_id: com.example.ExampleApp
+''');
+
+      expect(reader.read().android.appName, equals('Example'));
+      expect(reader.read().android.packageName, equals('com.example.app'));
+      expect(reader.read().android.flavor, equals('dev'));
+      expect(reader.read().ios.appName, equals('The Example'));
+      expect(reader.read().ios.bundleId, equals('com.example.ExampleApp'));
+      expect(reader.read().ios.flavor, equals('dev'));
     });
   });
 }

--- a/packages/patrol_cli/test/features/test/test_command_test.dart
+++ b/packages/patrol_cli/test/features/test/test_command_test.dart
@@ -75,7 +75,7 @@ void main() {
           fs: fs,
           projectRoot: fs.currentDirectory,
         ),
-        pubspecReader: PubspecReader(fs: fs, projectRoot: fs.currentDirectory),
+        pubspecReader: PubspecReader(projectRoot: fs.currentDirectory),
         parentDisposeScope: DisposeScope(),
         androidTestBackend: androidTestBackend,
         iosTestBackend: iosTestBackend,


### PR DESCRIPTION
- add `flavor` to `AndroidPubspecConfig` and `IOSPubspecConfig`
- WIP start refactoring PubspecReader
- AndroidTestBackend: fix failing tests
- progress with PubspecReader
- more tests
- TestCommand: use variables received from PubspecReader
- NativeAutomator: add `appName` field
- write more glue
- improve logging dart defines
