### PR TITLE
Fix artifacts from test ios workflow

### DIFF
--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -88,8 +88,8 @@ jobs:
         if: success() || failure()
         uses: kishikawakatsumi/xcresulttool@v1
         with:
-          title: "Patrol tests on ${{ matrix.device }}"
-          upload-bundles: "never"
+          title: Patrol tests on ${{ matrix.device }}
+          upload-bundles: never
           path: |
             ${{ env.XCRESULT_PATH }}
      

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -59,7 +59,8 @@ jobs:
       - name: Run tests
         id: tests_step
         run: |
-          xcrun simctl io booted recordVideo "${{ matrix.device }}.mov" &
+          xcrun simctl io booted recordVideo --codec=h264 "${{ matrix.device }}.mp4" &
+          recordingpid="$!"
 
           xcrun simctl spawn booted log stream --type log --color none > all_simulator_logs.txt &
           xcrun simctl spawn booted log stream --type activity --color none > activity_simulator_logs.txt &
@@ -78,6 +79,8 @@ jobs:
             --exclude integration_test/webview_login_test.dart \
             --exclude integration_test/webview_stackoverflow_test.dart || TESTS_EXIT_CODE=$?
 
+          pkill -SIGINT $recordingpid
+          echo "TESTS_EXIT_CODE"=$TESTS_EXIT_CODE >> $GITHUB_ENV
           exit $TESTS_EXIT_CODE
 
       - name: Find xcresult path
@@ -115,13 +118,13 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Captured video from ${{ matrix.device }}.mov
-          path: ${{ github.workspace }}/packages/patrol/example/${{ matrix.device }}.mov
+          path: ${{ github.workspace }}/packages/patrol/example/${{ matrix.device }}.mp4
 
       - name: Check if failed test occured
         id: set_failure
         if: always()
         run: >
-          if [ "${{ steps.tests_step.conclusion }}" == "failure" ]; then
+          if [ ! ${{ env.TESTS_EXIT_CODE }} == 0 ]; then
             echo "failure_status=failure" >> "$GITHUB_OUTPUT";
           fi;
 
@@ -129,7 +132,7 @@ jobs:
         id: set_error
         if: always()
         run: >
-          if [ "${{ steps.tests_step.conclusion }}" == "skipped" ] || [ "${{ steps.tests_step.conclusion }}" == "cancelled" ]; then
+          if [ "${{ steps.tests_step.conclusion }}" == "failure" ] || [ "${{ steps.tests_step.conclusion }}" == "skipped" ] || [ "${{ steps.tests_step.conclusion }}" == "cancelled" ]; then
             echo "error_status=error" >> "$GITHUB_OUTPUT";
           fi;
 

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -139,12 +139,20 @@ jobs:
           error_status: ${{ needs.run_tests.outputs.error_status }}
         run: >
           if [ ! -z "$error_status" ]; then
-            message="Something went wrong ⚠️";
-          elif [ ! -z "$failure_status" ]; then
-            message="There were failing tests 💥 ";
-          else
-            message="All tests have passed ✅ ";
-            status="success";
+            message="Something went wrong ⚠️ ";
+            status="failure";
+          fi;
+          if [ ! -z "$failure_status" ]; then
+            if [ ! -z "$message" ]; then
+              message+=" and there were failing tests 💥 ";
+            else
+              message+="There were failing tests 💥 ";
+              status="failure";
+            fi;
+          fi;
+          if [ -z "$message" ]; then
+              message="All tests have passed ✅ ";
+              status="success";
           fi;
 
           url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}";

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -64,7 +64,8 @@ jobs:
           
           xcrun simctl spawn booted log stream --type log --color none > all_simulator_logs.txt &
           logpid="$!"
-
+          
+          TESTS_EXIT_CODE=0
           patrol test \
             --exclude integration_test/android_app_test.dart \
             --exclude integration_test/service_airplane_mode_test.dart \

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -59,15 +59,11 @@ jobs:
       - name: Run tests
         id: tests_step
         run: |
-          xcrun simctl io booted recordVideo --codec=h264 "${{ matrix.device }}.mov" &
-          recordingpid="$!"
+          xcrun simctl io booted recordVideo "${{ matrix.device }}.mov" &
 
           xcrun simctl spawn booted log stream --type log --color none > all_simulator_logs.txt &
-          logpid="$!"
           xcrun simctl spawn booted log stream --type activity --color none > activity_simulator_logs.txt &
-          activitypid="$!"
           xcrun simctl spawn booted log stream --type trace --color none > trace_simulator_logs.txt &
-          tracepid="$!"
 
           TESTS_EXIT_CODE=0
 
@@ -82,10 +78,6 @@ jobs:
             --exclude integration_test/webview_login_test.dart \
             --exclude integration_test/webview_stackoverflow_test.dart || TESTS_EXIT_CODE=$?
 
-          kill $recordingpid
-          kill $logpid
-          kill $activitypid
-          kill $tracepid
           exit $TESTS_EXIT_CODE
 
       - name: Find xcresult path
@@ -101,11 +93,11 @@ jobs:
           path: |
             ${{ env.XCRESULT_PATH }}
      
-      - name: Upload XCRESULT test report to artifacts
+      - name: Upload XCRESULT test result to artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
-          name: Test reportfrom ${{ matrix.device }}.xcresult
+          name: Test result from ${{ matrix.device }}.xcresult
           path: ${{ env.XCRESULT_PATH }}
       
       - name: Upload simulator logs to artifacts

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -69,8 +69,6 @@ jobs:
           xcrun simctl spawn booted log stream --type trace --color none > trace_simulator_logs.txt &
           tracepid="$!"
 
-          TESTS_EXIT_CODE=0
-
           patrol test \
             --exclude integration_test/android_app_test.dart \
             --exclude integration_test/service_airplane_mode_test.dart \
@@ -83,11 +81,10 @@ jobs:
             --exclude integration_test/webview_stackoverflow_test.dart || TESTS_EXIT_CODE=$?
 
           kill -SIGINT $recordingpid
-          kill $logpid
-          kill $activitypid
-          kill $tracepid
+          kill -SIGINT $logpid
+          kill -SIGINT $activitypid
+          kill -SIGINT $tracepid
           echo "TESTS_EXIT_CODE=$TESTS_EXIT_CODE" >> $GITHUB_ENV
-          echo "code: $TESTS_EXIT_CODE"
           exit $TESTS_EXIT_CODE
 
       - name: Find xcresult path
@@ -98,7 +95,7 @@ jobs:
         if: success() || failure()
         uses: kishikawakatsumi/xcresulttool@v1
         with:
-          title: "Patrol tests from ${{ matrix.device }}"
+          title: "Patrol tests on ${{ matrix.device }}"
           upload-bundles: "never"
           path: |
             ${{ env.XCRESULT_PATH }}

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -86,7 +86,7 @@ jobs:
           kill $logpid
           kill $activitypid
           kill $tracepid
-          echo "TESTS_EXIT_CODE"=$TESTS_EXIT_CODE >> $GITHUB_ENV
+          echo "TESTS_EXIT_CODE=$TESTS_EXIT_CODE" >> $GITHUB_ENV
           echo "code: $TESTS_EXIT_CODE"
           exit $TESTS_EXIT_CODE
 

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -59,9 +59,17 @@ jobs:
       - name: Run tests
         id: tests_step
         run: |
-          xcrun simctl io booted recordVideo --codec=h264 "${{ matrix.device }}.mp4" &
+          xcrun simctl io booted recordVideo --codec=h264 "${{ matrix.device }}.mov" &
           recordingpid="$!"
-          EXIT_CODE=0
+
+          xcrun simctl spawn booted log stream --type log --color none > all_simulator_logs.txt &
+          logpid="$!"
+          xcrun simctl spawn booted log stream --type activity --color none > activity_simulator_logs.txt &
+          activitypid="$!"
+          xcrun simctl spawn booted log stream --type trace --color none > trace_simulator_logs.txt &
+          tracepid="$!"
+
+          TESTS_EXIT_CODE=0
 
           patrol test \
             --exclude integration_test/android_app_test.dart \
@@ -72,11 +80,18 @@ jobs:
             --exclude integration_test/swipe_test.dart \
             --exclude integration_test/webview_leancode_test.dart \
             --exclude integration_test/webview_login_test.dart \
-            --exclude integration_test/webview_stackoverflow_test.dart || EXIT_CODE=$?
+            --exclude integration_test/webview_stackoverflow_test.dart || TESTS_EXIT_CODE=$?
 
           kill $recordingpid
-          exit $EXIT_CODE
+          kill $logpid
+          kill $activitypid
+          kill $tracepid
+          exit $TESTS_EXIT_CODE
 
+      - name: Find xcresult path
+        if: success() || failure()
+        run: echo "XCRESULT_PATH=$(find ~/Library/Developer/Xcode/DerivedData -name "*.xcresult" -type d)" >> $GITHUB_ENV
+      
       - name: Publish test report to summary
         if: success() || failure()
         uses: kishikawakatsumi/xcresulttool@v1
@@ -85,11 +100,7 @@ jobs:
           upload-bundles: "never"
           path: |
             ${{ env.XCRESULT_PATH }}
-
-      - name: Find xcresult path
-        if: success() || failure()
-        run: echo "XCRESULT_PATH=$(find ~/Library/Developer/Xcode/DerivedData -name "*.xcresult" -type d)" >> $GITHUB_ENV
-
+     
       - name: Upload XCRESULT test report to artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -11,8 +11,8 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 60
     outputs:
-      failure_status: ${{ steps.set_failure.outputs.failure_status }}
-      error_status: ${{ steps.set_error.outputs.error_status }}
+      failure_status: ${{ steps.set_status.outputs.failure_status }}
+      error_status: ${{ steps.set_status.outputs.error_status }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -88,7 +88,7 @@ jobs:
         if: success() || failure()
         uses: kishikawakatsumi/xcresulttool@v1
         with:
-          title: "Patrol tests"
+          title: "Patrol tests from ${{ matrix.device }}"
           upload-bundles: "never"
           path: |
             ${{ env.XCRESULT_PATH }}
@@ -114,7 +114,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
-          name: Captured video from ${{ matrix.device }}
+          name: Captured video from ${{ matrix.device }}.mov
           path: ${{ github.workspace }}/packages/patrol/example/${{ matrix.device }}.mov
 
       - name: Check if failed test occured

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -62,7 +62,7 @@ jobs:
           xcrun simctl io booted recordVideo --codec=h264 "${{ matrix.device }}.mp4" &
           recordingpid="$!"
           
-          sleep 20
+          sleep 120
           xcrun simctl spawn booted log stream --type log --color none > all_simulator_logs.txt &
           logpid="$!"
           xcrun simctl spawn booted log stream --type activity --color none > activity_simulator_logs.txt &

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -62,7 +62,6 @@ jobs:
           xcrun simctl io booted recordVideo --codec=h264 "${{ matrix.device }}.mp4" &
           recordingpid="$!"
           
-          sleep 30
           xcrun simctl spawn booted log stream --type log --color none > all_simulator_logs.txt &
           logpid="$!"
 
@@ -73,7 +72,7 @@ jobs:
             --exclude integration_test/service_cellular_test.dart \
             --exclude integration_test/service_wifi_test.dart \
             --exclude integration_test/swipe_test.dart \
-            --exclude integration_test/webview_leancode_test.dart \
+            # --exclude integration_test/webview_leancode_test.dart \
             --exclude integration_test/webview_login_test.dart \
             --exclude integration_test/webview_stackoverflow_test.dart || TESTS_EXIT_CODE=$?
 

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -61,7 +61,8 @@ jobs:
         run: |
           xcrun simctl io booted recordVideo --codec=h264 "${{ matrix.device }}.mp4" &
           recordingpid="$!"
-
+          
+          sleep 20
           xcrun simctl spawn booted log stream --type log --color none > all_simulator_logs.txt &
           logpid="$!"
           xcrun simctl spawn booted log stream --type activity --color none > activity_simulator_logs.txt &
@@ -156,7 +157,7 @@ jobs:
           if [ ! -z "$failure_status" ]; then
             message="There were failing tests 💥 ";
             status="failure";
-          elif [ ! -z "$error_status" ]; then
+          if [ ! -z "$error_status" ]; then
             message="Something went wrong ⚠️";
             status="failure";
           else

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -63,8 +63,11 @@ jobs:
           recordingpid="$!"
 
           xcrun simctl spawn booted log stream --type log --color none > all_simulator_logs.txt &
+          logpid="$!"
           xcrun simctl spawn booted log stream --type activity --color none > activity_simulator_logs.txt &
+          activitypid="$!"
           xcrun simctl spawn booted log stream --type trace --color none > trace_simulator_logs.txt &
+          tracepid="$!"
 
           TESTS_EXIT_CODE=0
 
@@ -79,8 +82,12 @@ jobs:
             --exclude integration_test/webview_login_test.dart \
             --exclude integration_test/webview_stackoverflow_test.dart || TESTS_EXIT_CODE=$?
 
-          pkill -SIGINT $recordingpid
+          kill -SIGINT $recordingpid
+          kill $logpid
+          kill $activitypid
+          kill $tracepid
           echo "TESTS_EXIT_CODE"=$TESTS_EXIT_CODE >> $GITHUB_ENV
+          echo "code: $TESTS_EXIT_CODE"
           exit $TESTS_EXIT_CODE
 
       - name: Find xcresult path
@@ -117,7 +124,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
-          name: Captured video from ${{ matrix.device }}.mov
+          name: Captured video from ${{ matrix.device }}.mp4
           path: ${{ github.workspace }}/packages/patrol/example/${{ matrix.device }}.mp4
 
       - name: Check if failed test occured

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -105,9 +105,8 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
-          name: XCRESULT test report from ${{ matrix.device }}
-          path: |
-            ${{ env.XCRESULT_PATH }}
+          name: Test reportfrom ${{ matrix.device }}.xcresult
+          path: ${{ env.XCRESULT_PATH }}
       
       - name: Upload simulator logs to artifacts
         if: success() || failure()
@@ -124,7 +123,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Captured video from ${{ matrix.device }}
-          path: ${{ github.workspace }}/packages/patrol/example/${{ matrix.device }}.mp4
+          path: ${{ github.workspace }}/packages/patrol/example/${{ matrix.device }}.mov
 
       - name: Check if failed test occured
         id: set_failure

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -114,7 +114,10 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Logs from ${{ matrix.device }}
-          path: ~/Library/Logs/CoreSimulator/${{ steps.start_simulator.outputs.udid }}/system.log
+          path: |
+            ${{ github.workspace }}/packages/patrol/example/all_simulator_logs.txt
+            ${{ github.workspace }}/packages/patrol/example/activity_simulator_logs.txt
+            ${{ github.workspace }}/packages/patrol/example/trace_simulator_logs.txt
 
       - name: Upload captured video to artifacts
         if: success() || failure()

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -11,7 +11,8 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 60
     outputs:
-      status: ${{ steps.set_status.outputs.status }}
+      failure_status: ${{ steps.set_failure.outputs.failure_status }}
+      error_status: ${{ steps.set_error.outputs.error_status }}
 
     strategy:
       fail-fast: false
@@ -61,13 +62,9 @@ jobs:
           xcrun simctl io booted recordVideo --codec=h264 "${{ matrix.device }}.mp4" &
           recordingpid="$!"
           
-          sleep 20
+          sleep 30
           xcrun simctl spawn booted log stream --type log --color none > all_simulator_logs.txt &
           logpid="$!"
-          xcrun simctl spawn booted log stream --type activity --color none > activity_simulator_logs.txt &
-          activitypid="$!"
-          xcrun simctl spawn booted log stream --type trace --color none > trace_simulator_logs.txt &
-          tracepid="$!"
 
           patrol test \
             --exclude integration_test/android_app_test.dart \
@@ -82,8 +79,6 @@ jobs:
 
           kill -SIGINT $recordingpid
           kill -SIGINT $logpid
-          kill -SIGINT $activitypid
-          kill -SIGINT $tracepid
           echo "TESTS_EXIT_CODE=$TESTS_EXIT_CODE" >> $GITHUB_ENV
           exit $TESTS_EXIT_CODE
 
@@ -114,8 +109,6 @@ jobs:
           name: Logs from ${{ matrix.device }}
           path: |
             ${{ github.workspace }}/packages/patrol/example/all_simulator_logs.txt
-            ${{ github.workspace }}/packages/patrol/example/activity_simulator_logs.txt
-            ${{ github.workspace }}/packages/patrol/example/trace_simulator_logs.txt
 
       - name: Upload captured video to artifacts
         if: success() || failure()
@@ -129,9 +122,9 @@ jobs:
         if: always()
         run: >
           if [ -z ${{ env.TESTS_EXIT_CODE }} ]; then
-            echo "status=error" >> "$GITHUB_OUTPUT";
+            echo "error_status=error" >> "$GITHUB_OUTPUT";
           elif [ ! ${{ env.TESTS_EXIT_CODE }} == 0 ]; then
-            echo "status=failure" >> "$GITHUB_OUTPUT";
+            echo "failure_status=failure" >> "$GITHUB_OUTPUT";
           fi;
 
   slack_notify:
@@ -144,11 +137,12 @@ jobs:
       - name: Set Slack message
         id: slack_message
         env:
-          status: ${{ needs.run_tests.outputs.status }}
+          failure_status: ${{ needs.run_tests.outputs.failure_status }}
+          error_status: ${{ needs.run_tests.outputs.error_status }}
         run: >
-          if [ "$error_status" == "error" ]; then
+          if [ ! -z "$error_status" ]; then
             message="Something went wrong ⚠️";
-          elif [ "$status" == "failure" ]; then
+          elif [ ! -z "$failure_status" ]; then
             message="There were failing tests 💥 ";
           else
             message="All tests have passed ✅ ";

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -72,6 +72,7 @@ jobs:
             --exclude integration_test/service_cellular_test.dart \
             --exclude integration_test/service_wifi_test.dart \
             --exclude integration_test/swipe_test.dart \
+            --exclude integration_test/webview_leancode_test.dart \
             --exclude integration_test/webview_login_test.dart \
             --exclude integration_test/webview_stackoverflow_test.dart || TESTS_EXIT_CODE=$?
 

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -72,7 +72,6 @@ jobs:
             --exclude integration_test/service_cellular_test.dart \
             --exclude integration_test/service_wifi_test.dart \
             --exclude integration_test/swipe_test.dart \
-            # --exclude integration_test/webview_leancode_test.dart \
             --exclude integration_test/webview_login_test.dart \
             --exclude integration_test/webview_stackoverflow_test.dart || TESTS_EXIT_CODE=$?
 

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -11,8 +11,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 60
     outputs:
-      failure_status: ${{ steps.set_failure.outputs.failure_status }}
-      error_status: ${{ steps.set_error.outputs.error_status }}
+      status: ${{ steps.set_status.outputs.status }}
 
     strategy:
       fail-fast: false
@@ -62,7 +61,7 @@ jobs:
           xcrun simctl io booted recordVideo --codec=h264 "${{ matrix.device }}.mp4" &
           recordingpid="$!"
           
-          sleep 120
+          sleep 20
           xcrun simctl spawn booted log stream --type log --color none > all_simulator_logs.txt &
           logpid="$!"
           xcrun simctl spawn booted log stream --type activity --color none > activity_simulator_logs.txt &
@@ -125,20 +124,14 @@ jobs:
           name: Captured video from ${{ matrix.device }}.mp4
           path: ${{ github.workspace }}/packages/patrol/example/${{ matrix.device }}.mp4
 
-      - name: Check if failed test occured
-        id: set_failure
+      - name: Check if error or failed test occured during run
+        id: set_status
         if: always()
         run: >
-          if [ ! ${{ env.TESTS_EXIT_CODE }} == 0 ]; then
-            echo "failure_status=failure" >> "$GITHUB_OUTPUT";
-          fi;
-
-      - name: Check if error during run occurred
-        id: set_error
-        if: always()
-        run: >
-          if [ "${{ steps.tests_step.conclusion }}" == "failure" ] || [ "${{ steps.tests_step.conclusion }}" == "skipped" ] || [ "${{ steps.tests_step.conclusion }}" == "cancelled" ]; then
-            echo "error_status=error" >> "$GITHUB_OUTPUT";
+          if [ -z ${{ env.TESTS_EXIT_CODE }} ]; then
+            echo "status=error" >> "$GITHUB_OUTPUT";
+          elif [ ! ${{ env.TESTS_EXIT_CODE }} == 0 ]; then
+            echo "status=failure" >> "$GITHUB_OUTPUT";
           fi;
 
   slack_notify:
@@ -151,15 +144,12 @@ jobs:
       - name: Set Slack message
         id: slack_message
         env:
-          failure_status: ${{ needs.run_tests.outputs.failure_status }}
-          error_status: ${{ needs.run_tests.outputs.error_status }}
+          status: ${{ needs.run_tests.outputs.status }}
         run: >
-          if [ ! -z "$failure_status" ]; then
-            message="There were failing tests 💥 ";
-            status="failure";
-          if [ ! -z "$error_status" ]; then
+          if [ "$error_status" == "error" ]; then
             message="Something went wrong ⚠️";
-            status="failure";
+          elif [ "$status" == "failure" ]; then
+            message="There were failing tests 💥 ";
           else
             message="All tests have passed ✅ ";
             status="success";


### PR DESCRIPTION
This PR fixes:

- broken screen recordings
- blank simulator logs
- wrong format of .xcresult after unzipping

Additionaly I have changed logic of setting run status from tests to be more precise - if tests don't run, there'll be error status. If tests fail, there'll be failure status. It depends on tests exit code now.