### PR TITLE
Rename in andSettle deprecation message

### DIFF
--- a/packages/patrol/lib/src/custom_finders/patrol_finder.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_finder.dart
@@ -199,7 +199,7 @@ class PatrolFinder extends MatchFinder {
   ///    to appear
   ///  - [WidgetController.tap]
   Future<void> tap({
-    @Deprecated('Use settleBehavior argument instead') bool? andSettle,
+    @Deprecated('Use settlePolicy argument instead') bool? andSettle,
     SettlePolicy? settlePolicy,
     Duration? visibleTimeout,
     Duration? settleTimeout,
@@ -276,7 +276,7 @@ class PatrolFinder extends MatchFinder {
     int maxScrolls = defaultScrollMaxIteration,
     Duration? settleBetweenScrollsTimeout,
     Duration? dragDuration,
-    @Deprecated('Use settleBehavior argument instead') bool? andSettle,
+    @Deprecated('Use settlePolicy argument instead') bool? andSettle,
     SettlePolicy? settlePolicy,
   }) {
     return tester.scrollUntilVisible(
@@ -475,7 +475,7 @@ extension ActionCombiner on Future<PatrolFinder> {
   /// Same as [PatrolFinder.tap], but on a [PatrolFinder] which is not yet
   /// visible.
   Future<void> tap({
-    @Deprecated('Use settleBehavior argument instead') bool? andSettle,
+    @Deprecated('Use settlePolicy argument instead') bool? andSettle,
     SettlePolicy? settlePolicy,
     Duration? visibleTimeout,
     Duration? settleTimoeut,
@@ -494,7 +494,7 @@ extension ActionCombiner on Future<PatrolFinder> {
   /// visible.
   Future<void> enterText(
     String text, {
-    @Deprecated('Use settleBehavior argument instead') bool? andSettle,
+    @Deprecated('Use settlePolicy argument instead') bool? andSettle,
     SettlePolicy? settlePolicy,
     Duration? visibleTimeout,
     Duration? settleTimoeut,

--- a/packages/patrol/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_tester.dart
@@ -12,7 +12,7 @@ class PatrolTesterConfig {
     this.existsTimeout = const Duration(seconds: 10),
     this.visibleTimeout = const Duration(seconds: 10),
     this.settleTimeout = const Duration(seconds: 10),
-    @Deprecated('Use settleBehavior argument instead') this.andSettle = true,
+    @Deprecated('Use settlePolicy argument instead') this.andSettle = true,
     // TODO: change default to trySettle, see #1369 (https://github.com/leancodepl/patrol/issues/1369)
     this.settlePolicy = SettlePolicy.settle,
     this.dragDuration = const Duration(milliseconds: 100),
@@ -68,7 +68,7 @@ class PatrolTesterConfig {
     Duration? existsTimeout,
     Duration? visibleTimeout,
     Duration? settleTimeout,
-    @Deprecated('Use settleBehavior argument instead') bool? andSettle,
+    @Deprecated('Use settlePolicy argument instead') bool? andSettle,
     SettlePolicy? settlePolicy,
     Duration? dragDuration,
     String? appName,
@@ -276,7 +276,7 @@ class PatrolTester {
   ///  - [WidgetController.tap]
   Future<void> tap(
     Finder finder, {
-    @Deprecated('Use settleBehavior argument instead') bool? andSettle,
+    @Deprecated('Use settlePolicy argument instead') bool? andSettle,
     SettlePolicy? settlePolicy,
     Duration? visibleTimeout,
     Duration? settleTimeout,
@@ -326,7 +326,7 @@ class PatrolTester {
   Future<void> enterText(
     Finder finder,
     String text, {
-    @Deprecated('Use settleBehavior argument instead') bool? andSettle,
+    @Deprecated('Use settlePolicy argument instead') bool? andSettle,
     SettlePolicy? settlePolicy,
     Duration? visibleTimeout,
     Duration? settleTimeout,
@@ -457,7 +457,7 @@ class PatrolTester {
     int maxIteration = defaultScrollMaxIteration,
     Duration? settleBetweenScrollsTimeout,
     Duration? dragDuration,
-    @Deprecated('Use settleBehavior argument instead') bool? andSettle,
+    @Deprecated('Use settlePolicy argument instead') bool? andSettle,
     SettlePolicy? settlePolicy,
   }) {
     return TestAsyncUtils.guard(() async {
@@ -535,7 +535,7 @@ class PatrolTester {
     int maxIteration = defaultScrollMaxIteration,
     Duration? settleBetweenScrollsTimeout,
     Duration? dragDuration,
-    @Deprecated('Use settleBehavior argument instead') bool? andSettle,
+    @Deprecated('Use settlePolicy argument instead') bool? andSettle,
     SettlePolicy? settlePolicy,
   }) {
     return TestAsyncUtils.guard(() async {
@@ -590,7 +590,7 @@ class PatrolTester {
     int maxScrolls = defaultScrollMaxIteration,
     Duration? settleBetweenScrollsTimeout,
     Duration? dragDuration,
-    @Deprecated('Use settleBehavior argument instead') bool? andSettle,
+    @Deprecated('Use settlePolicy argument instead') bool? andSettle,
     SettlePolicy? settlePolicy,
   }) async {
     assert(maxScrolls > 0, 'maxScrolls must be positive number');
@@ -664,7 +664,7 @@ class PatrolTester {
     int maxScrolls = defaultScrollMaxIteration,
     Duration? settleBetweenScrollsTimeout,
     Duration? dragDuration,
-    @Deprecated('Use settleBehavior argument instead') bool? andSettle,
+    @Deprecated('Use settlePolicy argument instead') bool? andSettle,
     SettlePolicy? settlePolicy,
   }) async {
     assert(maxScrolls > 0, 'maxScrolls must be positive number');


### PR DESCRIPTION
Hey @bartekpacia,
Great work on this package, Flutter finally has a proper UI-testing framework!

I stumbled upon this typo will using the package. The deprecation message for `andSettle` refers to a `settleBehavior` parameter, whereas the correct name for the parameter is `settlePolicy`. This was added in pull request #1285.

I understand this might have been by mistake, but I thought I should fix this for future users, until it's removed.