### PR TITLE
Fix more broken links in docs and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ See [packages/patrol][github_patrol].
 [docs_page_badge]: https://img.shields.io/badge/documentation-docs.page-34C4AC.svg?style
 [docs_page_link]: https://docs.page
 [docs]: https://patrol.leancode.co
-[docs_finders]: https://patrol.leancode.co/finders
+[docs_finders]: https://patrol.leancode.co/finders/overview
 [promo_graphics]: docs/assets/promo.png
 [article_0x]: https://leancode.co/blog/patrol-flutter-first-ui-testing-framework
 [article_1x]: https://leancode.co/blog/patrol-1-0-powerful-flutter-ui-testing-framework

--- a/docs/ci.mdx
+++ b/docs/ci.mdx
@@ -5,7 +5,10 @@ that they pass. We know this too well, so we've put a lot of work into making it
 easy to run Patrol tests in a multitude of ways, so you can choose whatever
 suits you best.
 
-Before you proceed with steps below, make sure that you've completed [native setup].
+<Info>
+  Before you proceed with the steps listed below, make sure that you've
+  completed the [native setup] guide.
+</Info>
 
 ### Run on Firebase Test Lab
 


### PR DESCRIPTION
- add callout in "Patrol and CI" docs section
- fix broken link in top-level readme
