### PR TITLE
Temporary downgrade Flutter version to 3.7.12 for Android CI workflows

### DIFF
--- a/.github/workflows/test-android-device.yaml
+++ b/.github/workflows/test-android-device.yaml
@@ -43,8 +43,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
-          flutter-version: '3.7.x'
+          flutter-version: 3.7.x
 
       - name: Preload Flutter artifacts
         run: flutter precache

--- a/.github/workflows/test-android-emulator.yaml
+++ b/.github/workflows/test-android-emulator.yaml
@@ -14,8 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flutter-channel: ['stable']
-        flutter-version: ['3.7.x']
+        flutter-version: [3.7.x]
         api-level: [28, 29, 30, 31, 33]
         target: [google_apis]
         arch: [x86_64]
@@ -66,7 +65,6 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: ${{ matrix.flutter-channel }}
           flutter-version: ${{ matrix.flutter-version }}
 
       - name: Preload Flutter artifacts


### PR DESCRIPTION
We're downgrading from stable latest to stable 3.7.12 because of issue mentioned in https://github.com/leancodepl/patrol/issues/1265