### PR TITLE
Add analytics

### DIFF
--- a/packages/patrol_cli/lib/src/commands/build.dart
+++ b/packages/patrol_cli/lib/src/commands/build.dart
@@ -7,6 +7,7 @@ import 'package:patrol_cli/src/ios/ios_test_backend.dart';
 import 'package:patrol_cli/src/pubspec_reader.dart';
 import 'package:patrol_cli/src/runner/patrol_command.dart';
 import 'package:patrol_cli/src/test_finder.dart';
+import 'package:usage/usage.dart';
 
 class BuildCommand extends PatrolCommand {
   BuildCommand({
@@ -15,6 +16,7 @@ class BuildCommand extends PatrolCommand {
     required PubspecReader pubspecReader,
     required AndroidTestBackend androidTestBackend,
     required IOSTestBackend iosTestBackend,
+    required Analytics analytics,
     required Logger logger,
   }) {
     addSubcommand(
@@ -23,6 +25,7 @@ class BuildCommand extends PatrolCommand {
         dartDefinesReader: dartDefinesReader,
         pubspecReader: pubspecReader,
         androidTestBackend: androidTestBackend,
+        analytics: analytics,
         logger: logger,
       ),
     );
@@ -32,6 +35,7 @@ class BuildCommand extends PatrolCommand {
         dartDefinesReader: dartDefinesReader,
         pubspecReader: pubspecReader,
         iosTestBackend: iosTestBackend,
+        analytics: analytics,
         logger: logger,
       ),
     );

--- a/packages/patrol_cli/lib/src/commands/build_android.dart
+++ b/packages/patrol_cli/lib/src/commands/build_android.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:path/path.dart' show basename;
 import 'package:patrol_cli/src/android/android_test_backend.dart';
 import 'package:patrol_cli/src/base/exceptions.dart';
@@ -8,6 +10,7 @@ import 'package:patrol_cli/src/dart_defines_reader.dart';
 import 'package:patrol_cli/src/pubspec_reader.dart';
 import 'package:patrol_cli/src/runner/patrol_command.dart';
 import 'package:patrol_cli/src/test_finder.dart';
+import 'package:usage/usage.dart';
 
 class BuildAndroidCommand extends PatrolCommand {
   BuildAndroidCommand({
@@ -15,11 +18,13 @@ class BuildAndroidCommand extends PatrolCommand {
     required DartDefinesReader dartDefinesReader,
     required PubspecReader pubspecReader,
     required AndroidTestBackend androidTestBackend,
+    required Analytics analytics,
     required Logger logger,
   })  : _testFinder = testFinder,
         _dartDefinesReader = dartDefinesReader,
         _pubspecReader = pubspecReader,
         _androidTestBackend = androidTestBackend,
+        _analytics = analytics,
         _logger = logger {
     usesTargetOption();
     usesBuildModeOption();
@@ -36,6 +41,7 @@ class BuildAndroidCommand extends PatrolCommand {
   final PubspecReader _pubspecReader;
   final AndroidTestBackend _androidTestBackend;
 
+  final Analytics _analytics;
   final Logger _logger;
 
   @override
@@ -49,6 +55,8 @@ class BuildAndroidCommand extends PatrolCommand {
 
   @override
   Future<int> run() async {
+    unawaited(_analytics.sendEvent('command', 'build android'));
+
     final targetArg = stringsArg('target');
     if (targetArg.isEmpty) {
       throwToolExit('No test target specified');

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:path/path.dart' show basename, join;
 import 'package:patrol_cli/src/base/exceptions.dart';
 import 'package:patrol_cli/src/base/extensions/core.dart';
@@ -8,6 +10,7 @@ import 'package:patrol_cli/src/ios/ios_test_backend.dart';
 import 'package:patrol_cli/src/pubspec_reader.dart';
 import 'package:patrol_cli/src/runner/patrol_command.dart';
 import 'package:patrol_cli/src/test_finder.dart';
+import 'package:usage/usage.dart';
 
 class BuildIOSCommand extends PatrolCommand {
   BuildIOSCommand({
@@ -15,11 +18,13 @@ class BuildIOSCommand extends PatrolCommand {
     required DartDefinesReader dartDefinesReader,
     required PubspecReader pubspecReader,
     required IOSTestBackend iosTestBackend,
+    required Analytics analytics,
     required Logger logger,
   })  : _testFinder = testFinder,
         _dartDefinesReader = dartDefinesReader,
         _pubspecReader = pubspecReader,
         _iosTestBackend = iosTestBackend,
+        _analytics = analytics,
         _logger = logger {
     usesTargetOption();
     usesBuildModeOption();
@@ -40,6 +45,7 @@ class BuildIOSCommand extends PatrolCommand {
   final PubspecReader _pubspecReader;
   final IOSTestBackend _iosTestBackend;
 
+  final Analytics _analytics;
   final Logger _logger;
 
   @override
@@ -53,6 +59,8 @@ class BuildIOSCommand extends PatrolCommand {
 
   @override
   Future<int> run() async {
+    unawaited(_analytics.sendEvent('command', 'build ios'));
+
     final targetArg = stringsArg('target');
     if (targetArg.isEmpty) {
       throwToolExit('No test target specified');

--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -16,6 +16,7 @@ import 'package:patrol_cli/src/pubspec_reader.dart';
 import 'package:patrol_cli/src/runner/patrol_command.dart';
 import 'package:patrol_cli/src/test_finder.dart';
 import 'package:patrol_cli/src/test_runner.dart';
+import 'package:usage/usage.dart';
 
 class DevelopCommand extends PatrolCommand {
   DevelopCommand({
@@ -27,6 +28,7 @@ class DevelopCommand extends PatrolCommand {
     required AndroidTestBackend androidTestBackend,
     required IOSTestBackend iosTestBackend,
     required FlutterTool flutterTool,
+    required Analytics analytics,
     required DisposeScope parentDisposeScope,
     required Logger logger,
   })  : _deviceFinder = deviceFinder,
@@ -37,6 +39,7 @@ class DevelopCommand extends PatrolCommand {
         _androidTestBackend = androidTestBackend,
         _iosTestBackend = iosTestBackend,
         _flutterTool = flutterTool,
+        _analytics = analytics,
         _logger = logger {
     _testRunner.disposedBy(parentDisposeScope);
 
@@ -63,6 +66,7 @@ class DevelopCommand extends PatrolCommand {
   final IOSTestBackend _iosTestBackend;
   final FlutterTool _flutterTool;
 
+  final Analytics _analytics;
   final Logger _logger;
 
   @override
@@ -73,6 +77,8 @@ class DevelopCommand extends PatrolCommand {
 
   @override
   Future<int> run() async {
+    unawaited(_analytics.sendEvent('command', name));
+
     final targets = stringsArg('target');
     if (targets.isEmpty) {
       throwToolExit('No target provided with --target');

--- a/packages/patrol_cli/lib/src/commands/devices.dart
+++ b/packages/patrol_cli/lib/src/commands/devices.dart
@@ -3,8 +3,10 @@ import 'package:patrol_cli/src/devices.dart';
 import 'package:patrol_cli/src/runner/patrol_command.dart';
 
 class DevicesCommand extends PatrolCommand {
-  DevicesCommand({required DeviceFinder deviceFinder, required Logger logger})
-      : _deviceFinder = deviceFinder,
+  DevicesCommand({
+    required DeviceFinder deviceFinder,
+    required Logger logger,
+  })  : _deviceFinder = deviceFinder,
         _logger = logger;
 
   final DeviceFinder _deviceFinder;

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -15,6 +15,7 @@ import 'package:patrol_cli/src/pubspec_reader.dart';
 import 'package:patrol_cli/src/runner/patrol_command.dart';
 import 'package:patrol_cli/src/test_finder.dart';
 import 'package:patrol_cli/src/test_runner.dart';
+import 'package:usage/usage.dart';
 
 // Note: this class is a bit sphagetti because I didn't model classes to handle
 // multiple targets. This problem will go away when #1004 is done.
@@ -49,6 +50,7 @@ class TestCommand extends PatrolCommand {
     required AndroidTestBackend androidTestBackend,
     required IOSTestBackend iosTestBackend,
     required DisposeScope parentDisposeScope,
+    required Analytics analytics,
     required Logger logger,
   })  : _deviceFinder = deviceFinder,
         _testFinder = testFinder,
@@ -57,6 +59,7 @@ class TestCommand extends PatrolCommand {
         _pubspecReader = pubspecReader,
         _androidTestBackend = androidTestBackend,
         _iosTestBackend = iosTestBackend,
+        _analytics = analytics,
         _logger = logger {
     _testRunner.disposedBy(parentDisposeScope);
 
@@ -83,6 +86,7 @@ class TestCommand extends PatrolCommand {
   final AndroidTestBackend _androidTestBackend;
   final IOSTestBackend _iosTestBackend;
 
+  final Analytics _analytics;
   final Logger _logger;
 
   @override
@@ -93,6 +97,8 @@ class TestCommand extends PatrolCommand {
 
   @override
   Future<int> run() async {
+    unawaited(_analytics.sendEvent('command', name));
+
     final target = stringsArg('target');
     final targets = target.isNotEmpty
         ? _testFinder.findTests(target)

--- a/packages/patrol_cli/lib/src/commands/update.dart
+++ b/packages/patrol_cli/lib/src/commands/update.dart
@@ -1,16 +1,23 @@
+import 'dart:async';
+
 import 'package:patrol_cli/src/base/constants.dart';
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/runner/patrol_command.dart';
 import 'package:pub_updater/pub_updater.dart';
+import 'package:usage/usage.dart';
 
 class UpdateCommand extends PatrolCommand {
   UpdateCommand({
     required PubUpdater pubUpdater,
+    required Analytics analytics,
     required Logger logger,
   })  : _pubUpdater = pubUpdater,
+        _analytics = analytics,
         _logger = logger;
 
   final PubUpdater _pubUpdater;
+
+  final Analytics _analytics;
   final Logger _logger;
 
   static const _pkg = 'patrol_cli';
@@ -23,6 +30,8 @@ class UpdateCommand extends PatrolCommand {
 
   @override
   Future<int> run() async {
+    unawaited(_analytics.sendEvent('command', name));
+
     Progress progress;
 
     progress = _logger.progress('Checking if newer $_pkg version is available');

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -56,7 +56,7 @@ Future<int> patrolCommandRunner(List<String> args) async {
 }
 
 // The Google Analytics tracking ID.
-const _gaTrackingId = 'UA-117465969-4'; // FIXME: Use the correct tracking ID
+const _gaTrackingId = 'UA-144186929-3'; // FIXME: Use the correct tracking ID
 
 // The Google Analytics Application Name.
 const _gaAppName = 'patrol-cli';
@@ -92,8 +92,6 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
           'patrol',
           'Tool for running Flutter-native UI tests with superpowers',
         ) {
-    _analytics.sendEvent('some_category', 'run');
-
     final androidTestBackend = AndroidTestBackend(
       adb: Adb(),
       processManager: _processManager,

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -236,26 +236,7 @@ Ask questions, get support at https://github.com/leancodepl/patrol/discussions''
 
     var exitCode = 1;
     try {
-      if (_analytics.firstRun) {
-        final trackingResponse = _logger.prompt(
-          '''
-+---------------------------------------------------+
-|             Patrol - Ready for action!            |
-+---------------------------------------------------+
-| We would like to collect anonymous usage data     |
-| to improve Patrol CLI. Would you like to opt-in   |
-| to help us improve? [y/N]                         |
-+---------------------------------------------------+\n''',
-        );
-        final response = trackingResponse.toLowerCase().trim();
-        final analyticsEnabled = response == 'y' || response == 'yes';
-        if (analyticsEnabled) {
-          _logger.info('Analytics enabled. Thank you!');
-          _analytics.enabled = response == 'y' || response == 'yes';
-        } else {
-          _logger.info('Analytics disabled.');
-        }
-      }
+      _handleAnalytics();
 
       final topLevelResults = parse(args);
       verbose = topLevelResults['verbose'] == true;
@@ -328,6 +309,30 @@ Ask questions, get support at https://github.com/leancodepl/patrol/discussions''
 
   @override
   void printUsage() => _logger.info(usage);
+
+  void _handleAnalytics() {
+    if (_analytics.firstRun) {
+      _logger.info(
+        '''
+\n
++---------------------------------------------------+
+|             Patrol - Ready for action!            |
++---------------------------------------------------+
+| We would like to collect anonymous usage data     |
+| to improve Patrol CLI. No sensitive or private    |
+| information will ever leave your machine.         |
++---------------------------------------------------+
+\n''',
+      );
+      final analyticsEnabled = _logger.confirm('Enable analytics?');
+      if (analyticsEnabled) {
+        _logger.info('Analytics enabled. Thank you!');
+        _analytics.enabled = true;
+      } else {
+        _logger.info('Analytics disabled.');
+      }
+    }
+  }
 
   bool _wantsUpdateCheck(String? commandName) {
     if (commandName == 'update' || commandName == 'doctor') {

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -121,6 +121,7 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
         pubspecReader: PubspecReader(projectRoot: _fs.currentDirectory),
         androidTestBackend: androidTestBackend,
         iosTestBackend: iosTestBackend,
+        analytics: _analytics,
         logger: _logger,
       ),
     );
@@ -185,7 +186,13 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
         platform: _platform,
       ),
     );
-    addCommand(UpdateCommand(logger: _logger, pubUpdater: _pubUpdater));
+    addCommand(
+      UpdateCommand(
+        pubUpdater: _pubUpdater,
+        analytics: _analytics,
+        logger: _logger,
+      ),
+    );
 
     argParser
       ..addFlag(

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -56,7 +56,7 @@ Future<int> patrolCommandRunner(List<String> args) async {
 }
 
 // The Google Analytics tracking ID.
-const _gaTrackingId = 'UA-117465969-4';
+const _gaTrackingId = 'UA-117465969-4'; // FIXME: Use the correct tracking ID
 
 // The Google Analytics Application Name.
 const _gaAppName = 'patrol-cli';
@@ -138,16 +138,17 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
         testRunner: TestRunner(),
         dartDefinesReader: DartDefinesReader(projectRoot: _fs.currentDirectory),
         pubspecReader: PubspecReader(projectRoot: _fs.currentDirectory),
-        androidTestBackend: androidTestBackend,
-        iosTestBackend: iosTestBackend,
-        parentDisposeScope: _disposeScope,
-        logger: _logger,
         flutterTool: FlutterTool(
           stdin: stdin,
           processManager: _processManager,
           parentDisposeScope: _disposeScope,
           logger: _logger,
         ),
+        androidTestBackend: androidTestBackend,
+        iosTestBackend: iosTestBackend,
+        parentDisposeScope: _disposeScope,
+        analytics: _analytics,
+        logger: _logger,
       ),
     );
 
@@ -165,6 +166,7 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
         androidTestBackend: androidTestBackend,
         iosTestBackend: iosTestBackend,
         parentDisposeScope: _disposeScope,
+        analytics: _analytics,
         logger: _logger,
       ),
     );
@@ -236,19 +238,23 @@ Ask questions, get support at https://github.com/leancodepl/patrol/discussions''
     try {
       if (_analytics.firstRun) {
         final trackingResponse = _logger.prompt(
-          red.wrap(
-            '''
+          '''
 +---------------------------------------------------+
 |             Patrol - Ready for action!            |
 +---------------------------------------------------+
 | We would like to collect anonymous usage data     |
-| to improve the tool. Would you like to opt-in to  |
-| help us improve? [y/N]                            |
+| to improve Patrol CLI. Would you like to opt-in   |
+| to help us improve? [y/N]                         |
 +---------------------------------------------------+\n''',
-          ),
         );
         final response = trackingResponse.toLowerCase().trim();
-        _analytics.enabled = response == 'y' || response == 'yes';
+        final analyticsEnabled = response == 'y' || response == 'yes';
+        if (analyticsEnabled) {
+          _logger.info('Analytics enabled. Thank you!');
+          _analytics.enabled = response == 'y' || response == 'yes';
+        } else {
+          _logger.info('Analytics disabled.');
+        }
       }
 
       final topLevelResults = parse(args);

--- a/packages/patrol_cli/pubspec.lock
+++ b/packages/patrol_cli/pubspec.lock
@@ -617,6 +617,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  usage:
+    dependency: "direct main"
+    description:
+      name: usage
+      sha256: ccc861ca619157046d961a1d7fa21a364476c574bb8f3e90219e41b9103adee0
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   vm_service:
     dependency: transitive
     description:

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   process: ^4.2.4
   pub_updater: ^0.2.4
   tuple: ^2.0.1
+  usage: ^4.1.0
   yaml: ^3.1.1
 dev_dependencies:
   build_runner: ^2.3.3

--- a/packages/patrol_cli/test/commands/update_test.dart
+++ b/packages/patrol_cli/test/commands/update_test.dart
@@ -1,3 +1,4 @@
+import 'package:file/memory.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:patrol_cli/src/base/constants.dart';
 import 'package:patrol_cli/src/base/logger.dart';
@@ -27,6 +28,7 @@ void main() {
       commandRunner = PatrolCommandRunner(
         logger: logger,
         pubUpdater: pubUpdater,
+        fs: MemoryFileSystem.test(),
       );
     });
 


### PR DESCRIPTION
This PR resolves https://github.com/leancodepl/patrol-internal/issues/22

[`package:usage` doesn't support GA4](https://github.com/dart-lang/usage/issues/185). It uses the older Universal Analytics instead, which is shutting down on June 1st, 2023.


`flutter_tools` is using `package:usage` as well, but if they don't manage to upgrade this package on time, I'm pretty sure they'll get 1 year extension, which we most probably won't.