### PR TITLE
Disable showing software keyboard in enterText/enterTextByIndex()

### DIFF
--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -189,10 +189,7 @@ class Automator private constructor() {
 
         val uiSelector = UiSelector().className(EditText::class.java).instance(index)
         val uiObject = uiDevice.findObject(uiSelector)
-        uiObject.click()
         uiObject.text = text
-
-        pressBack() // Hide keyboard.
     }
 
     fun enterText(text: String, uiSelector: UiSelector, bySelector: BySelector, index: Int) {
@@ -203,10 +200,7 @@ class Automator private constructor() {
         }
 
         val uiObject = uiDevice.findObject(uiSelector).getFromParent(UiSelector().className(EditText::class.java))
-        uiObject.click()
         uiObject.text = text
-
-        pressBack() // Hide keyboard.
     }
 
     fun swipe(startX: Float, startY: Float, endX: Float, endY: Float, steps: Int) {


### PR DESCRIPTION
> This only affect `$.native.enterText()` and `$.native.enterTextByIndex()` methods.

The keyboard sometimes obscures a view. We don't have any `scrollTo()` equivalent in the `$.native` world, and it's impossible/very hard to reliably hide software keyboard in an Android UI test)

Removing showing software keyboard when entering text into text fields:

- Makes certain scenarios possible.

- We stray further from the real world. A real user always sees the software keyboard when entering some text.


I'm leaning toward merging this PR. We can come back to it once we have a reliable way

After all, Patrol's native features exist to unblock tests in native scenarios, and the software keyboard sometimes makes this goal impossible to achieve.


See also:
- #155
- #66

cc: @jBorkowska, @mateuszwojtczak