### PR TITLE
Stop passing the flutter build mode to the gradle test tasks

### DIFF
--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -59,7 +59,7 @@ class AndroidAppOptions {
     // for example: assembleDevDebugAndroidTest, assembleReleaseAndroidTest
     return _toGradleInvocation(
       isWindows: isWindows,
-      task: 'assemble$_effectiveFlavor${_buildMode}AndroidTest',
+      task: 'assemble${_effectiveFlavor}DebugAndroidTest',
     );
   }
 
@@ -67,7 +67,7 @@ class AndroidAppOptions {
     // for example: connectedDevDebugAndroidTest, connectedReleaseAndroidTest
     return _toGradleInvocation(
       isWindows: isWindows,
-      task: 'connected$_effectiveFlavor${_buildMode}AndroidTest',
+      task: 'connected${_effectiveFlavor}DebugAndroidTest',
     );
   }
 

--- a/packages/patrol_cli/test/crossplatform/app_options_test.dart
+++ b/packages/patrol_cli/test/crossplatform/app_options_test.dart
@@ -45,7 +45,7 @@ void main() {
           invocation,
           equals([
             './gradlew',
-            ':app:assembleReleaseAndroidTest',
+            ':app:assembleDebugAndroidTest',
             '-Ptarget=/Users/john/app/integration_test/app_test.dart',
           ]),
         );
@@ -74,7 +74,7 @@ void main() {
           invocation,
           equals([
             r'.\gradlew.bat',
-            ':app:assembleDevReleaseAndroidTest',
+            ':app:assembleDevDebugAndroidTest',
             r'-Ptarget=C:\Users\john\app\integration_test\app_test.dart',
             '-Pdart-defines=RU1BSUw9dXNlckBleGFtcGxlLmNvbQ==,UEFTU1dPUkQ9bnk0bmNhdA==,Zm9vPWJhcg=='
           ]),


### PR DESCRIPTION
Hello, 
Thanks for your efforts :)
This PR fixes the errors the users will get when they pass the --profile and --release build args:

` patrol test -t integration_test/app_test.dart --verbose --release`
```
FAILURE: Build failed with an exception.
        
        * What went wrong:
        Cannot locate tasks that match ':app:assembleReleaseAndroidTest' as task 'assembleReleaseAndroidTest' not found in project ':app'.
```

` patrol test -t integration_test/app_test.dart --verbose --profile`
```
FAILURE: Build failed with an exception.
        
        * What went wrong:
        Cannot locate tasks that match ':app:assembleProfileAndroidTest' as task 'assembleProfileAndroidTest' not found in project ':app'.
```