### PR TITLE
Fix error reports containing "Multiple errors were thrown" without any helpful information

### DIFF
--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolPlugin.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolPlugin.kt
@@ -10,6 +10,7 @@ class PatrolPlugin : FlutterPlugin, MethodCallHandler {
     private lateinit var channel: MethodChannel
 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        // This channel is currently not used
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "pl.leancode.patrol/main")
         channel.setMethodCallHandler(this)
     }

--- a/packages/patrol/example/integration_test/error_report_test.dart
+++ b/packages/patrol/example/integration_test/error_report_test.dart
@@ -7,6 +7,7 @@ void main() {
     await createApp($);
 
     await $(FloatingActionButton).tap();
+    expect($('1'), findsOneWidget);
   });
 
   patrol('bad report', ($) async {
@@ -14,5 +15,6 @@ void main() {
 
     await $(FloatingActionButton).tap();
     await $(FloatingActionButton).tap();
+    expect($('2'), findsOneWidget);
   });
 }

--- a/packages/patrol/example/integration_test/error_report_test.dart
+++ b/packages/patrol/example/integration_test/error_report_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+import 'common.dart';
+
+void main() {
+  patrol('good report', ($) async {
+    await createApp($);
+
+    await $(FloatingActionButton).tap();
+  });
+
+  patrol('bad report', ($) async {
+    await createApp($);
+
+    await $(FloatingActionButton).tap();
+    await $(FloatingActionButton).tap();
+  });
+}

--- a/packages/patrol/example/integration_test/error_report_test.dart
+++ b/packages/patrol/example/integration_test/error_report_test.dart
@@ -7,7 +7,6 @@ void main() {
     await createApp($);
 
     await $(FloatingActionButton).tap();
-    expect($('1'), findsOneWidget);
   });
 
   patrol('bad report', ($) async {
@@ -15,6 +14,5 @@ void main() {
 
     await $(FloatingActionButton).tap();
     await $(FloatingActionButton).tap();
-    expect($('2'), findsOneWidget);
   });
 }

--- a/packages/patrol/example/lib/main.dart
+++ b/packages/patrol/example/lib/main.dart
@@ -60,6 +60,7 @@ class _ExampleHomePageState extends State<ExampleHomePage> {
     setState(() {
       _counter = newValue;
     });
+    throw Exception('oopsie!');
   }
 
   void _decrementCounter([int value = 1]) {

--- a/packages/patrol/ios/Classes/SwiftPatrolPlugin.swift
+++ b/packages/patrol/ios/Classes/SwiftPatrolPlugin.swift
@@ -2,7 +2,7 @@ import Flutter
 import GRPC
 import UIKit
 
-let kChannelName = "pl.leancode.patrol/main"
+let kChannelName = "plugins.flutter.io/integration_test"
 let kMethodAllTestsFinished = "allTestsFinished"
 
 let kErrorCreateChannelFailed = "create_channel_failed"

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -15,12 +15,6 @@ void _defaultPrintLogger(String message) {
   }
 }
 
-// copied from package:integration_test/lib/integration_test.dart
-const bool _shouldReportResultsToNative = bool.fromEnvironment(
-  'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE',
-  defaultValue: true,
-);
-
 /// The method channel used to report the results of the tests to the underlying
 /// platform's testing framework.
 ///
@@ -35,24 +29,6 @@ const patrolChannel = MethodChannel('pl.leancode.patrol/main');
 class PatrolBinding extends IntegrationTestWidgetsFlutterBinding {
   /// Default constructor that only calls the superclass constructor.
   PatrolBinding() {
-    // Override FlutterError.onError to log all exceptions
-    final oldReporter = FlutterError.onError;
-    FlutterError.onError = (details) {
-      FlutterError.dumpErrorToConsole(details, forceReport: true);
-      oldReporter!(details);
-    };
-
-    final oldTestExceptionReporter = reportTestException;
-    reportTestException = (details, testDescription) {
-      // ignore: invalid_use_of_visible_for_testing_member
-      results[testDescription] = Failure(testDescription, details.toString());
-      oldTestExceptionReporter(details, testDescription);
-    };
-
-    if (!_shouldReportResultsToNative) {
-      return;
-    }
-
     tearDownAll(() async {
       try {
         if (!Platform.isIOS) {

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -4,8 +4,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/common.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:meta/meta.dart';
-import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
 
 // ignore: avoid_print
 void _defaultPrintLogger(String message) {
@@ -27,60 +25,8 @@ const patrolChannel = MethodChannel('plugins.flutter.io/integration_test');
 /// Binding that enables some of Patrol's custom functionality, such as tapping
 /// on WebViews during a test.
 class PatrolBinding extends IntegrationTestWidgetsFlutterBinding {
-  /// Returns an instance of the [PatrolBinding], creating and initializing it
-  /// if necessary.
-  factory PatrolBinding.ensureInitialized() {
-    if (_instance == null) {
-      PatrolBinding();
-    }
-    return _instance!;
-  }
-
   /// Default constructor that only calls the superclass constructor.
   PatrolBinding() {
-    // Override FlutterError.onError to log all exceptions
-    final oldReporter = FlutterError.onError;
-
-    setUp(() {
-      final name = Invoker.current?.liveTest.individualName;
-      print('DEBUG Starting test: $name');
-      _currentTestName = name;
-    });
-
-    tearDown(() {
-      final name = Invoker.current?.liveTest.individualName;
-      print('DEBUG Finishing test: $name');
-      _currentTestName = null;
-    });
-
-    FlutterError.onError = (details) {
-      final currentTestName = _currentTestName;
-      debugPrint('Exception caught during test: $currentTestName');
-      if (currentTestName == null) {
-        debugPrint(
-          'DEBUG FLutterError was thrown but current test name is null',
-        );
-        return;
-      }
-      testResults[currentTestName] = Failure(
-        'HELLO1 ${Invoker.current?.liveTest.individualName}',
-        'HELLO2 $details',
-      );
-
-      oldReporter!(details);
-    };
-
-    final oldTestExceptionReporter = reportTestException;
-    reportTestException = (details, testDescription) {
-      oldTestExceptionReporter(details, testDescription);
-
-      final previousResult = testResults[testDescription];
-      testResults[testDescription] = Failure(
-        'Name: $testDescription',
-        'Details: $details + $previousResult',
-      );
-    };
-
     tearDownAll(() async {
       try {
         // TODO: Migrate communication to gRPC
@@ -89,7 +35,7 @@ class PatrolBinding extends IntegrationTestWidgetsFlutterBinding {
           'allTestsFinished',
           <String, dynamic>{
             // ignore: invalid_use_of_visible_for_testing_member
-            'results': testResults.map<String, dynamic>((name, result) {
+            'results': results.map<String, dynamic>((name, result) {
               if (result is Failure) {
                 return MapEntry<String, dynamic>(name, result.details);
               }
@@ -108,7 +54,14 @@ Thrown by PatrolBinding.
     });
   }
 
-  String? _currentTestName;
+  /// Returns an instance of the [PatrolBinding], creating and initializing it
+  /// if necessary.
+  factory PatrolBinding.ensureInitialized() {
+    if (_instance == null) {
+      PatrolBinding();
+    }
+    return _instance!;
+  }
 
   final _logger = _defaultPrintLogger;
 
@@ -122,9 +75,6 @@ Thrown by PatrolBinding.
     _instance = this;
   }
 
-  @internal
-  Map<String, Object> testResults = <String, Object>{};
-
   /// The singleton instance of this object.
   ///
   /// Provides access to the features exposed by this class. The binding must be
@@ -132,6 +82,14 @@ Thrown by PatrolBinding.
   /// [PatrolBinding.ensureInitialized].
   static PatrolBinding get instance => BindingBase.checkInstance(_instance);
   static PatrolBinding? _instance;
+
+  @override
+  void reportExceptionNoticed(FlutterErrorDetails exception) {
+    debugPrint('Exception caught during test!!!\n'
+        'summary: ${exception.summary}}\n'
+        'context: ${exception.context}');
+    super.reportExceptionNoticed(exception);
+  }
 
   @override
   void attachRootWidget(Widget rootWidget) {

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -22,19 +20,25 @@ void _defaultPrintLogger(String message) {
 /// UIAutomator.
 ///
 /// On iOS, this is relevant when running UI tests with XCUITest.
-const patrolChannel = MethodChannel('pl.leancode.patrol/main');
+const patrolChannel = MethodChannel('plugins.flutter.io/integration_test');
 
 /// Binding that enables some of Patrol's custom functionality, such as tapping
 /// on WebViews during a test.
 class PatrolBinding extends IntegrationTestWidgetsFlutterBinding {
   /// Default constructor that only calls the superclass constructor.
   PatrolBinding() {
+    final oldTestExceptionReporter = reportTestException;
+    reportTestException = (details, testDescription) {
+      oldTestExceptionReporter(details, testDescription);
+      print('HERE HERE');
+      results[testDescription] = Failure(
+        'HELLO1 $testDescription',
+        'HELLO2 $details',
+      );
+    };
+
     tearDownAll(() async {
       try {
-        if (!Platform.isIOS) {
-          return;
-        }
-
         // TODO: Migrate communication to gRPC
         _logger('Sending Dart test results to the native side');
         await patrolChannel.invokeMethod<void>(

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -4,6 +4,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/common.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:meta/meta.dart';
+import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
 
 // ignore: avoid_print
 void _defaultPrintLogger(String message) {
@@ -25,8 +27,60 @@ const patrolChannel = MethodChannel('plugins.flutter.io/integration_test');
 /// Binding that enables some of Patrol's custom functionality, such as tapping
 /// on WebViews during a test.
 class PatrolBinding extends IntegrationTestWidgetsFlutterBinding {
+  /// Returns an instance of the [PatrolBinding], creating and initializing it
+  /// if necessary.
+  factory PatrolBinding.ensureInitialized() {
+    if (_instance == null) {
+      PatrolBinding();
+    }
+    return _instance!;
+  }
+
   /// Default constructor that only calls the superclass constructor.
   PatrolBinding() {
+    // Override FlutterError.onError to log all exceptions
+    final oldReporter = FlutterError.onError;
+
+    setUp(() {
+      final name = Invoker.current?.liveTest.individualName;
+      print('DEBUG Starting test: $name');
+      _currentTestName = name;
+    });
+
+    tearDown(() {
+      final name = Invoker.current?.liveTest.individualName;
+      print('DEBUG Finishing test: $name');
+      _currentTestName = null;
+    });
+
+    FlutterError.onError = (details) {
+      final currentTestName = _currentTestName;
+      debugPrint('Exception caught during test: $currentTestName');
+      if (currentTestName == null) {
+        debugPrint(
+          'DEBUG FLutterError was thrown but current test name is null',
+        );
+        return;
+      }
+      testResults[currentTestName] = Failure(
+        'HELLO1 ${Invoker.current?.liveTest.individualName}',
+        'HELLO2 $details',
+      );
+
+      oldReporter!(details);
+    };
+
+    final oldTestExceptionReporter = reportTestException;
+    reportTestException = (details, testDescription) {
+      oldTestExceptionReporter(details, testDescription);
+
+      final previousResult = testResults[testDescription];
+      testResults[testDescription] = Failure(
+        'Name: $testDescription',
+        'Details: $details + $previousResult',
+      );
+    };
+
     tearDownAll(() async {
       try {
         // TODO: Migrate communication to gRPC
@@ -35,7 +89,7 @@ class PatrolBinding extends IntegrationTestWidgetsFlutterBinding {
           'allTestsFinished',
           <String, dynamic>{
             // ignore: invalid_use_of_visible_for_testing_member
-            'results': results.map<String, dynamic>((name, result) {
+            'results': testResults.map<String, dynamic>((name, result) {
               if (result is Failure) {
                 return MapEntry<String, dynamic>(name, result.details);
               }
@@ -54,14 +108,7 @@ Thrown by PatrolBinding.
     });
   }
 
-  /// Returns an instance of the [PatrolBinding], creating and initializing it
-  /// if necessary.
-  factory PatrolBinding.ensureInitialized() {
-    if (_instance == null) {
-      PatrolBinding();
-    }
-    return _instance!;
-  }
+  String? _currentTestName;
 
   final _logger = _defaultPrintLogger;
 
@@ -75,6 +122,9 @@ Thrown by PatrolBinding.
     _instance = this;
   }
 
+  @internal
+  Map<String, Object> testResults = <String, Object>{};
+
   /// The singleton instance of this object.
   ///
   /// Provides access to the features exposed by this class. The binding must be
@@ -82,14 +132,6 @@ Thrown by PatrolBinding.
   /// [PatrolBinding.ensureInitialized].
   static PatrolBinding get instance => BindingBase.checkInstance(_instance);
   static PatrolBinding? _instance;
-
-  @override
-  void reportExceptionNoticed(FlutterErrorDetails exception) {
-    debugPrint('Exception caught during test!!!\n'
-        'summary: ${exception.summary}}\n'
-        'context: ${exception.context}');
-    super.reportExceptionNoticed(exception);
-  }
 
   @override
   void attachRootWidget(Widget rootWidget) {

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/common.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:meta/meta.dart';
+import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
 
 // ignore: avoid_print
 void _defaultPrintLogger(String message) {
@@ -26,23 +27,57 @@ const patrolChannel = MethodChannel('plugins.flutter.io/integration_test');
 /// Binding that enables some of Patrol's custom functionality, such as tapping
 /// on WebViews during a test.
 class PatrolBinding extends IntegrationTestWidgetsFlutterBinding {
+  /// Returns an instance of the [PatrolBinding], creating and initializing it
+  /// if necessary.
+  factory PatrolBinding.ensureInitialized() {
+    if (_instance == null) {
+      PatrolBinding();
+    }
+    return _instance!;
+  }
+
   /// Default constructor that only calls the superclass constructor.
   PatrolBinding() {
     // Override FlutterError.onError to log all exceptions
     final oldReporter = FlutterError.onError;
+
+    setUp(() {
+      final name = Invoker.current?.liveTest.individualName;
+      print('DEBUG Starting test: $name');
+      _currentTestName = name;
+    });
+
+    tearDown(() {
+      final name = Invoker.current?.liveTest.individualName;
+      print('DEBUG Finishing test: $name');
+      _currentTestName = null;
+    });
+
     FlutterError.onError = (details) {
-      testResults.
-      FlutterError.dumpErrorToConsole(details, forceReport: true);
+      final currentTestName = _currentTestName;
+      debugPrint('Exception caught during test: $currentTestName');
+      if (currentTestName == null) {
+        debugPrint(
+          'DEBUG FLutterError was thrown but current test name is null',
+        );
+        return;
+      }
+      testResults[currentTestName] = Failure(
+        'HELLO1 ${Invoker.current?.liveTest.individualName}',
+        'HELLO2 $details',
+      );
+
       oldReporter!(details);
     };
 
     final oldTestExceptionReporter = reportTestException;
     reportTestException = (details, testDescription) {
       oldTestExceptionReporter(details, testDescription);
-      print('HERE HERE');
-      results[testDescription] = Failure(
-        'HELLO1 $testDescription',
-        'HELLO2 $details',
+
+      final previousResult = testResults[testDescription];
+      testResults[testDescription] = Failure(
+        'Name: $testDescription',
+        'Details: $details + $previousResult',
       );
     };
 
@@ -73,14 +108,7 @@ Thrown by PatrolBinding.
     });
   }
 
-  /// Returns an instance of the [PatrolBinding], creating and initializing it
-  /// if necessary.
-  factory PatrolBinding.ensureInitialized() {
-    if (_instance == null) {
-      PatrolBinding();
-    }
-    return _instance!;
-  }
+  String? _currentTestName;
 
   final _logger = _defaultPrintLogger;
 

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -35,6 +35,13 @@ const patrolChannel = MethodChannel('pl.leancode.patrol/main');
 class PatrolBinding extends IntegrationTestWidgetsFlutterBinding {
   /// Default constructor that only calls the superclass constructor.
   PatrolBinding() {
+    // Override FlutterError.onError to log all exceptions
+    final oldReporter = FlutterError.onError;
+    FlutterError.onError = (details) {
+      FlutterError.dumpErrorToConsole(details, forceReport: true);
+      oldReporter!(details);
+    };
+
     final oldTestExceptionReporter = reportTestException;
     reportTestException = (details, testDescription) {
       // ignore: invalid_use_of_visible_for_testing_member

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -38,48 +38,17 @@ class PatrolBinding extends IntegrationTestWidgetsFlutterBinding {
 
   /// Default constructor that only calls the superclass constructor.
   PatrolBinding() {
-    // Override FlutterError.onError to log all exceptions
-    final oldReporter = FlutterError.onError;
-
     setUp(() {
       final name = Invoker.current?.liveTest.individualName;
       print('DEBUG Starting test: $name');
-      _currentTestName = name;
+      currentTestName = name;
     });
 
     tearDown(() {
       final name = Invoker.current?.liveTest.individualName;
       print('DEBUG Finishing test: $name');
-      _currentTestName = null;
+      currentTestName = null;
     });
-
-    FlutterError.onError = (details) {
-      final currentTestName = _currentTestName;
-      debugPrint('Exception caught during test: $currentTestName');
-      if (currentTestName == null) {
-        debugPrint(
-          'DEBUG FLutterError was thrown but current test name is null',
-        );
-        return;
-      }
-      testResults[currentTestName] = Failure(
-        'HELLO1 ${Invoker.current?.liveTest.individualName}',
-        'HELLO2 $details',
-      );
-
-      oldReporter!(details);
-    };
-
-    final oldTestExceptionReporter = reportTestException;
-    reportTestException = (details, testDescription) {
-      oldTestExceptionReporter(details, testDescription);
-
-      final previousResult = testResults[testDescription];
-      testResults[testDescription] = Failure(
-        'Name: $testDescription',
-        'Details: $details + $previousResult',
-      );
-    };
 
     tearDownAll(() async {
       try {
@@ -108,7 +77,8 @@ Thrown by PatrolBinding.
     });
   }
 
-  String? _currentTestName;
+  @internal
+  String? currentTestName;
 
   final _logger = _defaultPrintLogger;
 

--- a/packages/patrol_cli/lib/src/features/test/test_command.dart
+++ b/packages/patrol_cli/lib/src/features/test/test_command.dart
@@ -233,6 +233,7 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
       'PATROL_APP_BUNDLE_ID': bundleId,
       'PATROL_ANDROID_APP_NAME': pubspecConfig.android.appName,
       'PATROL_IOS_APP_NAME': pubspecConfig.ios.appName,
+      'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE': 'false',
     }.withNullsRemoved();
 
     final effectiveDartDefines = {...customDartDefines, ...internalDartDefines};


### PR DESCRIPTION
Attempt to fix #951

See also:
- [friendly tips on using `FlutterError.onError`](https://github.com/leancodepl/patrol/issues/922#issuecomment-1434813074)