### PR TITLE
Increase native find timeout in example app's UI tests

### DIFF
--- a/packages/patrol/example/integration_test/common.dart
+++ b/packages/patrol/example/integration_test/common.dart
@@ -7,7 +7,9 @@ export 'package:flutter_test/flutter_test.dart';
 export 'package:patrol/patrol.dart';
 
 final _patrolTesterConfig = PatrolTesterConfig();
-final _nativeAutomatorConfig = NativeAutomatorConfig();
+final _nativeAutomatorConfig = NativeAutomatorConfig(
+  findTimeout: Duration(seconds: 20), // 10 seconds is too short for some CIs
+);
 
 Future<void> createApp(PatrolTester $) async {
   await setUpTimezone();


### PR DESCRIPTION
Hopefully, it fixes webview flakiness on CIs.