### PR TITLE
Add namespace to android/build.gradle

### DIFF
--- a/packages/patrol/android/build.gradle
+++ b/packages/patrol/android/build.gradle
@@ -34,6 +34,7 @@ group "pl.leancode.patrol"
 version "1.0-SNAPSHOT"
 
 android {
+    namespace "pl.leancode.patrol"
     compileSdk 31
 
     compileOptions {


### PR DESCRIPTION
This should've been done in #1254.