### PR TITLE
Change location of generated iOS test results into `build/ios_results_$timestamp`

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Change the location of iOS test reports to `build/ios_results` with timestamp
-  appended (#1623)
+  appended. The path to the report is printed after `patrol test` exits (#1623)
 
 ## 2.1.0
 

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,4 +1,10 @@
+## Unreleased
+
+- Change the location of iOS test reports to `build/ios_results` with timestamp
+  appended (#1623)
+
 ## 2.1.0
+
 - Add `--no-generate-bundle` flag (#1565)
 - Don't check for `patrol_cli` updates on CI (#1557)
 

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -164,10 +164,7 @@ class IOSAppOptions {
 
   /// Translates these options into a proper `xcodebuild build-for-testing`
   /// invocation.
-  ///
-  /// [timestamp] (milliseconds since UNIX epoch) is required for the generation
-  /// of unique path for the results bundle.
-  List<String> buildForTestingInvocation({required int timestamp}) {
+  List<String> buildForTestingInvocation() {
     final cmd = [
       ...['xcodebuild', 'build-for-testing'],
       ...['-workspace', 'Runner.xcworkspace'],
@@ -181,7 +178,6 @@ class IOSAppOptions {
       ],
       '-quiet',
       ...['-derivedDataPath', '../build/ios_integ'],
-      ...['-resultBundlePath', '../build/ios_results_$timestamp'],
       r'OTHER_SWIFT_FLAGS=$(inherited) -D PATROL_ENABLED',
     ];
 
@@ -190,9 +186,13 @@ class IOSAppOptions {
 
   /// Translates these options into a proper `xcodebuild test-without-building`
   /// invocation.
+  ///
+  /// [timestamp] (milliseconds since UNIX epoch) is required for the generation
+  /// of unique path for the results bundle.
   List<String> testWithoutBuildingInvocation(
     Device device, {
     required String xcTestRunPath,
+    required int timestamp,
   }) {
     final cmd = [
       ...['xcodebuild', 'test-without-building'],
@@ -202,6 +202,7 @@ class IOSAppOptions {
         '-destination',
         'platform=${device.real ? 'iOS' : 'iOS Simulator'},name=${device.name}',
       ],
+      ...['-resultBundlePath', '../build/ios_results_$timestamp.xcresult'],
     ];
 
     return cmd;

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -186,13 +186,10 @@ class IOSAppOptions {
 
   /// Translates these options into a proper `xcodebuild test-without-building`
   /// invocation.
-  ///
-  /// [timestamp] (milliseconds since UNIX epoch) is required for the generation
-  /// of unique path for the results bundle.
   List<String> testWithoutBuildingInvocation(
     Device device, {
     required String xcTestRunPath,
-    required int timestamp,
+    required String resultBundlePath,
   }) {
     final cmd = [
       ...['xcodebuild', 'test-without-building'],
@@ -202,7 +199,7 @@ class IOSAppOptions {
         '-destination',
         'platform=${device.real ? 'iOS' : 'iOS Simulator'},name=${device.name}',
       ],
-      ...['-resultBundlePath', '../build/ios_results_$timestamp.xcresult'],
+      ...['-resultBundlePath', resultBundlePath],
     ];
 
     return cmd;

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -164,7 +164,10 @@ class IOSAppOptions {
 
   /// Translates these options into a proper `xcodebuild build-for-testing`
   /// invocation.
-  List<String> buildForTestingInvocation() {
+  ///
+  /// [timestamp] (milliseconds since UNIX epoch) is required for the generation
+  /// of unique path for the results bundle.
+  List<String> buildForTestingInvocation({required int timestamp}) {
     final cmd = [
       ...['xcodebuild', 'build-for-testing'],
       ...['-workspace', 'Runner.xcworkspace'],
@@ -178,6 +181,7 @@ class IOSAppOptions {
       ],
       '-quiet',
       ...['-derivedDataPath', '../build/ios_integ'],
+      ...['-resultBundlePath', '../build/ios_results_$timestamp'],
       r'OTHER_SWIFT_FLAGS=$(inherited) -D PATROL_ENABLED',
     ];
 

--- a/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
+++ b/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
@@ -111,7 +111,9 @@ class IOSTestBackend {
       // xcodebuild build-for-testing
 
       process = await _processManager.start(
-        options.buildForTestingInvocation(),
+        options.buildForTestingInvocation(
+          timestamp: DateTime.now().millisecondsSinceEpoch,
+        ),
         runInShell: true,
         workingDirectory: _fs.currentDirectory.childDirectory('ios').path,
       )

--- a/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
+++ b/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
@@ -111,9 +111,7 @@ class IOSTestBackend {
       // xcodebuild build-for-testing
 
       process = await _processManager.start(
-        options.buildForTestingInvocation(
-          timestamp: DateTime.now().millisecondsSinceEpoch,
-        ),
+        options.buildForTestingInvocation(),
         runInShell: true,
         workingDirectory: _fs.currentDirectory.childDirectory('ios').path,
       )
@@ -159,6 +157,7 @@ class IOSTestBackend {
             scheme: options.scheme,
             sdkVersion: sdkVersion,
           ),
+          timestamp: DateTime.now().millisecondsSinceEpoch,
         ),
         runInShell: true,
         workingDirectory: _fs.currentDirectory.childDirectory('ios').path,
@@ -171,6 +170,7 @@ class IOSTestBackend {
 
       if (exitCode == 0) {
         task.complete('Completed executing $subject');
+        _logger.info('See the report at ');
       } else if (exitCode != 0 && interruptible) {
         task.complete('App shut down on request');
       } else if (exitCode == _xcodebuildInterrupted) {

--- a/packages/patrol_cli/test/crossplatform/app_options_test.dart
+++ b/packages/patrol_cli/test/crossplatform/app_options_test.dart
@@ -166,7 +166,7 @@ void main() {
         final xcodebuildInvocation = options.testWithoutBuildingInvocation(
           iosDevice,
           xcTestRunPath: xcTestRunPath,
-          timestamp: 0,
+          resultBundlePath: '',
         );
 
         expect(
@@ -176,7 +176,7 @@ void main() {
             ...['-xctestrun', xcTestRunPath],
             ...['-only-testing', 'RunnerUITests'],
             ...['-destination', 'platform=iOS,name=iPhone 13'],
-            ...['-resultBundlePath', '../build/ios_results_0.xcresult'],
+            ...['-resultBundlePath', ''],
           ]),
         );
       });

--- a/packages/patrol_cli/test/crossplatform/app_options_test.dart
+++ b/packages/patrol_cli/test/crossplatform/app_options_test.dart
@@ -140,9 +140,7 @@ void main() {
           ]),
         );
 
-        final xcodebuildInvocation = options.buildForTestingInvocation(
-          timestamp: 0,
-        );
+        final xcodebuildInvocation = options.buildForTestingInvocation();
 
         expect(
           xcodebuildInvocation,
@@ -156,7 +154,6 @@ void main() {
             ...['-destination', 'generic/platform=iOS Simulator'],
             '-quiet',
             ...['-derivedDataPath', '../build/ios_integ'],
-            ...['-resultBundlePath', '../build/ios_results_0'],
             r'OTHER_SWIFT_FLAGS=$(inherited) -D PATROL_ENABLED',
           ]),
         );
@@ -169,6 +166,7 @@ void main() {
         final xcodebuildInvocation = options.testWithoutBuildingInvocation(
           iosDevice,
           xcTestRunPath: xcTestRunPath,
+          timestamp: 0,
         );
 
         expect(
@@ -178,6 +176,7 @@ void main() {
             ...['-xctestrun', xcTestRunPath],
             ...['-only-testing', 'RunnerUITests'],
             ...['-destination', 'platform=iOS,name=iPhone 13'],
+            ...['-resultBundlePath', '../build/ios_results_0.xcresult'],
           ]),
         );
       });
@@ -225,9 +224,7 @@ void main() {
             ]),
           );
 
-          final xcodebuildInvocation = options.buildForTestingInvocation(
-            timestamp: 0,
-          );
+          final xcodebuildInvocation = options.buildForTestingInvocation();
 
           expect(
             xcodebuildInvocation,
@@ -241,7 +238,6 @@ void main() {
               ...['-destination', 'generic/platform=iOS'],
               '-quiet',
               ...['-derivedDataPath', '../build/ios_integ'],
-              ...['-resultBundlePath', '../build/ios_results_0'],
               r'OTHER_SWIFT_FLAGS=$(inherited) -D PATROL_ENABLED',
             ]),
           );

--- a/packages/patrol_cli/test/crossplatform/app_options_test.dart
+++ b/packages/patrol_cli/test/crossplatform/app_options_test.dart
@@ -140,7 +140,9 @@ void main() {
           ]),
         );
 
-        final xcodebuildInvocation = options.buildForTestingInvocation();
+        final xcodebuildInvocation = options.buildForTestingInvocation(
+          timestamp: 0,
+        );
 
         expect(
           xcodebuildInvocation,
@@ -154,6 +156,7 @@ void main() {
             ...['-destination', 'generic/platform=iOS Simulator'],
             '-quiet',
             ...['-derivedDataPath', '../build/ios_integ'],
+            ...['-resultBundlePath', '../build/ios_results_0'],
             r'OTHER_SWIFT_FLAGS=$(inherited) -D PATROL_ENABLED',
           ]),
         );
@@ -222,7 +225,9 @@ void main() {
             ]),
           );
 
-          final xcodebuildInvocation = options.buildForTestingInvocation();
+          final xcodebuildInvocation = options.buildForTestingInvocation(
+            timestamp: 0,
+          );
 
           expect(
             xcodebuildInvocation,
@@ -236,6 +241,7 @@ void main() {
               ...['-destination', 'generic/platform=iOS'],
               '-quiet',
               ...['-derivedDataPath', '../build/ios_integ'],
+              ...['-resultBundlePath', '../build/ios_results_0'],
               r'OTHER_SWIFT_FLAGS=$(inherited) -D PATROL_ENABLED',
             ]),
           );


### PR DESCRIPTION
Thanks to this, the location of iOS reports will be much easier to find.

See also: #1589