### PR TITLE
Stop depending on Protobuf Gradle Plugin

### DIFF
--- a/packages/patrol/android/build.gradle
+++ b/packages/patrol/android/build.gradle
@@ -14,7 +14,6 @@ buildscript {
 plugins {
     id "com.android.library"
     id "kotlin-android"
-    id "com.google.protobuf" version "0.8.19"
     id "org.jlleitschuh.gradle.ktlint" version "11.1.0"
 }
 


### PR DESCRIPTION
This PR attempts to fix #1260.

Couldn't test if it _fixes_ the problem because of [this](https://github.com/leancodepl/patrol/issues/1260#issuecomment-1542146211). However, the app builds and the tests run, so it's not dangerous. 