### PR TITLE
Added check of kIsWeb before usage of Platform / dart:io package

### DIFF
--- a/packages/patrol/lib/src/common.dart
+++ b/packages/patrol/lib/src/common.dart
@@ -2,6 +2,7 @@
 
 import 'dart:io' as io;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/foundation.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:meta/meta.dart';
 import 'package:patrol/src/binding.dart';
@@ -110,8 +111,7 @@ void patrolTest(
           return;
         }
       }
-
-      if (io.Platform.isIOS) {
+      if (!kIsWeb && io.Platform.isIOS) {
         widgetTester.binding.platformDispatcher.onSemanticsEnabledChanged = () {
           // This callback is empty on purpose. It's a workaround for tests
           // failing on iOS.

--- a/packages/patrol/lib/src/common.dart
+++ b/packages/patrol/lib/src/common.dart
@@ -1,8 +1,8 @@
 // ignore_for_file: invalid_use_of_internal_member, implementation_imports
 
 import 'dart:io' as io;
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:meta/meta.dart';
 import 'package:patrol/src/binding.dart';


### PR DESCRIPTION
Just added the same check as the last time to prevent errors on web platform with dart:io.

Fixes #1577
