### PR TITLE
[LACKS TESTS] Replace `drag()` with `timedDrag()` in Patrol's scrolling and dragging methods

### DIFF
--- a/packages/patrol/lib/src/custom_finders/patrol_finder.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_finder.dart
@@ -266,6 +266,7 @@ class PatrolFinder extends MatchFinder {
     double step = defaultScrollDelta,
     int maxScrolls = defaultScrollMaxIteration,
     Duration duration = const Duration(milliseconds: 50),
+    Duration scrollDuration = const Duration(milliseconds: 500),
     bool? andSettle,
   }) {
     return tester.scrollUntilVisible(
@@ -274,6 +275,7 @@ class PatrolFinder extends MatchFinder {
       delta: step,
       maxScrolls: maxScrolls,
       duration: duration,
+      scrollDuration: scrollDuration,
       andSettle: andSettle,
     );
   }

--- a/packages/patrol/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_tester.dart
@@ -419,6 +419,7 @@ class PatrolTester {
     required Offset moveStep,
     int maxIteration = defaultScrollMaxIteration,
     Duration duration = const Duration(milliseconds: 50),
+    Duration dragDuration = const Duration(milliseconds: 500),
     bool? andSettle,
   }) {
     return TestAsyncUtils.guard(() async {
@@ -428,7 +429,7 @@ class PatrolTester {
 
       var iterationsLeft = maxIteration;
       while (iterationsLeft > 0 && finder.hitTestable().evaluate().isEmpty) {
-        await tester.drag(viewPatrolFinder, moveStep);
+        await tester.timedDrag(viewPatrolFinder, moveStep, dragDuration);
         await tester.pump(duration);
         iterationsLeft -= 1;
       }
@@ -511,6 +512,7 @@ class PatrolTester {
     double delta = defaultScrollDelta,
     int maxScrolls = defaultScrollMaxIteration,
     Duration duration = const Duration(milliseconds: 50),
+    Duration scrollDuration = const Duration(milliseconds: 500),
     bool? andSettle,
   }) async {
     assert(maxScrolls > 0, 'maxScrolls must be positive number');
@@ -544,6 +546,7 @@ class PatrolTester {
         moveStep: moveStep,
         maxIteration: maxScrolls,
         duration: duration,
+        dragDuration: scrollDuration,
         andSettle: andSettle,
       );
 


### PR DESCRIPTION
Feature: `drag()` in `dragUntilVisible()` replaced with `timedDrag()`

Motivation. Currently `scrollTo`/`scrollUntilVisible` run too fast through activity to target Widget which is not the behaviour users actually act. Having `dragDuration` optional param will allow to slow down scrolling which will bring us closer to it.

Signature will remain the same so API is not got broken, but now there is a confusion with first param - `duration` in relation to new `scrollDuration` which is actually a timeout. But changing that will break API.
`await $(#loc).scrollTo(duration: const Duration(seconds: 1), scrollDuration: const Duration(seconds: 1));`

Just a note: I tested it in my project over cloned 1.0.8 referring to local patrol repo, but I could not build (and test) it on forked 1.0.9 as faced kotlin compile issues and could not solve it due to lack of flutter/dart knowledge/exp:

<details>
  <summary>log</summary>

```
 : > Task :patrol:compileDebugKotlin FAILED
        e: /Users/user/.pub-cache/hosted/pub.dev/patrol-1.0.8/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt: (17, 11): Redeclaration: Empty
        e: /Users/user/.pub-cache/hosted/pub.dev/patrol-1.0.8/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt: (19, 7): Redeclaration: AutomatorServer
        e: /Users/user/.pub-cache/hosted/pub.dev/patrol-1.0.8/android/src/main/kotlin/pl/leancode/patrol/PatrolPlugin.kt: (9, 7): Redeclaration: PatrolPlugin
        e: /Users/user/.pub-cache/hosted/pub.dev/patrol-1.0.8/android/src/main/kotlin/pl/leancode/patrol/PatrolServer.kt: (8, 7): Redeclaration: PatrolServer
        e: /Users/user/.pub-cache/hosted/pub.dev/patrol-1.0.8/android/src/main/kotlin/pl/leancode/patrol/PatrolTestRunner.kt: (5, 7): Redeclaration: PatrolTestRunner
        e: /Users/user/patrol/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt: (17, 11): Redeclaration: Empty
        e: /Users/user/patrol/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt: (19, 7): Redeclaration: AutomatorServer
        e: /Users/user/patrol/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolPlugin.kt: (9, 7): Redeclaration: PatrolPlugin
        e: /Users/user/patrol/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolServer.kt: (9, 7): Redeclaration: PatrolServer
        e: /Users/user/patrol/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolServer.kt: (21, 21): Cannot find a parameter with this name: automation
        e: /Users/user/patrol/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolServer.kt: (22, 21): Cannot find a parameter with this name: onTestResultsSubmitted
        e: /Users/user/patrol/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolServer.kt: (22, 71): Unresolved reference: it
        e: /Users/user/patrol/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolTestRunner.kt: (13, 7): Redeclaration: PatrolTestRunner
        e: /Users/user/patrol/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolTestRunner.kt: (62, 26): Unresolved reference: testResults
        e: /Users/user/patrol/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolTestRunner.kt: (71, 30): Unresolved reference: keys
        e: /Users/user/patrol/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolTestRunner.kt: (75, 17): Operator '!=' cannot be applied to 'MatchGroup?' and 'String'
        e: /Users/user/patrol/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolTestRunner.kt: (76, 38): None of the following functions can be called with the arguments supplied: 
        public final fun <init>(p0: String!): kotlin.Exception /* = java.lang.Exception */ defined in kotlin.Exception
        public final fun <init>(p0: Throwable!): kotlin.Exception /* = java.lang.Exception */ defined in kotlin.Exception
        
        FAILURE: Build completed with 2 failures.
        
        1: Task failed with an exception.
        -----------
        * What went wrong:
        Execution failed for task ':patrol:compileDebugKotlin'.
        > Compilation error. See log for more details
```

</details>


