### PR TITLE
Add `--uninstall/--no-uninstall` flag to Patrol CLI

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
-- Added `--no-uninstall` flag, which lets you not uninstall the apps after the
-  tests finish
+- Add `--no-uninstall` flag, which lets you not uninstall the apps after the
+  tests finish (#983)
 
 ## 1.0.2
 

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Added `--no-uninstall` flag, which lets you not uninstall the apps after the
+  tests finish
+
 ## 1.0.2
 
 - Make output of `patrol test` much less verbose when test fails on Android.

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.3
 
 - Add `--no-uninstall` flag, which lets you not uninstall the apps after the
   tests finish (#983)

--- a/packages/patrol_cli/lib/src/common/constants.dart
+++ b/packages/patrol_cli/lib/src/common/constants.dart
@@ -1,2 +1,2 @@
 /// Version of Patrol CLI. Must be kept in sync with pubspec.yaml.
-const version = '1.0.2';
+const version = '1.0.3';

--- a/packages/patrol_cli/lib/src/features/test/test_command.dart
+++ b/packages/patrol_cli/lib/src/features/test/test_command.dart
@@ -23,14 +23,17 @@ class TestCommandConfig with _$TestCommandConfig {
     required List<Device> devices,
     required List<String> targets,
     required String? flavor,
+    required Map<String, String> dartDefines,
+    required int repeat,
+    required bool displayLabel,
+    required bool uninstall,
+    // Android-only options
+    required String? packageName,
+    // iOS-only options
+    required String? bundleId,
     required String scheme,
     required String xcconfigFile,
     required String configuration,
-    required Map<String, String> dartDefines,
-    required String? packageName,
-    required String? bundleId,
-    required int repeat,
-    required bool displayLabel,
   }) = _TestCommandConfig;
 }
 
@@ -89,16 +92,6 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
         valueHelp: 'KEY=VALUE',
       )
       ..addOption(
-        'package-name',
-        help: 'Package name of the Android app under test.',
-        valueHelp: 'pl.leancode.awesomeapp',
-      )
-      ..addOption(
-        'bundle-id',
-        help: 'Bundle identifier of the iOS app under test.',
-        valueHelp: 'pl.leancode.AwesomeApp',
-      )
-      ..addOption(
         'wait',
         help: 'Seconds to wait after the test fails or succeeds.',
         defaultsTo: '0',
@@ -110,9 +103,26 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
         defaultsTo: '$_defaultRepeats',
       )
       ..addFlag(
+        'uninstall',
+        help: 'Whether to uninstall the apps after test finishes.',
+        defaultsTo: true,
+      )
+      ..addFlag(
         'label',
         help: 'Display the label over the application under test.',
         defaultsTo: true,
+      )
+      // Android-only options
+      ..addOption(
+        'package-name',
+        help: 'Package name of the Android app under test.',
+        valueHelp: 'pl.leancode.awesomeapp',
+      )
+      // iOS-only options
+      ..addOption(
+        'bundle-id',
+        help: 'Bundle identifier of the iOS app under test.',
+        valueHelp: 'pl.leancode.AwesomeApp',
       )
       ..addOption(
         'scheme',
@@ -206,6 +216,7 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
     }
 
     final displayLabel = argResults?['label'] as bool?;
+    final uninstall = argResults?['uninstall'] as bool?;
 
     if (repeat < 1) {
       throwToolExit('repeat count must not be smaller than 1');
@@ -254,6 +265,7 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
       bundleId: bundleId,
       repeat: repeat,
       displayLabel: displayLabel ?? true,
+      uninstall: uninstall ?? true,
     );
   }
 

--- a/packages/patrol_cli/lib/src/features/test/test_command.dart
+++ b/packages/patrol_cli/lib/src/features/test/test_command.dart
@@ -369,7 +369,7 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
           );
           action = () => _androidTestBackend.execute(options, device);
           final package = config.packageName;
-          if (package != null) {
+          if (package != null && config.uninstall) {
             finalizer = () => _androidTestBackend.uninstall(package, device);
           }
           break;
@@ -387,7 +387,7 @@ class TestCommand extends StagedCommand<TestCommandConfig> {
           );
           action = () async => _iosTestBackend.execute(options, device);
           final bundle = config.bundleId;
-          if (bundle != null) {
+          if (bundle != null && config.uninstall) {
             finalizer = () => _iosTestBackend.uninstall(bundle, device);
           }
       }

--- a/packages/patrol_cli/lib/src/features/test/test_command.freezed.dart
+++ b/packages/patrol_cli/lib/src/features/test/test_command.freezed.dart
@@ -19,14 +19,17 @@ mixin _$TestCommandConfig {
   List<Device> get devices => throw _privateConstructorUsedError;
   List<String> get targets => throw _privateConstructorUsedError;
   String? get flavor => throw _privateConstructorUsedError;
+  Map<String, String> get dartDefines => throw _privateConstructorUsedError;
+  int get repeat => throw _privateConstructorUsedError;
+  bool get displayLabel => throw _privateConstructorUsedError;
+  bool get uninstall =>
+      throw _privateConstructorUsedError; // Android-only options
+  String? get packageName =>
+      throw _privateConstructorUsedError; // iOS-only options
+  String? get bundleId => throw _privateConstructorUsedError;
   String get scheme => throw _privateConstructorUsedError;
   String get xcconfigFile => throw _privateConstructorUsedError;
   String get configuration => throw _privateConstructorUsedError;
-  Map<String, String> get dartDefines => throw _privateConstructorUsedError;
-  String? get packageName => throw _privateConstructorUsedError;
-  String? get bundleId => throw _privateConstructorUsedError;
-  int get repeat => throw _privateConstructorUsedError;
-  bool get displayLabel => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $TestCommandConfigCopyWith<TestCommandConfig> get copyWith =>
@@ -43,14 +46,15 @@ abstract class $TestCommandConfigCopyWith<$Res> {
       {List<Device> devices,
       List<String> targets,
       String? flavor,
-      String scheme,
-      String xcconfigFile,
-      String configuration,
       Map<String, String> dartDefines,
+      int repeat,
+      bool displayLabel,
+      bool uninstall,
       String? packageName,
       String? bundleId,
-      int repeat,
-      bool displayLabel});
+      String scheme,
+      String xcconfigFile,
+      String configuration});
 }
 
 /// @nodoc
@@ -69,14 +73,15 @@ class _$TestCommandConfigCopyWithImpl<$Res, $Val extends TestCommandConfig>
     Object? devices = null,
     Object? targets = null,
     Object? flavor = freezed,
+    Object? dartDefines = null,
+    Object? repeat = null,
+    Object? displayLabel = null,
+    Object? uninstall = null,
+    Object? packageName = freezed,
+    Object? bundleId = freezed,
     Object? scheme = null,
     Object? xcconfigFile = null,
     Object? configuration = null,
-    Object? dartDefines = null,
-    Object? packageName = freezed,
-    Object? bundleId = freezed,
-    Object? repeat = null,
-    Object? displayLabel = null,
   }) {
     return _then(_value.copyWith(
       devices: null == devices
@@ -91,6 +96,30 @@ class _$TestCommandConfigCopyWithImpl<$Res, $Val extends TestCommandConfig>
           ? _value.flavor
           : flavor // ignore: cast_nullable_to_non_nullable
               as String?,
+      dartDefines: null == dartDefines
+          ? _value.dartDefines
+          : dartDefines // ignore: cast_nullable_to_non_nullable
+              as Map<String, String>,
+      repeat: null == repeat
+          ? _value.repeat
+          : repeat // ignore: cast_nullable_to_non_nullable
+              as int,
+      displayLabel: null == displayLabel
+          ? _value.displayLabel
+          : displayLabel // ignore: cast_nullable_to_non_nullable
+              as bool,
+      uninstall: null == uninstall
+          ? _value.uninstall
+          : uninstall // ignore: cast_nullable_to_non_nullable
+              as bool,
+      packageName: freezed == packageName
+          ? _value.packageName
+          : packageName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      bundleId: freezed == bundleId
+          ? _value.bundleId
+          : bundleId // ignore: cast_nullable_to_non_nullable
+              as String?,
       scheme: null == scheme
           ? _value.scheme
           : scheme // ignore: cast_nullable_to_non_nullable
@@ -103,26 +132,6 @@ class _$TestCommandConfigCopyWithImpl<$Res, $Val extends TestCommandConfig>
           ? _value.configuration
           : configuration // ignore: cast_nullable_to_non_nullable
               as String,
-      dartDefines: null == dartDefines
-          ? _value.dartDefines
-          : dartDefines // ignore: cast_nullable_to_non_nullable
-              as Map<String, String>,
-      packageName: freezed == packageName
-          ? _value.packageName
-          : packageName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bundleId: freezed == bundleId
-          ? _value.bundleId
-          : bundleId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      repeat: null == repeat
-          ? _value.repeat
-          : repeat // ignore: cast_nullable_to_non_nullable
-              as int,
-      displayLabel: null == displayLabel
-          ? _value.displayLabel
-          : displayLabel // ignore: cast_nullable_to_non_nullable
-              as bool,
     ) as $Val);
   }
 }
@@ -139,14 +148,15 @@ abstract class _$$_TestCommandConfigCopyWith<$Res>
       {List<Device> devices,
       List<String> targets,
       String? flavor,
-      String scheme,
-      String xcconfigFile,
-      String configuration,
       Map<String, String> dartDefines,
+      int repeat,
+      bool displayLabel,
+      bool uninstall,
       String? packageName,
       String? bundleId,
-      int repeat,
-      bool displayLabel});
+      String scheme,
+      String xcconfigFile,
+      String configuration});
 }
 
 /// @nodoc
@@ -163,14 +173,15 @@ class __$$_TestCommandConfigCopyWithImpl<$Res>
     Object? devices = null,
     Object? targets = null,
     Object? flavor = freezed,
+    Object? dartDefines = null,
+    Object? repeat = null,
+    Object? displayLabel = null,
+    Object? uninstall = null,
+    Object? packageName = freezed,
+    Object? bundleId = freezed,
     Object? scheme = null,
     Object? xcconfigFile = null,
     Object? configuration = null,
-    Object? dartDefines = null,
-    Object? packageName = freezed,
-    Object? bundleId = freezed,
-    Object? repeat = null,
-    Object? displayLabel = null,
   }) {
     return _then(_$_TestCommandConfig(
       devices: null == devices
@@ -185,6 +196,30 @@ class __$$_TestCommandConfigCopyWithImpl<$Res>
           ? _value.flavor
           : flavor // ignore: cast_nullable_to_non_nullable
               as String?,
+      dartDefines: null == dartDefines
+          ? _value._dartDefines
+          : dartDefines // ignore: cast_nullable_to_non_nullable
+              as Map<String, String>,
+      repeat: null == repeat
+          ? _value.repeat
+          : repeat // ignore: cast_nullable_to_non_nullable
+              as int,
+      displayLabel: null == displayLabel
+          ? _value.displayLabel
+          : displayLabel // ignore: cast_nullable_to_non_nullable
+              as bool,
+      uninstall: null == uninstall
+          ? _value.uninstall
+          : uninstall // ignore: cast_nullable_to_non_nullable
+              as bool,
+      packageName: freezed == packageName
+          ? _value.packageName
+          : packageName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      bundleId: freezed == bundleId
+          ? _value.bundleId
+          : bundleId // ignore: cast_nullable_to_non_nullable
+              as String?,
       scheme: null == scheme
           ? _value.scheme
           : scheme // ignore: cast_nullable_to_non_nullable
@@ -197,26 +232,6 @@ class __$$_TestCommandConfigCopyWithImpl<$Res>
           ? _value.configuration
           : configuration // ignore: cast_nullable_to_non_nullable
               as String,
-      dartDefines: null == dartDefines
-          ? _value._dartDefines
-          : dartDefines // ignore: cast_nullable_to_non_nullable
-              as Map<String, String>,
-      packageName: freezed == packageName
-          ? _value.packageName
-          : packageName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bundleId: freezed == bundleId
-          ? _value.bundleId
-          : bundleId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      repeat: null == repeat
-          ? _value.repeat
-          : repeat // ignore: cast_nullable_to_non_nullable
-              as int,
-      displayLabel: null == displayLabel
-          ? _value.displayLabel
-          : displayLabel // ignore: cast_nullable_to_non_nullable
-              as bool,
     ));
   }
 }
@@ -228,14 +243,15 @@ class _$_TestCommandConfig implements _TestCommandConfig {
       {required final List<Device> devices,
       required final List<String> targets,
       required this.flavor,
-      required this.scheme,
-      required this.xcconfigFile,
-      required this.configuration,
       required final Map<String, String> dartDefines,
+      required this.repeat,
+      required this.displayLabel,
+      required this.uninstall,
       required this.packageName,
       required this.bundleId,
-      required this.repeat,
-      required this.displayLabel})
+      required this.scheme,
+      required this.xcconfigFile,
+      required this.configuration})
       : _devices = devices,
         _targets = targets,
         _dartDefines = dartDefines;
@@ -258,12 +274,6 @@ class _$_TestCommandConfig implements _TestCommandConfig {
 
   @override
   final String? flavor;
-  @override
-  final String scheme;
-  @override
-  final String xcconfigFile;
-  @override
-  final String configuration;
   final Map<String, String> _dartDefines;
   @override
   Map<String, String> get dartDefines {
@@ -273,17 +283,27 @@ class _$_TestCommandConfig implements _TestCommandConfig {
   }
 
   @override
-  final String? packageName;
-  @override
-  final String? bundleId;
-  @override
   final int repeat;
   @override
   final bool displayLabel;
+  @override
+  final bool uninstall;
+// Android-only options
+  @override
+  final String? packageName;
+// iOS-only options
+  @override
+  final String? bundleId;
+  @override
+  final String scheme;
+  @override
+  final String xcconfigFile;
+  @override
+  final String configuration;
 
   @override
   String toString() {
-    return 'TestCommandConfig(devices: $devices, targets: $targets, flavor: $flavor, scheme: $scheme, xcconfigFile: $xcconfigFile, configuration: $configuration, dartDefines: $dartDefines, packageName: $packageName, bundleId: $bundleId, repeat: $repeat, displayLabel: $displayLabel)';
+    return 'TestCommandConfig(devices: $devices, targets: $targets, flavor: $flavor, dartDefines: $dartDefines, repeat: $repeat, displayLabel: $displayLabel, uninstall: $uninstall, packageName: $packageName, bundleId: $bundleId, scheme: $scheme, xcconfigFile: $xcconfigFile, configuration: $configuration)';
   }
 
   @override
@@ -294,20 +314,22 @@ class _$_TestCommandConfig implements _TestCommandConfig {
             const DeepCollectionEquality().equals(other._devices, _devices) &&
             const DeepCollectionEquality().equals(other._targets, _targets) &&
             (identical(other.flavor, flavor) || other.flavor == flavor) &&
-            (identical(other.scheme, scheme) || other.scheme == scheme) &&
-            (identical(other.xcconfigFile, xcconfigFile) ||
-                other.xcconfigFile == xcconfigFile) &&
-            (identical(other.configuration, configuration) ||
-                other.configuration == configuration) &&
             const DeepCollectionEquality()
                 .equals(other._dartDefines, _dartDefines) &&
+            (identical(other.repeat, repeat) || other.repeat == repeat) &&
+            (identical(other.displayLabel, displayLabel) ||
+                other.displayLabel == displayLabel) &&
+            (identical(other.uninstall, uninstall) ||
+                other.uninstall == uninstall) &&
             (identical(other.packageName, packageName) ||
                 other.packageName == packageName) &&
             (identical(other.bundleId, bundleId) ||
                 other.bundleId == bundleId) &&
-            (identical(other.repeat, repeat) || other.repeat == repeat) &&
-            (identical(other.displayLabel, displayLabel) ||
-                other.displayLabel == displayLabel));
+            (identical(other.scheme, scheme) || other.scheme == scheme) &&
+            (identical(other.xcconfigFile, xcconfigFile) ||
+                other.xcconfigFile == xcconfigFile) &&
+            (identical(other.configuration, configuration) ||
+                other.configuration == configuration));
   }
 
   @override
@@ -316,14 +338,15 @@ class _$_TestCommandConfig implements _TestCommandConfig {
       const DeepCollectionEquality().hash(_devices),
       const DeepCollectionEquality().hash(_targets),
       flavor,
-      scheme,
-      xcconfigFile,
-      configuration,
       const DeepCollectionEquality().hash(_dartDefines),
+      repeat,
+      displayLabel,
+      uninstall,
       packageName,
       bundleId,
-      repeat,
-      displayLabel);
+      scheme,
+      xcconfigFile,
+      configuration);
 
   @JsonKey(ignore: true)
   @override
@@ -338,14 +361,15 @@ abstract class _TestCommandConfig implements TestCommandConfig {
       {required final List<Device> devices,
       required final List<String> targets,
       required final String? flavor,
-      required final String scheme,
-      required final String xcconfigFile,
-      required final String configuration,
       required final Map<String, String> dartDefines,
+      required final int repeat,
+      required final bool displayLabel,
+      required final bool uninstall,
       required final String? packageName,
       required final String? bundleId,
-      required final int repeat,
-      required final bool displayLabel}) = _$_TestCommandConfig;
+      required final String scheme,
+      required final String xcconfigFile,
+      required final String configuration}) = _$_TestCommandConfig;
 
   @override
   List<Device> get devices;
@@ -354,21 +378,23 @@ abstract class _TestCommandConfig implements TestCommandConfig {
   @override
   String? get flavor;
   @override
+  Map<String, String> get dartDefines;
+  @override
+  int get repeat;
+  @override
+  bool get displayLabel;
+  @override
+  bool get uninstall;
+  @override // Android-only options
+  String? get packageName;
+  @override // iOS-only options
+  String? get bundleId;
+  @override
   String get scheme;
   @override
   String get xcconfigFile;
   @override
   String get configuration;
-  @override
-  Map<String, String> get dartDefines;
-  @override
-  String? get packageName;
-  @override
-  String? get bundleId;
-  @override
-  int get repeat;
-  @override
-  bool get displayLabel;
   @override
   @JsonKey(ignore: true)
   _$$_TestCommandConfigCopyWith<_$_TestCommandConfig> get copyWith =>

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: patrol_cli
 description: >
   Command-line tool for Patrol, a powerful Flutter-native UI testing framework.
-version: 1.0.2 # Must be kept in sync with constants.dart
+version: 1.0.3 # Must be kept in sync with constants.dart
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues

--- a/packages/patrol_cli/test/features/test/test_command_test.dart
+++ b/packages/patrol_cli/test/features/test/test_command_test.dart
@@ -25,6 +25,7 @@ final _defaultConfig = TestCommandConfig(
   configuration: 'Debug',
   dartDefines: {'PATROL_WAIT': '0', 'PATROL_VERBOSE': 'false'},
   displayLabel: true,
+  uninstall: true,
   packageName: null,
   bundleId: null,
   repeat: 1,


### PR DESCRIPTION
This will make it easy to run the tests again, without uninstallation.

Direct incentive is to check out https://github.com/danielpaulus/go-ios/issues/224.