### PR TITLE
Rewrite native test reporting to be simpler and consistent across platforms

### DIFF
--- a/packages/patrol/android/build.gradle
+++ b/packages/patrol/android/build.gradle
@@ -51,7 +51,7 @@ android {
     }
 
     defaultConfig {
-        minSdk 16
+        minSdk 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
@@ -16,8 +16,11 @@ import pl.leancode.patrol.contracts.permissionDialogVisibleResponse
 
 typealias Empty = Contracts.Empty
 
-class AutomatorServer : NativeAutomatorGrpcKt.NativeAutomatorCoroutineImplBase() {
-    private val automation = Automator.instance
+class AutomatorServer(
+    private val automation: Automator,
+    private val onTestResultsSubmitted: (Map<String, String>) -> Unit
+) :
+    NativeAutomatorGrpcKt.NativeAutomatorCoroutineImplBase() {
 
     override suspend fun configure(request: Contracts.ConfigureRequest): Empty {
         automation.configure(waitForSelectorTimeout = request.findTimeoutMillis)
@@ -202,5 +205,10 @@ class AutomatorServer : NativeAutomatorGrpcKt.NativeAutomatorCoroutineImplBase()
             else -> throw PatrolException("tapOnNotification(): neither index nor selector are set")
         }
         return empty { }
+    }
+
+    override suspend fun submitTestResults(request: Contracts.SubmitTestResultsRequest): Empty {
+        onTestResultsSubmitted(request.resultsMap)
+        return empty {}
     }
 }

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolPlugin.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolPlugin.kt
@@ -15,12 +15,7 @@ class PatrolPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
-        if (call.method == "allTestsFinished") {
-            // On Android, we're using the default integration_test plugin
-            result.notImplemented()
-        } else {
-            result.notImplemented()
-        }
+        result.notImplemented()
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolServer.kt
@@ -15,7 +15,11 @@ class PatrolServer {
         server = OkHttpServerBuilder
             .forPort(port, InsecureServerCredentials.create())
             .intercept(LoggerInterceptor())
-            .addService(AutomatorServer())
+            .addService(
+                AutomatorServer(
+                    automation = Automator.instance,
+                    onTestResultsSubmitted = { testResults = it })
+            )
             .build()
     }
 
@@ -37,5 +41,9 @@ class PatrolServer {
 
     fun blockUntilShutdown() {
         server?.awaitTermination()
+    }
+
+    companion object {
+        lateinit var testResults: Map<String, String>
     }
 }

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolServer.kt
@@ -1,6 +1,7 @@
 package pl.leancode.patrol
 
 import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.util.concurrent.SettableFuture
 import io.grpc.InsecureServerCredentials
 import io.grpc.Server
 import io.grpc.okhttp.OkHttpServerBuilder
@@ -18,7 +19,8 @@ class PatrolServer {
             .addService(
                 AutomatorServer(
                     automation = Automator.instance,
-                    onTestResultsSubmitted = { testResults = it })
+                    onTestResultsSubmitted = { testResulsSettable.set(it) }
+                )
             )
             .build()
     }
@@ -44,6 +46,10 @@ class PatrolServer {
     }
 
     companion object {
-        lateinit var testResults: Map<String, String>
+        private val testResulsSettable: SettableFuture<DartTestResults> = SettableFuture.create()
+        val testResults
+            get() = testResulsSettable
     }
 }
+
+typealias DartTestResults = Map<String, String>

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolTestRunner.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolTestRunner.kt
@@ -5,11 +5,12 @@ import androidx.test.rule.ActivityTestRule
 import org.junit.Rule
 import org.junit.rules.TestRule
 import org.junit.runner.Description
+import org.junit.runner.Runner
 import org.junit.runner.notification.Failure
 import org.junit.runner.notification.RunNotifier
 import java.util.concurrent.ExecutionException
 
-class PatrolTestRunner(private val testClass: Class<*>) {
+class PatrolTestRunner(private val testClass: Class<*>) : Runner() {
     private val tag = "PatrolTestRunner"
 
     var rule: TestRule? = null
@@ -57,16 +58,16 @@ class PatrolTestRunner(private val testClass: Class<*>) {
             )
         }
 
-        var results: Map<String, String>? = null
-        results = try {
-            // IntegrationTestPlugin.testResults.get()
-            // Start from here:
-            PatrolServer.testResults
+        val results = try {
+            PatrolServer.testResults.get() // Wait for test results asynchronously
         } catch (e: ExecutionException) {
             throw IllegalThreadStateException("Unable to get test results")
         } catch (e: InterruptedException) {
             throw IllegalThreadStateException("Unable to get test results")
+        } catch (e: Exception) {
+            throw e // We don't know yet what to do with it now, so just rethrow it
         }
+
         for (name in results.keys) {
             val d = Description.createTestDescription(testClass, name)
             notifier.fireTestStarted(d)

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolTestRunner.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolTestRunner.kt
@@ -1,5 +1,81 @@
 package pl.leancode.patrol
 
-import dev.flutter.plugins.integration_test.FlutterTestRunner
+import android.util.Log
+import androidx.test.rule.ActivityTestRule
+import org.junit.Rule
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runner.notification.Failure
+import org.junit.runner.notification.RunNotifier
+import java.util.concurrent.ExecutionException
 
-class PatrolTestRunner(testClass: Class<*>?) : FlutterTestRunner(testClass)
+class PatrolTestRunner(private val testClass: Class<*>) {
+    private val tag = "PatrolTestRunner"
+
+    var rule: TestRule? = null
+
+    init {
+        // Look for an `ActivityTestRule` annotated `@Rule` and invoke `launchActivity()`
+        val fields = testClass.declaredFields
+        for (field in fields) {
+            if (field.isAnnotationPresent(Rule::class.java)) {
+                try {
+                    val instance = testClass.newInstance()
+                    if (field[instance] is ActivityTestRule<*>) {
+                        rule = field[instance] as TestRule
+                        break
+                    }
+                } catch (e: InstantiationException) {
+                    // This might occur if the developer did not make the rule public.
+                    // We could call field.setAccessible(true) but it seems better to throw.
+                    throw RuntimeException("Unable to access activity rule", e)
+                } catch (e: IllegalAccessException) {
+                    throw RuntimeException("Unable to access activity rule", e)
+                }
+            }
+        }
+    }
+
+    override fun getDescription(): Description? {
+        return Description.createTestDescription(testClass, "Flutter Patrol Tests")
+    }
+
+    override fun run(notifier: RunNotifier) {
+        if (rule == null) {
+            throw RuntimeException("Unable to run tests due to missing activity rule")
+        }
+
+        try {
+            if (rule is PatrolTestRule<*>) {
+                (rule as PatrolTestRule<*>).launchActivity(null)
+            }
+        } catch (e: RuntimeException) {
+            Log.v(tag, "launchActivity failed, possibly because the activity was already running. $e")
+            Log.v(
+                tag,
+                "Try disabling auto-launch of the activity, e.g. ActivityTestRule<>(MainActivity.class, true, false);"
+            )
+        }
+
+        var results: Map<String, String>? = null
+        results = try {
+            // IntegrationTestPlugin.testResults.get()
+            // Start from here:
+            PatrolServer.testResults
+        } catch (e: ExecutionException) {
+            throw IllegalThreadStateException("Unable to get test results")
+        } catch (e: InterruptedException) {
+            throw IllegalThreadStateException("Unable to get test results")
+        }
+        for (name in results.keys) {
+            val d = Description.createTestDescription(testClass, name)
+            notifier.fireTestStarted(d)
+            val outcome = results.get(name)
+            if (outcome != "success") {
+                val dummyException = Exception(outcome)
+                notifier.fireTestFailure(Failure(d, dummyException))
+            }
+            notifier.fireTestFinished(d)
+        }
+    }
+}

--- a/packages/patrol/ios/Classes/SwiftPatrolPlugin.swift
+++ b/packages/patrol/ios/Classes/SwiftPatrolPlugin.swift
@@ -8,8 +8,10 @@ let kMethodAllTestsFinished = "allTestsFinished"
 let kErrorCreateChannelFailed = "create_channel_failed"
 let kErrorCreateChannelFailedMsg = "Failed to create GRPC channel"
 
-/// A Flutter plugin that's responsible for communicating the test results back
+/// A Flutter plugin that was  responsible for communicating the test results back
 /// to iOS XCUITest.
+///
+/// Since test reports are now sent directly from PatrolBinding to native test runners, this plugin does nothing.
 public class SwiftPatrolPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(
@@ -21,53 +23,7 @@ public class SwiftPatrolPlugin: NSObject, FlutterPlugin {
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
 
-  /// Called after all Dart tests finish sending the results to the RunnerUITests app.
-  ///
-  /// RunnerUITests app then dynamically creates test methods (using Objective-C runtime) from the Dart test results.
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    NSLog("SwiftPatrolPlugin: method call received: %@", call.method)
-
-    switch call.method {
-    case kMethodAllTestsFinished:
-      let arguments = (call.arguments ?? [:]) as! [String: Any]
-      let results = arguments["results"] as! [String: String]
-
-      let group = PlatformSupport.makeEventLoopGroup(loopCount: 1)
-      defer {
-        try? group.syncShutdownGracefully()
-      }
-
-      guard
-        let channel = try? GRPCChannelPool.with(
-          target: .host("localhost", port: 8081),
-          transportSecurity: .plaintext,
-          eventLoopGroup: group
-        )
-      else {
-        result(
-          FlutterError(
-            code: kErrorCreateChannelFailed,
-            message: kErrorCreateChannelFailedMsg,
-            details: nil
-          )
-        )
-        return
-      }
-
-      NSLog("SwiftPatrolPlugin: attempting to create client...")
-      let client = Patrol_NativeAutomatorNIOClient(
-        channel: channel,
-        defaultCallOptions: CallOptions(timeLimit: TimeLimit.timeout(.seconds(10)))
-      )
-      NSLog("SwiftPatrolPlugin: create client...")
-
-      let call = client.submitTestResults(.with { $0.results = results })
-
-      let status = try! call.status.wait()
-      NSLog("SwiftPatrolPlugin: after submitTestResults, status: %@", status.description)
-      result(nil)
-    default:
       result(FlutterMethodNotImplemented)
-    }
   }
 }

--- a/packages/patrol/ios/Classes/SwiftPatrolPlugin.swift
+++ b/packages/patrol/ios/Classes/SwiftPatrolPlugin.swift
@@ -24,6 +24,6 @@ public class SwiftPatrolPlugin: NSObject, FlutterPlugin {
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-      result(FlutterMethodNotImplemented)
+    result(FlutterMethodNotImplemented)
   }
 }

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -13,7 +13,10 @@ void _defaultPrintLogger(String message) {
   print('PatrolBinding: $message');
 }
 
-// copied from package:integration_test/lib/integration_test.dart
+/// An escape hatch in if, for any reason, the test reporting has to be
+/// disabled.
+///
+/// Patrol CLI doesn't pass this dart define anywhere.
 const bool _shouldReportResultsToNative = bool.fromEnvironment(
   'PATROL_INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE',
   defaultValue: true,

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -41,11 +39,6 @@ class PatrolBinding extends IntegrationTestWidgetsFlutterBinding {
     };
 
     tearDownAll(() async {
-      // TODO: Use patrolChannel for Android (see https://github.com/leancodepl/patrol/issues/969)
-      if (!Platform.isIOS) {
-        return;
-      }
-
       if (!_shouldReportResultsToNative) {
         return;
       }

--- a/packages/patrol/lib/src/common.dart
+++ b/packages/patrol/lib/src/common.dart
@@ -49,10 +49,11 @@ void patrolTest(
   if (nativeAutomation) {
     switch (bindingType) {
       case BindingType.patrol:
+        nativeAutomator = NativeAutomator(config: nativeAutomatorConfig);
+
         final binding = PatrolBinding.ensureInitialized();
         binding.framePolicy = framePolicy;
-
-        nativeAutomator = NativeAutomator(config: nativeAutomatorConfig);
+        binding.nativeAutomator = nativeAutomator;
         break;
       case BindingType.integrationTest:
         IntegrationTestWidgetsFlutterBinding.ensureInitialized().framePolicy =

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -4,6 +4,7 @@ import 'package:fixnum/fixnum.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:grpc/grpc.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:meta/meta.dart';
 import 'package:patrol/src/binding.dart';
 import 'package:patrol/src/native/contracts/contracts.pbgrpc.dart';
 
@@ -721,6 +722,20 @@ class NativeAutomator {
         SetLocationAccuracyRequest(
           locationAccuracy: SetLocationAccuracyRequest_LocationAccuracy.FINE,
         ),
+      ),
+    );
+  }
+
+  /// Submits test results to the native test runner.
+  ///
+  /// Virtual test cases are created for each key in [results] and the value is
+  /// used as the test result.
+  @internal
+  Future<void> submitTestResults(Map<String, String> results) async {
+    await _wrapRequest(
+      'submitTestResults',
+      () => _client.submitTestResults(
+        SubmitTestResultsRequest(results: results),
       ),
     );
   }

--- a/packages/patrol_cli/lib/src/commands/build_android.dart
+++ b/packages/patrol_cli/lib/src/commands/build_android.dart
@@ -85,6 +85,7 @@ class BuildAndroidCommand extends PatrolCommand {
       'PATROL_APP_PACKAGE_NAME': packageName,
       'PATROL_ANDROID_APP_NAME': config.android.appName,
       if (displayLabel) 'PATROL_TEST_LABEL': basename(target),
+      'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE': 'false',
     }.withNullsRemoved();
 
     final dartDefines = {...customDartDefines, ...internalDartDefines};

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -89,6 +89,7 @@ class BuildIOSCommand extends PatrolCommand {
       'PATROL_APP_BUNDLE_ID': bundleId,
       'PATROL_IOS_APP_NAME': config.ios.appName,
       if (displayLabel) 'PATROL_TEST_LABEL': basename(target),
+      'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE': 'false',
     }.withNullsRemoved();
 
     final dartDefines = {...customDartDefines, ...internalDartDefines};

--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -120,12 +120,10 @@ class DevelopCommand extends PatrolCommand {
       'PATROL_APP_BUNDLE_ID': bundleId,
       'PATROL_ANDROID_APP_NAME': config.android.appName,
       'PATROL_IOS_APP_NAME': config.ios.appName,
+      'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE': 'false',
       if (displayLabel) 'PATROL_TEST_LABEL': basename(target),
       // develop-specific
-      ...{
-        'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE': 'false',
-        'PATROL_HOT_RESTART': 'true',
-      },
+      ...{'PATROL_HOT_RESTART': 'true'},
     }.withNullsRemoved();
 
     final dartDefines = {...customDartDefines, ...internalDartDefines};

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -145,6 +145,7 @@ class TestCommand extends PatrolCommand {
       'PATROL_APP_BUNDLE_ID': bundleId,
       'PATROL_ANDROID_APP_NAME': config.android.appName,
       'PATROL_IOS_APP_NAME': config.ios.appName,
+      'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE': 'false',
     }.withNullsRemoved();
 
     final dartDefines = {...customDartDefines, ...internalDartDefines};


### PR DESCRIPTION
This PR resolves #969.

Test reporting was quite a mess, but it was manageable because Patrol didn't do many test-reporting-related things (`package:integration_test` did lots of that).

Now that we want to get [test bundling](#1004) done, it's high time we rewrite this code to something maintainable.