### PR TITLE
Create a new constructor for `PatrolAppServiceClient`

### DIFF
--- a/docs/getting-started/native.mdx
+++ b/docs/getting-started/native.mdx
@@ -144,6 +144,7 @@ Psst... Android is a bit easier to set up, so we recommend starting with it!
       ```java title="MainActivityTest.java"
       package pl.leancode.patrol.example; // replace "pl.leancode.patrol.example" with your app's package
 
+      import androidx.test.platform.app.InstrumentationRegistry;
       import org.junit.Test;
       import org.junit.runner.RunWith;
       import org.junit.runners.Parameterized;
@@ -154,9 +155,10 @@ Psst... Android is a bit easier to set up, so we recommend starting with it!
       public class MainActivityTest {
           @Parameters(name = "{0}")
           public static Object[] testCases() {
-              PatrolJUnitRunner.setUp(MainActivity.class);
-              PatrolJUnitRunner.waitForPatrolAppService();
-              return PatrolJUnitRunner.listDartTests();
+              PatrolJUnitRunner instrumentation = (PatrolJUnitRunner) InstrumentationRegistry.getInstrumentation();
+              instrumentation.setUp(MainActivity.class);
+              instrumentation.waitForPatrolAppService();
+              return instrumentation.listDartTests();
           }
 
           public MainActivityTest(String dartTestName) {
@@ -167,7 +169,8 @@ Psst... Android is a bit easier to set up, so we recommend starting with it!
 
           @Test
           public void runDartTest() {
-              PatrolJUnitRunner.runDartTest(dartTestName);
+              PatrolJUnitRunner instrumentation = (PatrolJUnitRunner) InstrumentationRegistry.getInstrumentation();
+              instrumentation.runDartTest(dartTestName);
           }
       }
       ```

--- a/docs/migration_guide_v2.mdx
+++ b/docs/migration_guide_v2.mdx
@@ -45,6 +45,7 @@ com, example, and myapp with values from your app's package name).
 ```java title="MainActivityTest.java"
 package pl.leancode.patrol.example; // replace "pl.leancode.patrol.example" with your app's package
 
+import androidx.test.platform.app.InstrumentationRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -55,9 +56,10 @@ import pl.leancode.patrol.PatrolJUnitRunner;
 public class MainActivityTest {
     @Parameters(name = "{0}")
     public static Object[] testCases() {
-        PatrolJUnitRunner.setUp(MainActivity.class);
-        PatrolJUnitRunner.waitForPatrolAppService();
-        return PatrolJUnitRunner.listDartTests();
+        PatrolJUnitRunner instrumentation = (PatrolJUnitRunner) InstrumentationRegistry.getInstrumentation();
+        instrumentation.setUp(MainActivity.class);
+        instrumentation.waitForPatrolAppService();
+        return instrumentation.listDartTests();
     }
 
     public MainActivityTest(String dartTestName) {
@@ -68,7 +70,8 @@ public class MainActivityTest {
 
     @Test
     public void runDartTest() {
-        PatrolJUnitRunner.runDartTest(dartTestName);
+        PatrolJUnitRunner instrumentation = (PatrolJUnitRunner) InstrumentationRegistry.getInstrumentation();
+        instrumentation.runDartTest(dartTestName);
     }
 }
 ```

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAppServiceClient.java
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAppServiceClient.java
@@ -15,15 +15,16 @@ public class PatrolAppServiceClient {
 
     private final PatrolAppServiceGrpc.PatrolAppServiceBlockingStub blockingStub;
 
-    /**
-     * Construct client for accessing PatrolAppService server using the existing channel.
-     */
     public PatrolAppServiceClient() {
         String target = "localhost:8082"; // TODO: Document this value better
+        Logger.INSTANCE.i("Created PatrolAppServiceClient with default target: " + target);
+        ManagedChannel channel = Grpc.newChannelBuilder(target, InsecureChannelCredentials.create()).build();
+        blockingStub = PatrolAppServiceGrpc.newBlockingStub(channel);
+    }
+
+    public PatrolAppServiceClient(String target) {
         Logger.INSTANCE.i("Created PatrolAppServiceClient, target: " + target);
         ManagedChannel channel = Grpc.newChannelBuilder(target, InsecureChannelCredentials.create()).build();
-
-        // Passing Channels to code makes code easier to test and makes it easier to reuse Channels.
         blockingStub = PatrolAppServiceGrpc.newBlockingStub(channel);
     }
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
@@ -24,7 +24,7 @@ import static pl.leancode.patrol.contracts.Contracts.RunDartTestResponse;
  * </p>
  */
 public class PatrolJUnitRunner extends AndroidJUnitRunner {
-    public static PatrolAppServiceClient patrolAppServiceClient;
+    public PatrolAppServiceClient patrolAppServiceClient;
 
     @Override
     protected boolean shouldWaitForActivitiesToComplete() {
@@ -56,7 +56,7 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
      * The app must also be run, and queried for Dart tests That's what this method does.
      * </p>
      */
-    public static void setUp(Class<?> activityClass) {
+    public void setUp(Class<?> activityClass) {
         Logger.INSTANCE.i("PatrolJUnitRunner.setUp(): activityClass = " + activityClass.getCanonicalName());
 
         // This code launches the app under test. It's based on ActivityTestRule#launchActivity.
@@ -70,6 +70,8 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
 
         PatrolServer patrolServer = new PatrolServer();
         patrolServer.start(); // Gets killed when the instrumentation process dies. We're okay with this.
+
+        patrolAppServiceClient = new PatrolAppServiceClient();
     }
 
     /**
@@ -82,7 +84,7 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
      * PatrolAppService becomes ready once the special Dart test named "patrol_test_explorer" finishes running.
      * </p>
      */
-    public static void waitForPatrolAppService() {
+    public void waitForPatrolAppService() {
         final String TAG = "PatrolJUnitRunner.setUp(): ";
 
         try {
@@ -96,7 +98,7 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
         Logger.INSTANCE.i(TAG + "PatrolAppService is ready to report Dart tests");
     }
 
-    public static Object[] listDartTests() {
+    public Object[] listDartTests() {
         final String TAG = "PatrolJUnitRunner.listDartTests(): ";
 
         try {
@@ -114,7 +116,7 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
      * Requests execution of a Dart test and waits for it to finish.
      * Throws AssertionError if the test fails.
      */
-    public static RunDartTestResponse runDartTest(String name) {
+    public RunDartTestResponse runDartTest(String name) {
         final String TAG = "PatrolJUnitRunner.runDartTest(" + name + "): ";
 
         try {

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
@@ -71,7 +71,11 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
         PatrolServer patrolServer = new PatrolServer();
         patrolServer.start(); // Gets killed when the instrumentation process dies. We're okay with this.
 
-        patrolAppServiceClient = new PatrolAppServiceClient();
+        patrolAppServiceClient = createAppServiceClient();
+    }
+
+    public PatrolAppServiceClient createAppServiceClient() {
+        return new PatrolAppServiceClient();
     }
 
     /**

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
@@ -24,7 +24,7 @@ import static pl.leancode.patrol.contracts.Contracts.RunDartTestResponse;
  * </p>
  */
 public class PatrolJUnitRunner extends AndroidJUnitRunner {
-    private static PatrolAppServiceClient patrolAppServiceClient;
+    public static PatrolAppServiceClient patrolAppServiceClient;
 
     @Override
     protected boolean shouldWaitForActivitiesToComplete() {
@@ -70,13 +70,11 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
 
         PatrolServer patrolServer = new PatrolServer();
         patrolServer.start(); // Gets killed when the instrumentation process dies. We're okay with this.
-
-        patrolAppServiceClient = new PatrolAppServiceClient();
     }
 
     /**
      * <p>
-     * Waits until PatrolAppService, running in the Dart side of the app, reports 
+     * Waits until PatrolAppService, running in the Dart side of the app, reports
      * that it's ready to be asked about the list of Dart tests.
      * </p>
      *

--- a/packages/patrol/example/android/app/src/androidTest/java/pl/leancode/patrol/example/MainActivityTest.java
+++ b/packages/patrol/example/android/app/src/androidTest/java/pl/leancode/patrol/example/MainActivityTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import pl.leancode.patrol.PatrolAppServiceClient;
 import pl.leancode.patrol.PatrolJUnitRunner;
 
 @RunWith(Parameterized.class)
@@ -11,6 +12,7 @@ public class MainActivityTest {
     @Parameters(name = "{0}")
     public static Object[] testCases() {
         PatrolJUnitRunner.setUp(MainActivity.class);
+        PatrolJUnitRunner.patrolAppServiceClient = new PatrolAppServiceClient();
         PatrolJUnitRunner.waitForPatrolAppService();
         return PatrolJUnitRunner.listDartTests();
     }

--- a/packages/patrol/example/android/app/src/androidTest/java/pl/leancode/patrol/example/MainActivityTest.java
+++ b/packages/patrol/example/android/app/src/androidTest/java/pl/leancode/patrol/example/MainActivityTest.java
@@ -1,20 +1,20 @@
 package pl.leancode.patrol.example;
 
+import androidx.test.platform.app.InstrumentationRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-import pl.leancode.patrol.PatrolAppServiceClient;
 import pl.leancode.patrol.PatrolJUnitRunner;
 
 @RunWith(Parameterized.class)
 public class MainActivityTest {
     @Parameters(name = "{0}")
     public static Object[] testCases() {
-        PatrolJUnitRunner.setUp(MainActivity.class);
-        PatrolJUnitRunner.patrolAppServiceClient = new PatrolAppServiceClient();
-        PatrolJUnitRunner.waitForPatrolAppService();
-        return PatrolJUnitRunner.listDartTests();
+        PatrolJUnitRunner instrumentation = (PatrolJUnitRunner) InstrumentationRegistry.getInstrumentation();
+        instrumentation.setUp(MainActivity.class);
+        instrumentation.waitForPatrolAppService();
+        return instrumentation.listDartTests();
     }
 
     public MainActivityTest(String dartTestName) {
@@ -25,6 +25,7 @@ public class MainActivityTest {
 
     @Test
     public void runDartTest() {
-        PatrolJUnitRunner.runDartTest(dartTestName);
+        PatrolJUnitRunner instrumentation = (PatrolJUnitRunner) InstrumentationRegistry.getInstrumentation();
+        instrumentation.runDartTest(dartTestName);
     }
 }


### PR DESCRIPTION
Required to make BrowserStack workaround work without modifying Patrol's internal files.