### PR TITLE
show Patrol config in pubspec.yaml in `patrol doctor`

### DIFF
--- a/packages/patrol_cli/lib/src/commands/doctor.dart
+++ b/packages/patrol_cli/lib/src/commands/doctor.dart
@@ -3,18 +3,23 @@ import 'dart:io' as io;
 import 'package:patrol_cli/src/base/constants.dart';
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/base/process.dart';
+import 'package:patrol_cli/src/pubspec_reader.dart';
 import 'package:patrol_cli/src/runner/patrol_command.dart';
 import 'package:platform/platform.dart';
 
 class DoctorCommand extends PatrolCommand {
   DoctorCommand({
-    required Logger logger,
+    required PubspecReader pubspecReader,
     required Platform platform,
-  })  : _logger = logger,
-        _platform = platform;
+    required Logger logger,
+  })  : _pubspecReader = pubspecReader,
+        _platform = platform,
+        _logger = logger;
+
+  final PubspecReader _pubspecReader;
+  final Platform _platform;
 
   final Logger _logger;
-  final Platform _platform;
 
   @override
   String get name => 'doctor';
@@ -30,6 +35,8 @@ class DoctorCommand extends PatrolCommand {
     if (_platform.isMacOS) {
       _printIosSpecifics();
     }
+
+    _printProjectSpecifics();
 
     return 0;
   }
@@ -66,5 +73,19 @@ class DoctorCommand extends PatrolCommand {
         'Program $tool not found ${hint != null ? "(install with `$hint`)" : ""}',
       );
     }
+  }
+
+  void _printProjectSpecifics() {
+    final pubspecConfig = _pubspecReader.read();
+    _logger
+      ..info('Patrol configuration in pubspec.yaml:')
+      ..info('  Android')
+      ..info('    package_name: ${pubspecConfig.android.packageName}')
+      ..info('    app_name: ${pubspecConfig.android.appName}')
+      ..info('    flavor: ${pubspecConfig.android.flavor}')
+      ..info('  IOS')
+      ..info('    bundle_id: ${pubspecConfig.ios.bundleId}')
+      ..info('    app_name: ${pubspecConfig.ios.appName}')
+      ..info('    flavor: ${pubspecConfig.ios.flavor}');
   }
 }

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -5,6 +5,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:cli_completion/cli_completion.dart';
 import 'package:dispose_scope/dispose_scope.dart';
+import 'package:equatable/equatable.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:patrol_cli/src/android/android_test_backend.dart';
@@ -31,6 +32,7 @@ import 'package:process/process.dart';
 import 'package:pub_updater/pub_updater.dart';
 
 Future<int> patrolCommandRunner(List<String> args) async {
+  EquatableConfig.stringify = true;
   final logger = Logger();
   final runner = PatrolCommandRunner(logger: logger);
 
@@ -160,8 +162,9 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
     );
     addCommand(
       DoctorCommand(
-        logger: _logger,
+        pubspecReader: PubspecReader(projectRoot: _fs.currentDirectory),
         platform: _platform,
+        logger: _logger,
       ),
     );
     addCommand(UpdateCommand(logger: _logger, pubUpdater: _pubUpdater));


### PR DESCRIPTION
New output:

```console
$ patrol doctor
Patrol CLI version: 1.1.2
Program adb found in /Users/bartek/androidsdk/platform-tools/adb
Env var $ANDROID_HOME set to /Users/bartek/androidsdk
Program xcodebuild found in /usr/bin/xcodebuild
Program ideviceinstaller found in /opt/homebrew/bin/ideviceinstaller
Program ios-deploy found in /opt/homebrew/bin/ios-deploy
Patrol configuration in pubspec.yaml:
  Android
    package_name: pl.leancode.patrol.example
    app_name: Patrol example
    flavor: null
  IOS
    bundle_id: pl.leancode.patrol.Example
    app_name: Patrol example
    flavor: null
```

Should help in triage.