### PR TITLE
Don't print verbose Gradle output when test fails and `--verbose` is not passed

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+- Make output of `patrol test` much less verbose when test fails on Android.
+  (#964)
+
+  Run with `--verbose` to still see all the logs that were previously visible.
+
 ## 1.0.1+1
 
 - Fix publish workflow (#955) (#956)
@@ -9,7 +16,8 @@
 
 ## 1.0.0
 
-- [Patrol 1.0 is released!](https://leancode.co/blog/patrol-1-0-powerful-flutter-ui-testing-framework))
+- [Patrol 1.0 is
+  released!](https://leancode.co/blog/patrol-1-0-powerful-flutter-ui-testing-framework)
 
 ## 0.9.4
 

--- a/packages/patrol_cli/lib/src/features/test/android_test_backend.dart
+++ b/packages/patrol_cli/lib/src/features/test/android_test_backend.dart
@@ -188,7 +188,15 @@ class AndroidTestBackend extends TestBackend {
       )
         ..disposedBy(scope);
       process.listenStdOut((l) => _logger.detail('\t: $l')).disposedBy(scope);
-      process.listenStdErr((l) => _logger.err('\t$l')).disposedBy(scope);
+      process.listenStdErr((l) {
+        const prefix = 'There were failing tests. ';
+        if (l.contains(prefix)) {
+          final msg = l.substring(prefix.length + 2);
+          _logger.err('\t$msg');
+        } else {
+          _logger.detail('\t$l');
+        }
+      }).disposedBy(scope);
 
       final exitCode = await process.exitCode;
       if (exitCode == 0) {

--- a/packages/patrol_cli/lib/src/features/update/update_command.dart
+++ b/packages/patrol_cli/lib/src/features/update/update_command.dart
@@ -19,7 +19,7 @@ class UpdateCommand extends Command<int> {
   String get name => 'update';
 
   @override
-  String get description => 'Updates the tool.';
+  String get description => 'Update the tool.';
 
   @override
   Future<int> run() async {


### PR DESCRIPTION
Inspired by @jBorkowska.