### PR TITLE
Fix crash caused by `PatrolBinding` when using AGP 7.3.1 and resuming the app from background when using `patrol test`

### DIFF
--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -208,26 +208,28 @@ Thrown by PatrolBinding.
     const testLabel = String.fromEnvironment('PATROL_TEST_LABEL');
     if (testLabel.isEmpty) {
       super.attachRootWidget(RepaintBoundary(child: rootWidget));
+    } else {
+      super.attachRootWidget(
+        Stack(
+          textDirection: TextDirection.ltr,
+          children: [
+            RepaintBoundary(child: rootWidget),
+            ExcludeSemantics(
+              child: Padding(
+                padding: EdgeInsets.only(
+                  top: MediaQueryData.fromWindow(window).padding.top + 4,
+                  left: 4,
+                ),
+                child: const Text(
+                  testLabel,
+                  textDirection: TextDirection.ltr,
+                  style: TextStyle(color: Colors.red),
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
     }
-
-    super.attachRootWidget(
-      Stack(
-        textDirection: TextDirection.ltr,
-        children: [
-          RepaintBoundary(child: rootWidget),
-          Padding(
-            padding: EdgeInsets.only(
-              top: MediaQueryData.fromWindow(window).padding.top + 4,
-              left: 4,
-            ),
-            child: const Text(
-              testLabel,
-              textDirection: TextDirection.ltr,
-              style: TextStyle(color: Colors.red),
-            ),
-          ),
-        ],
-      ),
-    );
   }
 }


### PR DESCRIPTION
This fixes an elusive bug in `PatrolBinding` which occurred when:
- the app under test was using AGP 7.3.1
- `PATROL_TEST_LABEL` was passed
- the app under test went to the background, and then resumed

This resulted in the following error (`flutter logs` output):

```
I/flutter (24357): test label is notifications_test.dart
E/flutter (24357): [ERROR:flutter/fml/platform/android/jni_util.cc(204)] java.lang.AssertionError: transform has not been initialized
E/flutter (24357): 	at io.flutter.view.AccessibilityBridge$SemanticsNode.updateRecursively(AccessibilityBridge.java:2734)
E/flutter (24357): 	at io.flutter.view.AccessibilityBridge$SemanticsNode.updateRecursively(AccessibilityBridge.java:2789)
E/flutter (24357): 	at io.flutter.view.AccessibilityBridge$SemanticsNode.access$5200(AccessibilityBridge.java:2279)
E/flutter (24357): 	at io.flutter.view.AccessibilityBridge.updateSemantics(AccessibilityBridge.java:1670)
E/flutter (24357): 	at io.flutter.view.AccessibilityBridge$1.updateSemantics(AccessibilityBridge.java:345)
E/flutter (24357): 	at io.flutter.embedding.engine.FlutterJNI.updateSemantics(FlutterJNI.java:762)
E/flutter (24357): 	at android.os.MessageQueue.nativePollOnce(Native Method)
E/flutter (24357): 	at android.os.MessageQueue.next(MessageQueue.java:335)
E/flutter (24357): 	at android.os.Looper.loopOnce(Looper.java:161)
E/flutter (24357): 	at android.os.Looper.loop(Looper.java:288)
E/flutter (24357): 	at android.app.ActivityThread.main(ActivityThread.java:7872)
E/flutter (24357): 	at java.lang.reflect.Method.invoke(Native Method)
E/flutter (24357): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
E/flutter (24357): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
E/flutter (24357):
F/flutter (24357): [FATAL:flutter/shell/platform/android/platform_view_android_jni_impl.cc(1233)] Check failed: fml::jni::CheckException(env).
```

Looks like the root cause is our custom binding was trying to create some semantic information before Flutter engine was ready for it. 

Fixes #901

Special thanks to @crisboarna for providing nice reproduction steps.