### PR TITLE
release new versions (patrol 2.0.7, patrol_cli 2.0.4)

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,7 +1,7 @@
-## Unreleased
+## 2.0.7
 
-- Add `BrowserstackPatrolJUnitRunner`, which implements a fix to make tests run
-  on BrowserStack (#1402)
+- Added an alternative `BrowserstackPatrolJUnitRunner`, which implements a fix
+  to make tests run on BrowserStack (#1402)
 
 ## 2.0.6
 

--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -2,7 +2,7 @@ name: patrol
 description: >
   Powerful Flutter-native UI testing framework overcoming limitations of
   existing Flutter testing tools. Ready for action!
-version: 2.0.6
+version: 2.0.7
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.0.4
 
 - Fix crashes on some older Android versions when speculative `adb uninstall` is
   called (#1529)

--- a/packages/patrol_cli/lib/src/base/constants.dart
+++ b/packages/patrol_cli/lib/src/base/constants.dart
@@ -1,2 +1,2 @@
 /// Version of Patrol CLI. Must be kept in sync with pubspec.yaml.
-const version = '2.0.3';
+const version = '2.0.4';

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: patrol_cli
 description: >
   Command-line tool for Patrol, a powerful Flutter-native UI testing framework.
-version: 2.0.3 # Must be kept in sync with constants.dart
+version: 2.0.4 # Must be kept in sync with constants.dart
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues


### PR DESCRIPTION
- patrol: bump version to 2.0.7
- patrol_cli: bump version to 2.0.4
