### PR TITLE
Remove `patrol`'s dependency on `http`

### DIFF
--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   flutter_test:
     sdk: flutter
   grpc: ^3.1.0
-  http: ^0.13.5
   integration_test:
     sdk: flutter
   meta: ^1.7.0


### PR DESCRIPTION
This PR fixes #1481.

