### PR TITLE
Use correct, platform-native path separator everywhere

### DIFF
--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -1,7 +1,7 @@
 import 'dart:convert' show base64Encode, utf8;
 
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' show basename;
+import 'package:path/path.dart' as path;
 import 'package:patrol_cli/src/devices.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
 
@@ -45,7 +45,9 @@ class AndroidAppOptions {
   final FlutterAppOptions flutter;
   final String? packageName;
 
-  String get description => 'apk with entrypoint ${basename(flutter.target)}';
+  String get description {
+    return 'apk with entrypoint ${path.basename(flutter.target)}';
+  }
 
   List<String> toGradleAssembleInvocation({required bool isWindows}) {
     return _toGradleInvocation(
@@ -131,7 +133,7 @@ class IOSAppOptions {
 
   String get description {
     final platform = simulator ? 'simulator' : 'device';
-    return 'app with entrypoint ${basename(flutter.target)} for iOS $platform';
+    return 'app with entrypoint ${path.basename(flutter.target)} for iOS $platform';
   }
 
   /// Translates these options into a proper flutter build invocation, which
@@ -159,7 +161,7 @@ class IOSAppOptions {
 
   /// Translates these options into a proper `xcodebuild build-for-testing`
   /// invocation.
-  List<String> buildForTestingInvocation() {
+  List<String> buildForTestingInvocation(path.Context pathContext) {
     final cmd = [
       ...['xcodebuild', 'build-for-testing'],
       ...['-workspace', 'Runner.xcworkspace'],
@@ -171,7 +173,7 @@ class IOSAppOptions {
         'generic/platform=${simulator ? 'iOS Simulator' : 'iOS'}',
       ],
       '-quiet',
-      ...['-derivedDataPath', '../build/ios_integ'],
+      ...['-derivedDataPath', pathContext.join('..', 'build', 'ios_integ')],
       r'OTHER_SWIFT_FLAGS=$(inherited) -D PATROL_ENABLED',
     ];
 

--- a/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
+++ b/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
@@ -4,7 +4,6 @@ import 'dart:io' show Process;
 import 'package:dispose_scope/dispose_scope.dart';
 import 'package:file/file.dart';
 import 'package:glob/glob.dart';
-import 'package:path/path.dart' show join;
 import 'package:patrol_cli/src/base/exceptions.dart';
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/base/process.dart';
@@ -107,7 +106,7 @@ class IOSTestBackend {
       // xcodebuild build-for-testing
 
       process = await _processManager.start(
-        options.buildForTestingInvocation(),
+        options.buildForTestingInvocation(_fs.path),
         runInShell: true,
         workingDirectory: _fs.currentDirectory.childDirectory('ios').path,
       )
@@ -228,9 +227,9 @@ class IOSTestBackend {
     final targetPlatform = real ? 'iphoneos' : 'iphonesimulator';
     final glob = Glob('${scheme}_$targetPlatform$sdkVersion*.xctestrun');
 
-    var root = 'build/ios_integ/Build/Products';
+    var root = _fs.path.join('build', 'ios_integ', 'Build', 'Products');
     if (absolutePath) {
-      root = join(_fs.currentDirectory.absolute.path, root);
+      root = _fs.path.join(_fs.currentDirectory.absolute.path, root);
     }
     _logger.detail('Looking for .xctestrun matching ${glob.pattern} at $root');
     final files = await glob.listFileSystem(_fs, root: root).toList();

--- a/packages/patrol_cli/test/crossplatform/app_options_test.dart
+++ b/packages/patrol_cli/test/crossplatform/app_options_test.dart
@@ -1,10 +1,20 @@
+import 'package:path/path.dart' as path;
 import 'package:patrol_cli/src/crossplatform/app_options.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
+import '../src/common.dart';
 import '../src/fixtures.dart';
 
 void main() {
+  _test(initFakePlatform(Platform.macOS));
+  _test(initFakePlatform(Platform.windows));
+}
+
+final _path = path.Context(style: path.Style.posix);
+
+void _test(Platform platform) {
   group('AndroidAppOptions', () {
     late AndroidAppOptions options;
 
@@ -140,7 +150,7 @@ void main() {
           ]),
         );
 
-        final xcodebuildInvocation = options.buildForTestingInvocation();
+        final xcodebuildInvocation = options.buildForTestingInvocation(_path);
 
         expect(
           xcodebuildInvocation,
@@ -221,7 +231,7 @@ void main() {
             ]),
           );
 
-          final xcodebuildInvocation = options.buildForTestingInvocation();
+          final xcodebuildInvocation = options.buildForTestingInvocation(_path);
 
           expect(
             xcodebuildInvocation,

--- a/packages/patrol_cli/test/general/dart_defines_reader_test.dart
+++ b/packages/patrol_cli/test/general/dart_defines_reader_test.dart
@@ -15,7 +15,7 @@ void main() {
 void _test(Platform platform) {
   late FileSystem fs;
 
-  group('DartDefinesReader', () {
+  group('(${platform.operatingSystem}) DartDefinesReader', () {
     late DartDefinesReader reader;
 
     setUp(() {


### PR DESCRIPTION
This PR is a follow-up of #1274. Most of the work to migrate to platform-native path separator was done there.

In this PR, I'm only refactoring the iOS-specific classes. This is low-prio because functionality provided by these iOS-specific classes can only be used when `patrol_cli` is running on a macOS host, which always has the Unix-style path separator.