### PR TITLE
Fix set of devices in `emulatorwtf.yaml`

### DIFF
--- a/packages/patrol/example/emulatorwtf.yaml
+++ b/packages/patrol/example/emulatorwtf.yaml
@@ -1,14 +1,18 @@
 devices:
   device:
     - model: Pixel7
-      version: 33
+      version: 31
       gpu: auto
     - model: NexusLowRes
       version: 31
       gpu: auto
     - model: Tablet10
-      version: 33
+      version: 31
       gpu: auto
+    # Unstable, see https://github.com/leancodepl/patrol/issues/1445
+    # - model: Pixel2
+    #   version: 27
+    #   gpu: auto
 
 apps:
   app: build/app/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
Don't use API 33 emulators, which don't have hardware acceleration enabled.

cc @fylyppo 