### PR TITLE
Fix trying to reference non-existent job in `*-publish` workflows

### DIFF
--- a/.github/workflows/adb-publish.yaml
+++ b/.github/workflows/adb-publish.yaml
@@ -8,7 +8,6 @@ jobs:
   main:
     name: Publish on pub.dev
     runs-on: ubuntu-latest
-    needs: check_versions
 
     permissions:
       id-token: write

--- a/.github/workflows/patrol-publish.yaml
+++ b/.github/workflows/patrol-publish.yaml
@@ -8,7 +8,6 @@ jobs:
   main:
     name: Publish on pub.dev
     runs-on: ubuntu-latest
-    needs: check_versions
 
     permissions:
       id-token: write

--- a/.github/workflows/patrol_cli-publish.yaml
+++ b/.github/workflows/patrol_cli-publish.yaml
@@ -8,7 +8,6 @@ jobs:
   main:
     name: Publish on pub.dev
     runs-on: ubuntu-latest
-    needs: check_versions
 
     permissions:
       id-token: write

--- a/packages/adb/CHANGELOG.md
+++ b/packages/adb/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.4+2
 
-- Fix publish workflow (#955)
+- Fix publish workflow (#955) (#956)
 
 ## 0.2.4+1
 

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -6,7 +6,7 @@
   Documentation of these 2 methods has also been updated to explain the behavior
   in more detail.
 
-- Use automated publishing with GitHub Actions on pub.dev (#953) (#955)
+- Use automated publishing with GitHub Actions on pub.dev (#953) (#955) (#956)
 
 ## 1.0.1
 

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.1+1
 
-- Fix publish workflow (#955)
+- Fix publish workflow (#955) (#956)
 
 ## 1.0.1
 

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: patrol_cli
 description: >
   Command-line tool for Patrol, a powerful Flutter-native UI testing framework.
-version: 1.0.1+1
+version: 1.0.1+1 # Must be kept in sync with constants.dart
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues


### PR DESCRIPTION
Fixes bug introduced in #954.