### PR TITLE
Fix/android buildtime bug

### DIFF
--- a/packages/patrol/android/build.gradle
+++ b/packages/patrol/android/build.gradle
@@ -66,9 +66,9 @@ android {
         api "androidx.test.uiautomator:uiautomator:2.2.0"
 
         implementation platform("org.http4k:http4k-bom:5.7.4.0")
-        implementation "org.http4k:http4k-core:5.7.4.0"
-        implementation "org.http4k:http4k-client-apache:5.7.4.0"
-        implementation "org.http4k:http4k-server-netty:5.7.4.0"
+        implementation "org.http4k:http4k-core"
+        implementation "org.http4k:http4k-client-okhttp"
+        implementation "org.http4k:http4k-server-ktorcio"
         implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0"
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.5.2"
 

--- a/packages/patrol/android/build.gradle
+++ b/packages/patrol/android/build.gradle
@@ -67,7 +67,7 @@ android {
 
         implementation platform("org.http4k:http4k-bom:5.7.4.0")
         implementation "org.http4k:http4k-core"
-        implementation "org.http4k:http4k-client-okhttp"
+        implementation "org.http4k:http4k-client-fuel"
         implementation "org.http4k:http4k-server-ktorcio"
         implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0"
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.5.2"

--- a/packages/patrol/android/build.gradle
+++ b/packages/patrol/android/build.gradle
@@ -67,7 +67,6 @@ android {
 
         implementation platform("org.http4k:http4k-bom:5.7.4.0")
         implementation "org.http4k:http4k-core"
-        implementation "org.http4k:http4k-client-fuel"
         implementation "org.http4k:http4k-server-ktorcio"
         implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0"
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.5.2"

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAppServiceClient.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAppServiceClient.kt
@@ -17,12 +17,12 @@ class PatrolAppServiceClient {
     private val timeUnit = TimeUnit.HOURS
 
     constructor() {
-        client = Client(address = "localhost", port = 8082, timeout = timeout, timeUnit = timeUnit)
+        client = Client(address = "localhost", port = 8082)
         Logger.i("Created PatrolAppServiceClient: ${client.serverUrl}")
     }
 
     constructor(address: String) {
-        client = Client(address = address, port = 8082, timeout = timeout, timeUnit = timeUnit)
+        client = Client(address = address, port = 8082)
         Logger.i("Created PatrolAppServiceClient: ${client.serverUrl}")
     }
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAppServiceClient.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAppServiceClient.kt
@@ -1,8 +1,8 @@
 package pl.leancode.patrol
 
-import okio.Timeout
 import pl.leancode.patrol.contracts.Contracts
 import pl.leancode.patrol.contracts.PatrolAppServiceClientException
+import java.util.concurrent.TimeUnit
 import pl.leancode.patrol.contracts.PatrolAppServiceClient as Client
 
 /**
@@ -13,15 +13,16 @@ class PatrolAppServiceClient {
     private var client: Client
 
     // https://github.com/leancodepl/patrol/issues/1683
-    // private val timeout = Timeout.ofHours(2)
+    private val timeout = 2L
+    private val timeUnit = TimeUnit.HOURS
 
     constructor() {
-        client = Client(address = "localhost", port = 8082)
+        client = Client(address = "localhost", port = 8082, timeout = timeout, timeUnit = timeUnit)
         Logger.i("Created PatrolAppServiceClient: ${client.serverUrl}")
     }
 
     constructor(address: String) {
-        client = Client(address = address, port = 8082)
+        client = Client(address = address, port = 8082, timeout = timeout, timeUnit = timeUnit)
         Logger.i("Created PatrolAppServiceClient: ${client.serverUrl}")
     }
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAppServiceClient.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAppServiceClient.kt
@@ -1,6 +1,6 @@
 package pl.leancode.patrol
 
-import org.apache.hc.core5.util.Timeout
+import okio.Timeout
 import pl.leancode.patrol.contracts.Contracts
 import pl.leancode.patrol.contracts.PatrolAppServiceClientException
 import pl.leancode.patrol.contracts.PatrolAppServiceClient as Client
@@ -13,15 +13,15 @@ class PatrolAppServiceClient {
     private var client: Client
 
     // https://github.com/leancodepl/patrol/issues/1683
-    private val timeout = Timeout.ofHours(2)
+    // private val timeout = Timeout.ofHours(2)
 
     constructor() {
-        client = Client(address = "localhost", port = 8082, timeout = timeout)
+        client = Client(address = "localhost", port = 8082)
         Logger.i("Created PatrolAppServiceClient: ${client.serverUrl}")
     }
 
     constructor(address: String) {
-        client = Client(address = address, port = 8082, timeout = timeout)
+        client = Client(address = address, port = 8082)
         Logger.i("Created PatrolAppServiceClient: ${client.serverUrl}")
     }
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolServer.kt
@@ -5,7 +5,7 @@ import com.google.common.util.concurrent.SettableFuture
 import org.http4k.core.ContentType
 import org.http4k.filter.ServerFilters
 import org.http4k.server.Http4kServer
-import org.http4k.server.Netty
+import org.http4k.server.KtorCIO
 import org.http4k.server.asServer
 import java.util.concurrent.Future
 
@@ -29,7 +29,7 @@ class PatrolServer {
             .withFilter(catcher)
             .withFilter(printer)
             .withFilter(ServerFilters.SetContentType(ContentType.TEXT_PLAIN))
-            .asServer(Netty(port))
+            .asServer(KtorCIO(port))
             .start()
 
         Logger.i("Created and started PatrolServer, port: $port")

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/PatrolAppServiceClient.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/PatrolAppServiceClient.kt
@@ -7,11 +7,18 @@ package pl.leancode.patrol.contracts;
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import okhttp3.OkHttpClient
-import org.http4k.client.OkHttp
+import org.http4k.client.JavaHttpClient
+import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Request
 import org.http4k.core.Status
+import org.http4k.core.then
+import org.http4k.filter.DebuggingFilters.PrintResponse
+//import okhttp3.OkHttpClient
+//import org.http4k.client.OkHttp
+//import org.http4k.core.Method
+//import org.http4k.core.Request
+//import org.http4k.core.Status
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
@@ -33,16 +40,20 @@ class PatrolAppServiceClient(address: String, port: Int, private val timeout: Lo
             request = request.body(requestBody)
         }
 
-        val okHttpClient = OkHttp(
-            OkHttpClient.Builder()
-                .connectTimeout(timeout, timeUnit)
-                .readTimeout(timeout, timeUnit)
-                .writeTimeout(timeout, timeUnit)
-                .callTimeout(timeout, timeUnit)
-                .build()
-        )
+        val client = JavaHttpClient()
 
-        val response = okHttpClient(request)
+        // val printingClient = PrintResponse().then(client)
+
+//        val okHttpClient = OkHttp(
+//            OkHttpClient.Builder()
+//                .connectTimeout(timeout, timeUnit)
+//                .readTimeout(timeout, timeUnit)
+//                .writeTimeout(timeout, timeUnit)
+//                .callTimeout(timeout, timeUnit)
+//                .build()
+//        )
+
+        val response = client(request)
 
         if (response.status != Status.OK) {
             throw PatrolAppServiceClientException("Invalid response ${response.status}, ${response.bodyString()}")

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/PatrolAppServiceClient.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/PatrolAppServiceClient.kt
@@ -7,15 +7,20 @@ package pl.leancode.patrol.contracts;
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.apache.hc.client5.http.config.RequestConfig
-import org.apache.hc.client5.http.impl.classic.HttpClients
-import org.apache.hc.core5.util.Timeout
-import org.http4k.client.ApacheClient
+import okhttp3.OkHttpClient
+import okio.Timeout
+import org.http4k.client.OkHttp
+//import org.apache.hc.client5.http.config.RequestConfig
+//import org.apache.hc.client5.http.impl.classic.HttpClients
+//import org.apache.hc.core5.util.Timeout
+// import org.http4k.client.ApacheClient
 import org.http4k.core.Method
 import org.http4k.core.Request
 import org.http4k.core.Status
+import org.http4k.metrics.MetricsDefaults.Companion.client
+import java.time.Duration
 
-class PatrolAppServiceClient(private val address: String, private val port: Int, private val timeout: Timeout) {
+class PatrolAppServiceClient(private val address: String, private val port: Int) {
 
     fun listDartTests() : Contracts.ListDartTestsResponse {
         val response = performRequest("listDartTests")
@@ -33,16 +38,12 @@ class PatrolAppServiceClient(private val address: String, private val port: Int,
             request = request.body(requestBody)
         }
 
-        val client = ApacheClient(
-              HttpClients.custom().setDefaultRequestConfig(
-                  RequestConfig
-                    .copy(RequestConfig.DEFAULT)
-                    .setResponseTimeout(timeout)
-                    .setConnectionRequestTimeout(timeout)
-                    .build()
-              ).build())
+        // FIXME: Figure out how to add timeouts (java.time is API 26+ only)
+        val okHttpClient = OkHttp(OkHttpClient.Builder()
+            .build()
+        )
         
-        val response = client(request)
+        val response = okHttpClient (request)
 
         if (response.status != Status.OK) {
             throw PatrolAppServiceClientException("Invalid response ${response.status}, ${response.bodyString()}")

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/PatrolAppServiceClient.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/PatrolAppServiceClient.kt
@@ -33,10 +33,11 @@ class PatrolAppServiceClient(address: String, port: Int, private val timeout: Lo
             request = request.body(requestBody)
         }
 
-        // FIXME: Figure out how to add timeouts (java.time is API 26+ only)
         val okHttpClient = OkHttp(
             OkHttpClient.Builder()
-                // all other timeouts (write, read, connect) default to 10 seconds
+                .connectTimeout(timeout, timeUnit)
+                .readTimeout(timeout, timeUnit)
+                .writeTimeout(timeout, timeUnit)
                 .callTimeout(timeout, timeUnit)
                 .build()
         )

--- a/packages/patrol/example/android/app/build.gradle
+++ b/packages/patrol/example/android/app/build.gradle
@@ -32,13 +32,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    
-    //TODO verify
-//    packagingOptions {
-//        pickFirst "META-INF/INDEX.LIST"
-//        pickFirst "META-INF/io.netty.versions.properties"
-//        pickFirst "META-INF/DEPENDENCIES"
-//    }
 
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"

--- a/packages/patrol/example/android/app/build.gradle
+++ b/packages/patrol/example/android/app/build.gradle
@@ -34,11 +34,11 @@ android {
     }
     
     //TODO verify
-    packagingOptions {
-        pickFirst "META-INF/INDEX.LIST"
-        pickFirst "META-INF/io.netty.versions.properties"
-        pickFirst "META-INF/DEPENDENCIES"
-    }
+//    packagingOptions {
+//        pickFirst "META-INF/INDEX.LIST"
+//        pickFirst "META-INF/io.netty.versions.properties"
+//        pickFirst "META-INF/DEPENDENCIES"
+//    }
 
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"


### PR DESCRIPTION
Fixes problem with `META-INF` being malformed or something:

<details><summary>Details</summary>

```
FAILURE: Build failed with an exception.

	* What went wrong:
	Execution failed for task ':app:mergeTstDebugJavaResource'.
	> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeJavaResWorkAction
	   > 8 files found with path 'META-INF/INDEX.LIST' from inputs:
	      - /Users/bartek/.gradle/caches/transforms-3/98ae5c88d5d9e3a49e85ceeadaccd680/transformed/jetified-netty-codec-http2-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/transforms-3/585598deb7118dd86a2c91b7b3075b31/transformed/jetified-netty-codec-http-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/transforms-3/d3358bfd0e025c85a6f891b9ed3f2f31/transformed/jetified-netty-handler-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/transforms-3/6e8f68de7d2406c67c44dcef25255c78/transformed/jetified-netty-codec-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/transforms-3/a261241c75df2e8a68b904aac3b66a6d/transformed/jetified-netty-transport-native-unix-common-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/transforms-3/e845d3b30e38824ff09a8cacda9eb4d0/transformed/jetified-netty-transport-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/transforms-3/fbe9ace71e46599ec1d465186846083e/transformed/jetified-netty-buffer-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/transforms-3/75dbc5850a0808ffbf1a6160a82855c2/transformed/jetified-netty-resolver-4.1.97.Final.jar
	     Adding a packagingOptions block may help, please refer to
	     https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/dsl/ResourcesPackagingOptions
	     for more information

	* Try:
	> Run with --stacktrace option to get the stack trace.
	> Run with --info or --debug option to get more log output.
	> Run with --scan to get full insights.

	* Get more help at https://help.gradle.org/
```

</details> 