### PR TITLE
Fix hot restart being broken on `develop` branch

### DIFF
--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -163,10 +163,12 @@ class PatrolBinding extends IntegrationTestWidgetsFlutterBinding {
 
   @override
   void attachRootWidget(Widget rootWidget) {
-    assert(_currentDartTestFile != null);
+    if (!constants.hotRestartEnabled) {
+      assert(_currentDartTestFile != null);
+    }
 
     const testLabelEnabled = bool.fromEnvironment('PATROL_TEST_LABEL_ENABLED');
-    if (!testLabelEnabled) {
+    if (!testLabelEnabled || constants.hotRestartEnabled) {
       super.attachRootWidget(RepaintBoundary(child: rootWidget));
     } else {
       super.attachRootWidget(


### PR DESCRIPTION
This PR fixes #1344.

Cause: an invariant was being violated when hot restart was enabled.

I broke this in #1306, and since we have no tests for hot restart on CI, it passed through.