### PR TITLE
Add info about missing `print()`s in Native Setup guide

### DIFF
--- a/docs/native/setup.mdx
+++ b/docs/native/setup.mdx
@@ -319,6 +319,11 @@ Psst... Android is a bit easier to set up, so we recommend starting with it!
   </TabItem>
 </Tabs>
 
+<Warning>
+  Dart-side logs are currently not printed during `patrol test`. We're aware of
+  this issue and will fix it. Use `flutter logs` as a temporary workaround.
+</Warning>
+
 ### What did you just do?
 
 If you've diligently followed the above steps and `patrol test` prints a **TEST


### PR DESCRIPTION
Related to #935 to prevent new people from creating this issue because we're aware of it