### PR TITLE
Fix IndexOutOfBounds exception when waiting for native views on Android

### DIFF
--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -424,7 +424,8 @@ class Automator private constructor() {
     private fun waitForSelector(bySelector: BySelector, index: Int): Boolean {
         val startTime = System.currentTimeMillis()
         while (System.currentTimeMillis() - startTime < timeoutMillis) {
-            if (uiDevice.findObjects(bySelector)[index] != null) {
+            val objects = uiDevice.findObjects(bySelector)
+            if (objects.size > index && objects[index] != null) {
                 return true
             }
 


### PR DESCRIPTION
Cherry-picked from #938.