### PR TITLE
Explicitly specify `appId` when running `flutter attach`

### DIFF
--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -203,9 +203,11 @@ class DevelopCommand extends PatrolCommand {
   }) async {
     Future<void> Function() action;
     Future<void> Function()? finalizer;
+    String? appId;
 
     switch (device.targetPlatform) {
       case TargetPlatform.android:
+        appId = android.packageName;
         action = () =>
             _androidTestBackend.execute(android, device, interruptible: true);
         final package = android.packageName;
@@ -214,6 +216,7 @@ class DevelopCommand extends PatrolCommand {
         }
         break;
       case TargetPlatform.iOS:
+        appId = ios.bundleId;
         action = () async =>
             _iosTestBackend.execute(ios, device, interruptible: true);
         final bundle = ios.bundleId;
@@ -230,6 +233,7 @@ class DevelopCommand extends PatrolCommand {
         _flutterTool.attach(
           deviceId: device.id,
           target: flutterOpts.target,
+          appId: appId,
           dartDefines: flutterOpts.dartDefines,
         )
       ]);

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -28,6 +28,7 @@ class FlutterTool {
   Future<void> attach({
     required String deviceId,
     required String target,
+    required String? appId,
     required Map<String, String> dartDefines,
   }) async {
     final process = await _processManager.start(
@@ -35,6 +36,7 @@ class FlutterTool {
         ...['flutter', 'attach'],
         '--no-version-check',
         '--debug',
+        if (appId != null) ...['--app-id', appId],
         ...['--target', target],
         for (final dartDefine in dartDefines.entries) ...[
           '--dart-define',


### PR DESCRIPTION
I hoped this could fix #1059, but it didn't. Anyway, it won't hurt.