### PR TITLE
Enable basic CI on all branches, not only `master`

### DIFF
--- a/.github/workflows/adb-prepare.yaml
+++ b/.github/workflows/adb-prepare.yaml
@@ -3,7 +3,6 @@ name: adb prepare
 on:
   workflow_dispatch:
   pull_request:
-    branches: [master]
     paths:
       - 'packages/adb/**'
 

--- a/.github/workflows/patrol-prepare.yaml
+++ b/.github/workflows/patrol-prepare.yaml
@@ -3,7 +3,6 @@ name: patrol prepare
 on:
   workflow_dispatch:
   pull_request:
-    branches: [master]
     paths:
       - 'packages/patrol/**'
 

--- a/.github/workflows/patrol_cli-prepare.yaml
+++ b/.github/workflows/patrol_cli-prepare.yaml
@@ -3,7 +3,6 @@ name: patrol_cli prepare
 on:
   workflow_dispatch:
   pull_request:
-    branches: [master]
     paths:
       - 'packages/patrol_cli/**'
 

--- a/.github/workflows/patrol_finders-prepare.yaml
+++ b/.github/workflows/patrol_finders-prepare.yaml
@@ -3,7 +3,6 @@ name: patrol_finders prepare
 on:
   workflow_dispatch:
   pull_request:
-    branches: [master]
     paths:
       - 'packages/patrol_finders/**'
 


### PR DESCRIPTION
Cause: some important workflows are not running in PR #1681 because it targets `develop`, not `master`