### PR TITLE
Ignore all `adb` crashes when uninstalling in pre-execute step

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Fix crashes on some older Android versions when speculative `adb uninstall` is
+  called (#1529)
+
 ## 2.0.3
 
 - Uninstall the app before `patrol test` and `patrol develop`, in addition to

--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -208,22 +208,28 @@ class DevelopCommand extends PatrolCommand {
     if (!uninstall) {
       return;
     }
-
     _logger.detail('Will uninstall apps before running tests');
 
+    late Future<void> Function()? action;
     switch (device.targetPlatform) {
       case TargetPlatform.android:
         final packageName = androidOpts.packageName;
         if (packageName != null) {
-          await _androidTestBackend.uninstall(packageName, device);
+          action = () => _androidTestBackend.uninstall(packageName, device);
         }
         break;
       case TargetPlatform.iOS:
         final bundleId = iosOpts.bundleId;
         if (bundleId != null) {
-          await _iosTestBackend.uninstall(bundleId, device);
+          action = () => _iosTestBackend.uninstall(bundleId, device);
         }
         break;
+    }
+
+    try {
+      await action?.call();
+    } catch (_) {
+      // ignore any failures, we don't care
     }
   }
 

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -187,22 +187,28 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
     if (!uninstall) {
       return;
     }
-
     _logger.detail('Will uninstall apps before running tests');
 
+    late Future<void> Function()? action;
     switch (device.targetPlatform) {
       case TargetPlatform.android:
         final packageName = androidOpts.packageName;
         if (packageName != null) {
-          await _androidTestBackend.uninstall(packageName, device);
+          action = () => _androidTestBackend.uninstall(packageName, device);
         }
         break;
       case TargetPlatform.iOS:
         final bundleId = iosOpts.bundleId;
         if (bundleId != null) {
-          await _iosTestBackend.uninstall(bundleId, device);
+          action = () => _iosTestBackend.uninstall(bundleId, device);
         }
         break;
+    }
+
+    try {
+      await action?.call();
+    } catch (_) {
+      // ignore any failures, we don't care
     }
   }
 


### PR DESCRIPTION
Should fix the problem mentioned in https://github.com/leancodepl/patrol/issues/1496#issuecomment-1633463919