### PR TITLE
Fix `tap()` not being able to tap on widget previously found by `scrollTo()`

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Fix `tap()` sometimes not being able to tap on a widget that was previously
+  found and scrolled to by `scrollTo()` (#1072)
+
 ## 1.0.6
 
 - Add preliminary support for `patrol develop`. Requires version 1.0.6 of

--- a/packages/patrol/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_tester.dart
@@ -324,8 +324,8 @@ class PatrolTester {
     return TestAsyncUtils.guard(() async {
       final duration = timeout ?? config.visibleTimeout;
       final end = tester.binding.clock.now().add(duration);
-
-      while (finder.hitTestable().evaluate().isEmpty) {
+      final hitTestableFinder = finder.hitTestable();
+      while (hitTestableFinder.evaluate().isEmpty) {
         final now = tester.binding.clock.now();
         if (now.isAfter(end)) {
           throw WaitUntilVisibleTimeoutException(
@@ -337,7 +337,7 @@ class PatrolTester {
         await tester.pump(const Duration(milliseconds: 100));
       }
 
-      return PatrolFinder(finder: finder, tester: this);
+      return PatrolFinder(finder: hitTestableFinder, tester: this);
     });
   }
 
@@ -390,7 +390,7 @@ class PatrolTester {
         settleTimeout: config.settleTimeout,
       );
 
-      return PatrolFinder(finder: finder.first, tester: this);
+      return PatrolFinder(finder: finder, tester: this);
     });
   }
 
@@ -407,7 +407,7 @@ class PatrolTester {
   ///
   ///  * waits until [view] is visible
   ///
-  ///  * if the [view] finder finds more than 1 view, it scrolls the first one
+  ///  * if the [view] finder finds more than 1 widget, it scrolls the first one
   ///    instead of throwing a [StateError]
   ///
   ///  * uses [WidgetController.firstElement] instead of
@@ -439,7 +439,7 @@ class PatrolTester {
         settleTimeout: config.settleTimeout,
       );
 
-      return PatrolFinder(finder: finder.first, tester: this);
+      return PatrolFinder(finder: finder, tester: this);
     });
   }
 

--- a/packages/patrol/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_tester.dart
@@ -439,7 +439,7 @@ class PatrolTester {
         settleTimeout: config.settleTimeout,
       );
 
-      return PatrolFinder(finder: finder, tester: this);
+      return PatrolFinder(finder: finder.hitTestable().first, tester: this);
     });
   }
 

--- a/packages/patrol/test/patrol_tester_test.dart
+++ b/packages/patrol/test/patrol_tester_test.dart
@@ -640,6 +640,54 @@ void main() {
       );
     });
 
+    patrolTest(
+      'returns a finder matching the first widget that was dragged to',
+      (tester) async {
+        var count = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (context, setState) {
+                  return ListView(
+                    children: [
+                      Stack(
+                        children: [
+                          const Center(child: Text('Text')),
+                          Center(
+                            child: Container(
+                              width: 100,
+                              height: 100,
+                              color: Colors.blue,
+                            ),
+                          ),
+                        ],
+                      ),
+                      GestureDetector(
+                        onTap: () => setState(() => count++),
+                        child: const Text('Text'),
+                      ),
+                      const Text('Text'),
+                      Text('Count: $count'),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        final returnedFinder = await tester.dragUntilVisible(
+          finder: find.text('Text'),
+          view: find.byType(Scrollable),
+          moveStep: const Offset(0, 16),
+        );
+        await tester.tester.tap(returnedFinder); // tap without safety checks
+        await tester.pump();
+        expect(find.text('Count: 1'), findsOneWidget);
+      },
+    );
+
     group('scrollUntilExists()', () {
       patrolTest(
         'throws exception when no Scrollable is found within timeout',

--- a/packages/patrol/test/smoke_test.dart
+++ b/packages/patrol/test/smoke_test.dart
@@ -130,6 +130,46 @@ void main() {
       );
     },
   );
+
+  patrolTest('can tap() on widget scrolled to by scrollTo()', ($) async {
+    // Regression test for https://github.com/leancodepl/patrol/issues/1046
+
+    var count = 0;
+    await $.pumpWidgetAndSettle(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (context, setState) {
+              return ListView(
+                children: [
+                  Stack(
+                    children: [
+                      const Center(child: Text('Text')),
+                      Center(
+                        child: Container(
+                          width: 100,
+                          height: 100,
+                          color: Colors.blue,
+                        ),
+                      ),
+                    ],
+                  ),
+                  GestureDetector(
+                    onTap: () => setState(() => count++),
+                    child: const Text('Text'),
+                  ),
+                  Text('Count: $count'),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await $('Text').scrollTo().tap();
+    expect($('Count: 1'), findsOneWidget);
+  });
 }
 
 Future<void> smallPump(PatrolTester $) async {


### PR DESCRIPTION
Fixes #1046

Huge thank you to @jBorkowska for such an in-depth investigation of the issue!