### PR TITLE
Fix `PatrolFinder.which()` so that it takes previous finder(s) into account

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix `which()` not taking previous finder(s) into account (#1271)
+
 ## 1.1.2
 
 - Fix crashing when using Gradle 8 (#1262)

--- a/packages/patrol/lib/src/custom_finders/patrol_finder.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_finder.dart
@@ -310,15 +310,16 @@ class PatrolFinder extends MatchFinder {
         matchRoot: true,
         of: finder,
         matching: find.byWidgetPredicate((widget) {
-          if (widget is T &&
-              find
-                  .descendant(of: finder, matching: find.byWidget(widget))
-                  .evaluate()
-                  .isEmpty &&
-              find
-                  .ancestor(of: finder, matching: find.byWidget(widget))
-                  .evaluate()
-                  .isEmpty) {
+          final foundWidget = find.byWidget(widget);
+          final isNotAboveFoundWidget = find
+              .ancestor(of: finder, matching: foundWidget)
+              .evaluate()
+              .isEmpty;
+          final isNotBelowFoundWidget = find
+              .descendant(of: finder, matching: foundWidget)
+              .evaluate()
+              .isEmpty;
+          if (widget is T && isNotBelowFoundWidget && isNotAboveFoundWidget) {
             return predicate(widget);
           } else {
             return false;

--- a/packages/patrol/lib/src/custom_finders/patrol_finder.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_finder.dart
@@ -308,22 +308,18 @@ class PatrolFinder extends MatchFinder {
     return PatrolFinder(
       finder: find.descendant(
         matchRoot: true,
-        of: finder,
+        of: this,
         matching: find.byWidgetPredicate((widget) {
-          final foundWidget = find.byWidget(widget);
-          final isNotAboveFoundWidget = find
-              .ancestor(of: finder, matching: foundWidget)
-              .evaluate()
-              .isEmpty;
-          final isNotBelowFoundWidget = find
-              .descendant(of: finder, matching: foundWidget)
-              .evaluate()
-              .isEmpty;
-          if (widget is T && isNotBelowFoundWidget && isNotAboveFoundWidget) {
-            return predicate(widget);
-          } else {
+          if (widget is! T) {
             return false;
           }
+          final foundWidgets = evaluate().map(
+            (e) => e.widget,
+          );
+          if (!foundWidgets.contains(widget)) {
+            return false;
+          }
+          return predicate(widget);
         }),
       ),
       tester: tester,

--- a/packages/patrol/lib/src/custom_finders/patrol_finder.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_finder.dart
@@ -306,13 +306,25 @@ class PatrolFinder extends MatchFinder {
   /// * [CommonFinders.byWidgetPredicate]
   PatrolFinder which<T extends Widget>(bool Function(T widget) predicate) {
     return PatrolFinder(
-      finder: find.byWidgetPredicate((widget) {
-        if (widget is T) {
-          return predicate(widget);
-        } else {
-          return false;
-        }
-      }),
+      finder: find.descendant(
+        matchRoot: true,
+        of: finder,
+        matching: find.byWidgetPredicate((widget) {
+          if (widget is T &&
+              find
+                  .descendant(of: finder, matching: find.byWidget(widget))
+                  .evaluate()
+                  .isEmpty &&
+              find
+                  .ancestor(of: finder, matching: find.byWidget(widget))
+                  .evaluate()
+                  .isEmpty) {
+            return predicate(widget);
+          } else {
+            return false;
+          }
+        }),
+      ),
       tester: tester,
     );
   }

--- a/packages/patrol/test/patrol_finder_test.dart
+++ b/packages/patrol/test/patrol_finder_test.dart
@@ -871,7 +871,7 @@ void main() {
         expect($('count: 10'), findsOneWidget);
       });
 
-      patrolTest('finds 2 buttons by its inactive status', ($) async {
+      patrolTest('finds 2 buttons by their inactive status', ($) async {
         await $.pumpWidget(app);
 
         expect(

--- a/packages/patrol/test/patrol_finder_test.dart
+++ b/packages/patrol/test/patrol_finder_test.dart
@@ -796,8 +796,20 @@ void main() {
             child: StatefulBuilder(
               builder: (context, setState) {
                 return Column(
+                  key: Key('column'),
                   children: [
+                    Row(
+                      children: [
+                        Column(
+                          children: [],
+                        ),
+                      ],
+                    ),
                     Text('count: $count'),
+                    const ElevatedButton(
+                      onPressed: null,
+                      child: Text('Disabled button'),
+                    ),
                     const ElevatedButton(
                       onPressed: null,
                       child: Text('Disabled button'),
@@ -857,6 +869,37 @@ void main() {
             .tap();
 
         expect($('count: 10'), findsOneWidget);
+      });
+
+      patrolTest('finds 2 buttons by its inactive status', ($) async {
+        await $.pumpWidget(app);
+
+        expect(
+          $(ElevatedButton).which<ElevatedButton>((button) => !button.enabled),
+          findsNWidgets(2),
+        );
+      });
+
+      patrolTest('finds zero widgets if type does not match', ($) async {
+        await $.pumpWidget(app);
+
+        expect(
+          $(#column).which<ElevatedButton>((button) => !button.enabled),
+          findsNothing,
+        );
+      });
+
+      patrolTest(
+          'finds one widget if there are 2 widgets of the same type in the subtree',
+          ($) async {
+        await $.pumpWidget(app);
+
+        expect(
+          $(#column).which<Column>(
+            (column) => column.mainAxisAlignment == MainAxisAlignment.start,
+          ),
+          findsOneWidget,
+        );
       });
     });
 

--- a/packages/patrol/test/patrol_finder_test.dart
+++ b/packages/patrol/test/patrol_finder_test.dart
@@ -827,7 +827,7 @@ void main() {
       patrolTest('finds button by its active status', ($) async {
         await $.pumpWidget(app);
 
-        await $('Enabled button')
+        await $(ElevatedButton)
             .which<ElevatedButton>((button) => button.enabled)
             .tap();
 
@@ -837,7 +837,7 @@ void main() {
       patrolTest('finds button by its font size', ($) async {
         await $.pumpWidget(app);
 
-        await $('Enabled button')
+        await $(ElevatedButton)
             .which<ElevatedButton>(
               (button) => button.style?.textStyle?.resolve({})?.fontSize == 20,
             )
@@ -849,7 +849,7 @@ void main() {
       patrolTest('finds button by its active status and color', ($) async {
         await $.pumpWidget(app);
 
-        await $('Enabled button with color')
+        await $(ElevatedButton)
             .which<ElevatedButton>((button) => button.enabled)
             .which<ElevatedButton>(
               (btn) => btn.style?.backgroundColor?.resolve({}) == Colors.red,


### PR DESCRIPTION
This PR fixes https://github.com/leancodepl/patrol/issues/1150.