### PR TITLE
Fix `patrol test`/`patrol develop` being stuck on app installation when `adb` is not in $PATH

### DIFF
--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -247,7 +247,12 @@ class DevelopCommand extends PatrolCommand {
         ..err(defaultFailureMessage);
       rethrow;
     } finally {
-      await finalizer?.call();
+      try {
+        await finalizer?.call();
+      } catch (err) {
+        _logger.err('Failed to call finalizer: $err');
+        rethrow;
+      }
     }
   }
 }

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -278,7 +278,12 @@ class TestCommand extends PatrolCommand {
           ..err(defaultFailureMessage);
         rethrow;
       } finally {
-        await finalizer?.call();
+        try {
+          await finalizer?.call();
+        } catch (err) {
+          _logger.err('Failed to call finalizer: $err');
+          rethrow;
+        }
       }
     };
   }

--- a/packages/patrol_cli/pubspec.lock
+++ b/packages/patrol_cli/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: "direct main"
     description:
       name: adb
-      sha256: "8a1c7ada5bc1d04e64e6c46f51048fb322b588131aa9138e104c21d0516274bd"
+      sha256: d1723247d7c0bb9fe57e531fd3e4e6c685152dd1f75241183f33a754a0cc10ea
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.4"
+    version: "0.2.5"
   analyzer:
     dependency: transitive
     description:

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  adb: ^0.2.4
+  adb: ^0.2.5
   ansi_styles: ^0.3.2
   args: ^2.4.0
   cli_completion: ^0.3.0


### PR DESCRIPTION
This PR fixes #1115.
