### PR TITLE
Release new versions (patrol 2.2.0, patrol_cli 2.1.0)

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.0
+- Use proper context in `PatrolJUnitRunner` (#1591)
+- Make `Selector.instance` work on iOS (#1569)
+- Ignore calls to `select[Fine|Coarse]Location()` on iOS < 14 (#1564)
+- Add support for `getNativeViews` on iOS (#1553)
+
 ## 2.1.0
 
 - Add `$.native.waitUntilVisible()` (#1543)

--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -2,7 +2,7 @@ name: patrol
 description: >
   Powerful Flutter-native UI testing framework overcoming limitations of
   existing Flutter testing tools. Ready for action!
-version: 2.1.0
+version: 2.2.0
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+- Add `--no-generate-bundle` flag (#1565)
+- Don't check for `patrol_cli` updates on CI (#1557)
+
 ## 2.0.4
 
 - Fix crashes on some older Android versions when speculative `adb uninstall` is

--- a/packages/patrol_cli/lib/src/base/constants.dart
+++ b/packages/patrol_cli/lib/src/base/constants.dart
@@ -1,2 +1,2 @@
 /// Version of Patrol CLI. Must be kept in sync with pubspec.yaml.
-const version = '2.0.4';
+const version = '2.1.0';

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: patrol_cli
 description: >
   Command-line tool for Patrol, a powerful Flutter-native UI testing framework.
-version: 2.0.4 # Must be kept in sync with constants.dart
+version: 2.1.0 # Must be kept in sync with constants.dart
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues


### PR DESCRIPTION
* patrol: bump version to 2.2.0
* patrol_cli: bump version to 2.1.0