### PR TITLE
Add dart defines from file

### DIFF
--- a/packages/patrol/example/defines_1.json
+++ b/packages/patrol/example/defines_1.json
@@ -1,0 +1,4 @@
+{
+    "FIRST_KEY": "First key from defines_1.json",
+    "SECOND_KEY": "Second key from defines_1.json"
+}

--- a/packages/patrol/example/defines_2.json
+++ b/packages/patrol/example/defines_2.json
@@ -1,0 +1,5 @@
+{
+    "FIRST_KEY": "First key from defines_2.json",
+    "SECOND_KEY": "Second key from defines_2.json",
+    "THIRD_KEY": "Third key from defines_2.json"
+}

--- a/packages/patrol/example/lib/main.dart
+++ b/packages/patrol/example/lib/main.dart
@@ -236,7 +236,9 @@ class _ExampleHomePageState extends State<ExampleHomePage> {
             ),
             child: const Text('Open permissions screen'),
           ),
-          Text('EXAMPLE_KEY: ${const String.fromEnvironment('EXAMPLE_KEY')}'),
+          Text('FIRST_KEY: ${const String.fromEnvironment('FIRST_KEY')}'),
+          Text('SECOND_KEY: ${const String.fromEnvironment('SECOND_KEY')}'),
+          Text('THIRD_KEY: ${const String.fromEnvironment('THIRD_KEY')}'),
         ],
       ),
       floatingActionButton: FloatingActionButton(

--- a/packages/patrol_cli/lib/src/commands/build_android.dart
+++ b/packages/patrol_cli/lib/src/commands/build_android.dart
@@ -124,6 +124,7 @@ class BuildAndroidCommand extends PatrolCommand {
       buildMode: buildMode,
       dartDefines: dartDefines,
       dartDefineFromFile: dartDefineFromFile,
+      dartDefineFromFilePath: dartDefineFromFilePath,
     );
     final androidOpts = AndroidAppOptions(
       flutter: flutterOpts,

--- a/packages/patrol_cli/lib/src/commands/build_android.dart
+++ b/packages/patrol_cli/lib/src/commands/build_android.dart
@@ -109,7 +109,7 @@ class BuildAndroidCommand extends PatrolCommand {
       );
     }
 
-    final dartDefineFromFilePath = stringsArg('dart-define-from-file');
+    final dartDefineFromFilePath = stringArg('dart-define-from-file') ?? '';
     if (dartDefineFromFilePath.isNotEmpty) {
       _logger.detail(
         'Received path for --dart-define-from-file: $dartDefineFromFilePath',
@@ -121,6 +121,7 @@ class BuildAndroidCommand extends PatrolCommand {
       flavor: flavor,
       buildMode: buildMode,
       dartDefines: dartDefines,
+      dartDefinesPath: dartDefineFromFilePath,
     );
     final androidOpts = AndroidAppOptions(
       flutter: flutterOpts,

--- a/packages/patrol_cli/lib/src/commands/build_android.dart
+++ b/packages/patrol_cli/lib/src/commands/build_android.dart
@@ -31,6 +31,7 @@ class BuildAndroidCommand extends PatrolCommand {
     usesBuildModeOption();
     usesFlavorOption();
     usesDartDefineOption();
+    usesDartDefineFromFileOption();
     usesLabelOption();
     usesWaitOption();
 
@@ -105,6 +106,13 @@ class BuildAndroidCommand extends PatrolCommand {
     for (final dartDefine in internalDartDefines.entries) {
       _logger.detail(
         'Received internal --dart-define: ${dartDefine.key}=${dartDefine.value}',
+      );
+    }
+
+    final dartDefineFromFilePath = stringsArg('dart-define-from-file');
+    if (dartDefineFromFilePath.isNotEmpty) {
+      _logger.detail(
+        'Received path for --dart-define-from-file: $dartDefineFromFilePath',
       );
     }
 

--- a/packages/patrol_cli/lib/src/commands/build_android.dart
+++ b/packages/patrol_cli/lib/src/commands/build_android.dart
@@ -115,13 +115,15 @@ class BuildAndroidCommand extends PatrolCommand {
         'Received path for --dart-define-from-file: $dartDefineFromFilePath',
       );
     }
+    final dartDefineFromFile =
+        _dartDefinesReader.fromConfigFile(path: dartDefineFromFilePath);
 
     final flutterOpts = FlutterAppOptions(
       target: testBundle.path,
       flavor: flavor,
       buildMode: buildMode,
       dartDefines: dartDefines,
-      dartDefinesPath: dartDefineFromFilePath,
+      dartDefineFromFile: dartDefineFromFile,
     );
     final androidOpts = AndroidAppOptions(
       flutter: flutterOpts,

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -92,6 +92,7 @@ class BuildIOSCommand extends PatrolCommand {
       ..._dartDefinesReader.fromFile(),
       ..._dartDefinesReader.fromCli(args: stringsArg('dart-define')),
     };
+
     final internalDartDefines = {
       'PATROL_WAIT': defaultWait.toString(),
       'PATROL_APP_BUNDLE_ID': bundleId,
@@ -115,18 +116,21 @@ class BuildIOSCommand extends PatrolCommand {
     }
 
     final dartDefineFromFilePath = stringArg('dart-define-from-file') ?? '';
+
     if (dartDefineFromFilePath.isNotEmpty) {
       _logger.detail(
         'Received path for --dart-define-from-file: $dartDefineFromFilePath',
       );
     }
+    final dartDefineFromFile =
+        _dartDefinesReader.fromConfigFile(path: dartDefineFromFilePath);
 
     final flutterOpts = FlutterAppOptions(
       target: testBundle.path,
       flavor: flavor,
       buildMode: buildMode,
       dartDefines: dartDefines,
-      dartDefinesPath: dartDefineFromFilePath,
+      dartDefineFromFile: dartDefineFromFile,
     );
 
     final iosOpts = IOSAppOptions(

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -114,11 +114,19 @@ class BuildIOSCommand extends PatrolCommand {
       );
     }
 
+    final dartDefineFromFilePath = stringArg('dart-define-from-file') ?? '';
+    if (dartDefineFromFilePath.isNotEmpty) {
+      _logger.detail(
+        'Received path for --dart-define-from-file: $dartDefineFromFilePath',
+      );
+    }
+
     final flutterOpts = FlutterAppOptions(
       target: testBundle.path,
       flavor: flavor,
       buildMode: buildMode,
       dartDefines: dartDefines,
+      dartDefinesPath: dartDefineFromFilePath,
     );
 
     final iosOpts = IOSAppOptions(

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -122,8 +122,10 @@ class BuildIOSCommand extends PatrolCommand {
         'Received path for --dart-define-from-file: $dartDefineFromFilePath',
       );
     }
-    final dartDefineFromFile =
-        _dartDefinesReader.fromConfigFile(path: dartDefineFromFilePath);
+    final dartDefineFromFile = _overrideKeys(
+      json: _dartDefinesReader.fromConfigFile(path: dartDefineFromFilePath),
+      dartDefines: dartDefines,
+    );
 
     final flutterOpts = FlutterAppOptions(
       target: testBundle.path,
@@ -191,5 +193,20 @@ class BuildIOSCommand extends PatrolCommand {
     );
 
     _logger.info('$xcTestRunPath (xctestrun file)');
+  }
+
+  Map<String, dynamic> _overrideKeys({
+    required Map<String, dynamic> json,
+    required Map<String, String> dartDefines,
+  }) {
+    final modified = Map<String, dynamic>.from(json);
+    if (dartDefines.isNotEmpty) {
+      modified.forEach((key, value) {
+        if (dartDefines.containsKey(key)) {
+          modified[key] = dartDefines[key];
+        }
+      });
+    }
+    return modified;
   }
 }

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -32,6 +32,7 @@ class BuildIOSCommand extends PatrolCommand {
     usesBuildModeOption();
     usesFlavorOption();
     usesDartDefineOption();
+    usesDartDefineFromFileOption();
     usesLabelOption();
     usesWaitOption();
 

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -131,6 +131,7 @@ class BuildIOSCommand extends PatrolCommand {
       buildMode: buildMode,
       dartDefines: dartDefines,
       dartDefineFromFile: dartDefineFromFile,
+      dartDefineFromFilePath: dartDefineFromFilePath,
     );
 
     final iosOpts = IOSAppOptions(

--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -156,6 +156,7 @@ class DevelopCommand extends PatrolCommand {
       buildMode: buildMode,
       dartDefines: dartDefines,
       dartDefineFromFile: dartDefineFromFile,
+      dartDefineFromFilePath: dartDefineFromFilePath,
     );
 
     final androidOpts = AndroidAppOptions(

--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -141,11 +141,19 @@ class DevelopCommand extends PatrolCommand {
       );
     }
 
+    final dartDefineFromFilePath = stringArg('dart-define-from-file') ?? '';
+    if (dartDefineFromFilePath.isNotEmpty) {
+      _logger.detail(
+        'Received path for --dart-define-from-file: $dartDefineFromFilePath',
+      );
+    }
+
     final flutterOpts = FlutterAppOptions(
       target: entrypoint.path,
       flavor: androidFlavor,
       buildMode: buildMode,
       dartDefines: dartDefines,
+      dartDefinesPath: dartDefineFromFilePath,
     );
 
     final androidOpts = AndroidAppOptions(

--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -147,13 +147,15 @@ class DevelopCommand extends PatrolCommand {
         'Received path for --dart-define-from-file: $dartDefineFromFilePath',
       );
     }
+    final dartDefineFromFile =
+        _dartDefinesReader.fromConfigFile(path: dartDefineFromFilePath);
 
     final flutterOpts = FlutterAppOptions(
       target: entrypoint.path,
       flavor: androidFlavor,
       buildMode: buildMode,
       dartDefines: dartDefines,
-      dartDefinesPath: dartDefineFromFilePath,
+      dartDefineFromFile: dartDefineFromFile,
     );
 
     final androidOpts = AndroidAppOptions(

--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -42,6 +42,7 @@ class DevelopCommand extends PatrolCommand {
     usesBuildModeOption();
     usesFlavorOption();
     usesDartDefineOption();
+    usesDartDefineFromFileOption();
     usesLabelOption();
     usesWaitOption();
 

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -160,6 +160,7 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
       buildMode: buildMode,
       dartDefines: dartDefines,
       dartDefineFromFile: dartDefineFromFile,
+      dartDefineFromFilePath: dartDefineFromFilePath,
     );
 
     final androidOpts = AndroidAppOptions(

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -151,13 +151,15 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
         'Received path for --dart-define-from-file: $dartDefineFromFilePath',
       );
     }
+    final dartDefineFromFile =
+        _dartDefinesReader.fromConfigFile(path: dartDefineFromFilePath);
 
     final flutterOpts = FlutterAppOptions(
       target: entrypoint.path,
       flavor: androidFlavor,
       buildMode: buildMode,
       dartDefines: dartDefines,
-      dartDefinesPath: dartDefineFromFilePath,
+      dartDefineFromFile: dartDefineFromFile,
     );
 
     final androidOpts = AndroidAppOptions(

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -145,11 +145,19 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
       );
     }
 
+    final dartDefineFromFilePath = stringArg('dart-define-from-file') ?? '';
+    if (dartDefineFromFilePath.isNotEmpty) {
+      _logger.detail(
+        'Received path for --dart-define-from-file: $dartDefineFromFilePath',
+      );
+    }
+
     final flutterOpts = FlutterAppOptions(
       target: entrypoint.path,
       flavor: androidFlavor,
       buildMode: buildMode,
       dartDefines: dartDefines,
+      dartDefinesPath: dartDefineFromFilePath,
     );
 
     final androidOpts = AndroidAppOptions(

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -38,6 +38,7 @@ class TestCommand extends PatrolCommand {
     usesBuildModeOption();
     usesFlavorOption();
     usesDartDefineOption();
+    usesDartDefineFromFileOption();
     usesLabelOption();
     usesWaitOption();
 

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -11,12 +11,14 @@ class FlutterAppOptions {
     required this.flavor,
     required this.buildMode,
     required this.dartDefines,
+    this.dartDefinesPath = '',
   });
 
   final String target;
   final String? flavor;
   final BuildMode buildMode;
   final Map<String, String> dartDefines;
+  final String dartDefinesPath;
 
   /// Translates these options into a proper `flutter attach`.
   @nonVirtual
@@ -29,6 +31,10 @@ class FlutterAppOptions {
       for (final dartDefine in dartDefines.entries) ...[
         '--dart-define',
         '${dartDefine.key}=${dartDefine.value}',
+      ],
+      if (dartDefinesPath.isNotEmpty) ...[
+        '--dart-define-from-file',
+        dartDefinesPath
       ],
     ];
 
@@ -108,6 +114,11 @@ class AndroidAppOptions {
       }
 
       cmd.add('-Pdart-defines=$dartDefinesString');
+    }
+    if (flutter.dartDefinesPath.isNotEmpty) {
+      final dartDefinesFromFile =
+          '-Pdart-define-from-file=${flutter.dartDefinesPath}';
+      cmd.add(dartDefinesFromFile);
     }
 
     return cmd;

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -12,6 +12,7 @@ class FlutterAppOptions {
     required this.buildMode,
     required this.dartDefines,
     required this.dartDefineFromFile,
+    required this.dartDefineFromFilePath,
   });
 
   final String target;
@@ -19,6 +20,7 @@ class FlutterAppOptions {
   final BuildMode buildMode;
   final Map<String, String> dartDefines;
   final Map<String, dynamic> dartDefineFromFile;
+  final String dartDefineFromFilePath;
 
   /// Translates these options into a proper `flutter attach`.
   @nonVirtual
@@ -32,6 +34,10 @@ class FlutterAppOptions {
         '--dart-define',
         '${dartDefine.key}=${dartDefine.value}',
       ],
+      if (dartDefineFromFilePath.isNotEmpty) ...[
+        '--dart-define-from-file',
+        dartDefineFromFilePath,
+      ]
     ];
 
     return cmd;
@@ -166,6 +172,10 @@ class IOSAppOptions {
         '--dart-define',
         '${dartDefine.key}=${dartDefine.value}',
       ],
+      if (flutter.dartDefineFromFilePath.isNotEmpty) ...[
+        '--dart-define-from-file',
+        flutter.dartDefineFromFilePath,
+      ]
     ];
 
     return cmd;

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -118,7 +118,11 @@ class AndroidAppOptions {
       cmd.add('-Pdart-defines=$dartDefinesString');
     }
     if (flutter.dartDefineFromFile.isNotEmpty) {
-      cmd.addAll(_parseJsonToGradleConfig(flutter.dartDefineFromFile));
+      final dartDefinesFromFile = _overrideKeys(
+        json: flutter.dartDefineFromFile,
+        dartDefines: flutter.dartDefines,
+      );
+      cmd.addAll(_parseJsonToGradleConfig(dartDefinesFromFile));
     }
 
     return cmd;
@@ -131,6 +135,21 @@ class AndroidAppOptions {
     });
 
     return result;
+  }
+
+  Map<String, dynamic> _overrideKeys({
+    required Map<String, dynamic> json,
+    required Map<String, String> dartDefines,
+  }) {
+    final modified = Map<String, dynamic>.from(json);
+    if (dartDefines.isNotEmpty) {
+      modified.forEach((key, value) {
+        if (dartDefines.containsKey(key)) {
+          modified[key] = dartDefines[key];
+        }
+      });
+    }
+    return modified;
   }
 }
 

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -20,7 +20,7 @@ class FlutterAppOptions {
   final BuildMode buildMode;
   final Map<String, String> dartDefines;
   final Map<String, dynamic> dartDefineFromFile;
-  final String dartDefineFromFilePath;
+  final String? dartDefineFromFilePath;
 
   /// Translates these options into a proper `flutter attach`.
   @nonVirtual
@@ -34,9 +34,9 @@ class FlutterAppOptions {
         '--dart-define',
         '${dartDefine.key}=${dartDefine.value}',
       ],
-      if (dartDefineFromFilePath.isNotEmpty) ...[
+      if (dartDefineFromFilePath != null) ...[
         '--dart-define-from-file',
-        dartDefineFromFilePath,
+        dartDefineFromFilePath!,
       ]
     ];
 
@@ -191,9 +191,9 @@ class IOSAppOptions {
         '--dart-define',
         '${dartDefine.key}=${dartDefine.value}',
       ],
-      if (flutter.dartDefineFromFilePath.isNotEmpty) ...[
+      if (flutter.dartDefineFromFilePath != null) ...[
         '--dart-define-from-file',
-        flutter.dartDefineFromFilePath,
+        flutter.dartDefineFromFilePath!,
       ]
     ];
 

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -11,7 +11,7 @@ class FlutterAppOptions {
     required this.flavor,
     required this.buildMode,
     required this.dartDefines,
-    this.dartDefineFromFile = const {},
+    required this.dartDefineFromFile,
   });
 
   final String target;

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -11,14 +11,14 @@ class FlutterAppOptions {
     required this.flavor,
     required this.buildMode,
     required this.dartDefines,
-    this.dartDefinesPath = '',
+    this.dartDefineFromFile = const {},
   });
 
   final String target;
   final String? flavor;
   final BuildMode buildMode;
   final Map<String, String> dartDefines;
-  final String dartDefinesPath;
+  final Map<String, dynamic> dartDefineFromFile;
 
   /// Translates these options into a proper `flutter attach`.
   @nonVirtual
@@ -31,10 +31,6 @@ class FlutterAppOptions {
       for (final dartDefine in dartDefines.entries) ...[
         '--dart-define',
         '${dartDefine.key}=${dartDefine.value}',
-      ],
-      if (dartDefinesPath.isNotEmpty) ...[
-        '--dart-define-from-file',
-        dartDefinesPath
       ],
     ];
 
@@ -115,13 +111,20 @@ class AndroidAppOptions {
 
       cmd.add('-Pdart-defines=$dartDefinesString');
     }
-    if (flutter.dartDefinesPath.isNotEmpty) {
-      final dartDefinesFromFile =
-          '-Pdart-define-from-file=${flutter.dartDefinesPath}';
-      cmd.add(dartDefinesFromFile);
+    if (flutter.dartDefineFromFile.isNotEmpty) {
+      cmd.addAll(_parseJsonToGradleConfig(flutter.dartDefineFromFile));
     }
 
     return cmd;
+  }
+
+  List<String> _parseJsonToGradleConfig(Map<String, dynamic> json) {
+    final result = <String>[];
+    json.forEach((key, value) {
+      result.add('-P$key=$value');
+    });
+
+    return result;
   }
 }
 

--- a/packages/patrol_cli/lib/src/dart_defines_reader.dart
+++ b/packages/patrol_cli/lib/src/dart_defines_reader.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:file/file.dart';
 import 'package:patrol_cli/src/base/extensions/core.dart';
 
@@ -23,6 +25,19 @@ class DartDefinesReader {
     final lines = file.readAsLinesSync()
       ..removeWhere((line) => line.trim().isEmpty);
     return _parse(lines);
+  }
+
+  Map<String, dynamic> fromConfigFile({required String path}) {
+    final filePath = _fs.path.join(_projectRoot.path, path);
+    final file = _fs.file(filePath);
+
+    if (!file.existsSync()) {
+      return {};
+    }
+
+    final jsonString = file.readAsStringSync();
+    final json = jsonDecode(jsonString) as Map<String, dynamic>;
+    return json;
   }
 
   Map<String, String> _parse(List<String> args) {

--- a/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
+++ b/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
@@ -110,6 +110,7 @@ class IOSTestBackend {
         options.buildForTestingInvocation(),
         runInShell: true,
         workingDirectory: _fs.currentDirectory.childDirectory('ios').path,
+        environment: Map.castFrom(options.flutter.dartDefineFromFile),
       )
         ..disposedBy(scope);
       process.listenStdOut((l) => _logger.detail('\t$l')).disposedBy(scope);
@@ -156,6 +157,7 @@ class IOSTestBackend {
         ),
         runInShell: true,
         workingDirectory: _fs.currentDirectory.childDirectory('ios').path,
+        environment: Map.castFrom(options.flutter.dartDefineFromFile),
       )
         ..disposedBy(_disposeScope);
       process.listenStdOut((l) => _logger.detail('\t$l')).disposedBy(scope);

--- a/packages/patrol_cli/lib/src/runner/patrol_command.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command.dart
@@ -94,6 +94,17 @@ abstract class PatrolCommand extends Command<int> {
     );
   }
 
+  void usesDartDefineFromFileOption() {
+    argParser.addMultiOption(
+      'dart-define-from-file',
+      aliases: ['dart-define-from-file'],
+      help:
+          'Environment configuration from a provided path that will be available to the app '
+          'under test.',
+      valueHelp: 'config/test.json',
+    );
+  }
+
   void usesAndroidOptions() {
     argParser.addOption(
       'package-name',

--- a/packages/patrol_cli/lib/src/runner/patrol_command.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command.dart
@@ -95,7 +95,7 @@ abstract class PatrolCommand extends Command<int> {
   }
 
   void usesDartDefineFromFileOption() {
-    argParser.addMultiOption(
+    argParser.addOption(
       'dart-define-from-file',
       aliases: ['dart-define-from-file'],
       help:

--- a/packages/patrol_cli/lib/src/runner/patrol_command.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command.dart
@@ -97,7 +97,6 @@ abstract class PatrolCommand extends Command<int> {
   void usesDartDefineFromFileOption() {
     argParser.addOption(
       'dart-define-from-file',
-      aliases: ['dart-define-from-file'],
       help:
           'Environment configuration from a provided path that will be available to the app '
           'under test.',

--- a/packages/patrol_cli/test/crossplatform/app_options_test.dart
+++ b/packages/patrol_cli/test/crossplatform/app_options_test.dart
@@ -16,6 +16,7 @@ void main() {
           flavor: null,
           dartDefines: {},
           dartDefineFromFile: {},
+          dartDefineFromFilePath: '',
         );
         options = AndroidAppOptions(flutter: flutterOptions);
 
@@ -38,6 +39,7 @@ void main() {
           flavor: null,
           dartDefines: {},
           dartDefineFromFile: {},
+          dartDefineFromFilePath: '',
         );
         options = AndroidAppOptions(flutter: flutterOpts);
 
@@ -68,6 +70,7 @@ void main() {
           flavor: 'dev',
           dartDefines: dartDefines,
           dartDefineFromFile: {},
+          dartDefineFromFilePath: '',
         );
         options = AndroidAppOptions(flutter: flutterOpts);
 
@@ -91,6 +94,7 @@ void main() {
           flavor: 'dev',
           dartDefines: dartDefines,
           dartDefineFromFile: {},
+          dartDefineFromFilePath: '',
         );
         options = AndroidAppOptions(flutter: flutterOpts);
 
@@ -119,6 +123,7 @@ void main() {
         flavor: null,
         dartDefines: {},
         dartDefineFromFile: {},
+        dartDefineFromFilePath: '',
       );
 
       setUp(() {
@@ -198,6 +203,7 @@ void main() {
             'foo': 'bar',
           },
           dartDefineFromFile: {},
+          dartDefineFromFilePath: '',
         );
 
         setUp(() {

--- a/packages/patrol_cli/test/crossplatform/app_options_test.dart
+++ b/packages/patrol_cli/test/crossplatform/app_options_test.dart
@@ -15,6 +15,7 @@ void main() {
           buildMode: BuildMode.debug,
           flavor: null,
           dartDefines: {},
+          dartDefineFromFile: {},
         );
         options = AndroidAppOptions(flutter: flutterOptions);
 
@@ -36,6 +37,7 @@ void main() {
           buildMode: BuildMode.debug,
           flavor: null,
           dartDefines: {},
+          dartDefineFromFile: {},
         );
         options = AndroidAppOptions(flutter: flutterOpts);
 
@@ -65,6 +67,7 @@ void main() {
           buildMode: BuildMode.debug,
           flavor: 'dev',
           dartDefines: dartDefines,
+          dartDefineFromFile: {},
         );
         options = AndroidAppOptions(flutter: flutterOpts);
 
@@ -87,6 +90,7 @@ void main() {
           buildMode: BuildMode.debug,
           flavor: 'dev',
           dartDefines: dartDefines,
+          dartDefineFromFile: {},
         );
         options = AndroidAppOptions(flutter: flutterOpts);
 
@@ -114,6 +118,7 @@ void main() {
         buildMode: BuildMode.debug,
         flavor: null,
         dartDefines: {},
+        dartDefineFromFile: {},
       );
 
       setUp(() {
@@ -192,6 +197,7 @@ void main() {
             'PASSWORD': 'ny4ncat',
             'foo': 'bar',
           },
+          dartDefineFromFile: {},
         );
 
         setUp(() {

--- a/packages/patrol_cli/test/crossplatform/app_options_test.dart
+++ b/packages/patrol_cli/test/crossplatform/app_options_test.dart
@@ -111,6 +111,75 @@ void main() {
         );
       });
     });
+
+    group('correctly overrides dart defines from file values with dart defines',
+        () {
+      const dartDefines = {
+        'EMAIL': 'user@example.com',
+        'PASSWORD': 'ny4ncat',
+        'foo': 'bar',
+      };
+
+      const dartDefinesFromFile = {
+        'EMAIL': 'banana@example.com',
+        'PASSWORD': 'hello',
+        'FLAVOR': 'dev'
+      };
+
+      test('on Windows', () {
+        final flutterOpts = FlutterAppOptions(
+          target: r'C:\Users\john\app\integration_test\app_test.dart',
+          buildMode: BuildMode.debug,
+          flavor: 'dev',
+          dartDefines: dartDefines,
+          dartDefineFromFile: dartDefinesFromFile,
+          dartDefineFromFilePath: '',
+        );
+        options = AndroidAppOptions(flutter: flutterOpts);
+
+        final invocation =
+            options.toGradleAssembleTestInvocation(isWindows: true);
+        expect(
+          invocation,
+          equals([
+            r'.\gradlew.bat',
+            ':app:assembleDevDebugAndroidTest',
+            r'-Ptarget=C:\Users\john\app\integration_test\app_test.dart',
+            '-Pdart-defines=RU1BSUw9dXNlckBleGFtcGxlLmNvbQ==,UEFTU1dPUkQ9bnk0bmNhdA==,Zm9vPWJhcg==',
+            '-PEMAIL=user@example.com',
+            '-PPASSWORD=ny4ncat',
+            '-PFLAVOR=dev',
+          ]),
+        );
+      });
+
+      test('on macOS', () {
+        final flutterOpts = FlutterAppOptions(
+          target: '/Users/john/app/integration_test/app_test.dart',
+          buildMode: BuildMode.debug,
+          flavor: 'dev',
+          dartDefines: dartDefines,
+          dartDefineFromFile: dartDefinesFromFile,
+          dartDefineFromFilePath: '',
+        );
+        options = AndroidAppOptions(flutter: flutterOpts);
+
+        final invocation =
+            options.toGradleAssembleTestInvocation(isWindows: false);
+        expect(
+          invocation,
+          equals([
+            './gradlew',
+            ':app:assembleDevDebugAndroidTest',
+            '-Ptarget=/Users/john/app/integration_test/app_test.dart',
+            '-Pdart-defines=RU1BSUw9dXNlckBleGFtcGxlLmNvbQ==,UEFTU1dPUkQ9bnk0bmNhdA==,Zm9vPWJhcg==',
+            '-PEMAIL=user@example.com',
+            '-PPASSWORD=ny4ncat',
+            '-PFLAVOR=dev',
+          ]),
+        );
+      });
+    });
   });
 
   group('IOSAppOptions', () {


### PR DESCRIPTION
In order to receive a JSON file for the configuration, add a `--dart-define-from-file` flag and use the same approach as flutter does [to create the gradle config with the JSON keys](https://github.com/blendthink/flutter/blob/2e8c3c0950e8fc64d9cdc901e5aa4c635e57528f/packages/flutter_tools/lib/src/build_info.dart#L310). For iOS, passing the JSON map to the environment in the `_processManager.start `method. 