### PR TITLE
Added check of kIsWeb before usage of Platform / dart:io package

### DIFF
--- a/packages/patrol/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_tester.dart
@@ -314,7 +314,7 @@ class PatrolTester {
     Duration? visibleTimeout,
     Duration? settleTimeout,
   }) {
-    if (Platform.isIOS && kReleaseMode) {
+    if (!kIsWeb && Platform.isIOS && kReleaseMode) {
       // Fix for enterText() not working in release mode on real iOS devices.
       // See https://github.com/flutter/flutter/pull/89703
       tester.testTextInput.register();


### PR DESCRIPTION
Fix for https://github.com/leancodepl/patrol/issues/1457

Prevent usage of Platform package which uses dart:io, because this doesn't work on Flutter Web.