### PR TITLE
[Android] Stop passing the flutter build mode to the gradle test tasks because those don't exist

### DIFF
--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -59,7 +59,7 @@ class AndroidAppOptions {
     // for example: assembleDevDebugAndroidTest, assembleReleaseAndroidTest
     return _toGradleInvocation(
       isWindows: isWindows,
-      task: 'assemble$_effectiveFlavor${_buildMode}AndroidTest',
+      task: 'assemble${_effectiveFlavor}DebugAndroidTest',
     );
   }
 
@@ -67,7 +67,7 @@ class AndroidAppOptions {
     // for example: connectedDevDebugAndroidTest, connectedReleaseAndroidTest
     return _toGradleInvocation(
       isWindows: isWindows,
-      task: 'connected$_effectiveFlavor${_buildMode}AndroidTest',
+      task: 'connected${_effectiveFlavor}DebugAndroidTest',
     );
   }
 


### PR DESCRIPTION
Hello, 
Thanks for your efforts :)
This PR fixes the errors the users will get when they pass the --profile and --release build args:

` patrol test -t integration_test/app_test.dart --verbose --release`
```
FAILURE: Build failed with an exception.
        
        * What went wrong:
        Cannot locate tasks that match ':app:assembleReleaseAndroidTest' as task 'assembleReleaseAndroidTest' not found in project ':app'.
```

` patrol test -t integration_test/app_test.dart --verbose --profile`
```
FAILURE: Build failed with an exception.
        
        * What went wrong:
        Cannot locate tasks that match ':app:assembleProfileAndroidTest' as task 'assembleProfileAndroidTest' not found in project ':app'.
```