### PR TITLE
patrol: drop podspec platform version to 11

### DIFF
--- a/packages/patrol/ios/patrol.podspec
+++ b/packages/patrol/ios/patrol.podspec
@@ -18,12 +18,12 @@ Runs tests that use flutter_test and patrol APIs as native iOS integration tests
   s.dependency 'Flutter'
   s.weak_framework = 'XCTest'
   s.ios.framework  = 'UIKit'
-  s.platform = :ios, '13.0'
+  s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
-  
+
   s.dependency 'gRPC-Swift', '~> 1.8.0' # This is the last version published on CocoaPods.
                                         # Newer ones are only available on SPM.
 end


### PR DESCRIPTION
Fixes #999.

There doesn't seem to be a specific reason that 13 is required, and 11 allows a wider range of apps to use Patrol.