### PR TITLE
Replace HTTP server

### DIFF
--- a/packages/patrol/android/build.gradle
+++ b/packages/patrol/android/build.gradle
@@ -66,9 +66,9 @@ android {
         api "androidx.test.uiautomator:uiautomator:2.2.0"
 
         implementation platform("org.http4k:http4k-bom:5.7.4.0")
-        implementation "org.http4k:http4k-core:5.7.4.0"
-        implementation "org.http4k:http4k-client-apache:5.7.4.0"
-        implementation "org.http4k:http4k-server-netty:5.7.4.0"
+        implementation "org.http4k:http4k-core"
+        implementation "org.http4k:http4k-client-apache"
+        implementation "org.http4k:http4k-server-ktorcio"
         implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0"
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.5.2"
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolServer.kt
@@ -5,7 +5,7 @@ import com.google.common.util.concurrent.SettableFuture
 import org.http4k.core.ContentType
 import org.http4k.filter.ServerFilters
 import org.http4k.server.Http4kServer
-import org.http4k.server.Netty
+import org.http4k.server.KtorCIO
 import org.http4k.server.asServer
 import java.util.concurrent.Future
 
@@ -29,7 +29,7 @@ class PatrolServer {
             .withFilter(catcher)
             .withFilter(printer)
             .withFilter(ServerFilters.SetContentType(ContentType.TEXT_PLAIN))
-            .asServer(Netty(port))
+            .asServer(KtorCIO(port))
             .start()
 
         Logger.i("Created and started PatrolServer, port: $port")

--- a/packages/patrol/example/android/app/build.gradle
+++ b/packages/patrol/example/android/app/build.gradle
@@ -33,12 +33,12 @@ android {
         jvmTarget = "1.8"
     }
     
-    //TODO verify
-//    packagingOptions {
-//        pickFirst "META-INF/INDEX.LIST"
-//        pickFirst "META-INF/io.netty.versions.properties"
-//        pickFirst "META-INF/DEPENDENCIES"
-//    }
+    // TODO: Find workaround
+    packagingOptions {
+        pickFirst "META-INF/INDEX.LIST"
+        pickFirst "META-INF/io.netty.versions.properties"
+        pickFirst "META-INF/DEPENDENCIES"
+    }
 
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"

--- a/packages/patrol/example/android/app/build.gradle
+++ b/packages/patrol/example/android/app/build.gradle
@@ -34,11 +34,11 @@ android {
     }
     
     //TODO verify
-    packagingOptions {
-        pickFirst "META-INF/INDEX.LIST"
-        pickFirst "META-INF/io.netty.versions.properties"
-        pickFirst "META-INF/DEPENDENCIES"
-    }
+//    packagingOptions {
+//        pickFirst "META-INF/INDEX.LIST"
+//        pickFirst "META-INF/io.netty.versions.properties"
+//        pickFirst "META-INF/DEPENDENCIES"
+//    }
 
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"


### PR DESCRIPTION
Split from #1708

This PR fixes the following build error when `packagingOptions` are not set. It does this by replacing the `org.http4k:http4k-server-netty` server with `org.http4k:http4k-server-ktorcnio`:

<details><summary>Build error</summary>

```
	: > Task :app:mergeDebugJavaResource FAILED

	FAILURE: Build failed with an exception.

	* What went wrong:
	Execution failed for task ':app:mergeDebugJavaResource'.
	> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeJavaResWorkAction
	   > 8 files found with path 'META-INF/INDEX.LIST' from inputs:
	      - /Users/bartek/.gradle/caches/modules-2/files-2.1/io.netty/netty-codec-http2/4.1.97.Final/893888d09a7bef0d0ba973d7471943e765d0fd08/netty-codec-http2-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/modules-2/files-2.1/io.netty/netty-codec-http/4.1.97.Final/af78acec783ffd77c63d8aeecc21041fd39ac54f/netty-codec-http-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/modules-2/files-2.1/io.netty/netty-handler/4.1.97.Final/abb86c6906bf512bf2b797a41cd7d2e8d3cd7c36/netty-handler-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/modules-2/files-2.1/io.netty/netty-codec/4.1.97.Final/384ba4d75670befbedb45c4d3b497a93639c206d/netty-codec-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/modules-2/files-2.1/io.netty/netty-transport-native-unix-common/4.1.97.Final/d469d84265ab70095b01b40886cabdd433b6e664/netty-transport-native-unix-common-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/modules-2/files-2.1/io.netty/netty-transport/4.1.97.Final/f37380d23c9bb079bc702910833b2fd532c9abd0/netty-transport-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/modules-2/files-2.1/io.netty/netty-buffer/4.1.97.Final/f8f3d8644afa5e6e1a40a3a6aeb9d9aa970ecb4f/netty-buffer-4.1.97.Final.jar
	      - /Users/bartek/.gradle/caches/modules-2/files-2.1/io.netty/netty-resolver/4.1.97.Final/cec8348108dc76c47cf87c669d514be52c922144/netty-resolver-4.1.97.Final.jar
	     Adding a packagingOptions block may help, please refer to
	     https://developer.android.com/reference/tools/gradle-api/7.4/com/android/build/api/dsl/ResourcesPackagingOptions
	     for more information

	* Try:
	> Run with --stacktrace option to get the stack trace.
	> Run with --info or --debug option to get more log output.
	> Run with --scan to get full insights.

	* Get more help at https://help.gradle.org

	BUILD FAILED in 5s
```
</details> 


It **does not** fix the new error that appeared:


<details><summary>Build error</summary>

```
	FAILURE: Build failed with an exception.

	* What went wrong:
	Execution failed for task ':app:mergeDebugJavaResource'.
	> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeJavaResWorkAction
	   > 3 files found with path 'META-INF/DEPENDENCIES' from inputs:
	      - /Users/bartek/.gradle/caches/modules-2/files-2.1/org.apache.httpcomponents.client5/httpclient5/5.2.1/c900514d3446d9ce5d9dbd90c21192048125440/httpclient5-5.2.1.jar
	      - /Users/bartek/.gradle/caches/modules-2/files-2.1/org.apache.httpcomponents.core5/httpcore5-h2/5.2/698bd8c759ccc7fd7398f3179ff45d0e5a7ccc16/httpcore5-h2-5.2.jar
	      - /Users/bartek/.gradle/caches/modules-2/files-2.1/org.apache.httpcomponents.core5/httpcore5/5.2/ab7d251b8dfa3f2878f1eefbcca0e1fc0ebeba27/httpcore5-5.2.jar
	     Adding a packagingOptions block may help, please refer to
	     https://developer.android.com/reference/tools/gradle-api/7.4/com/android/build/api/dsl/ResourcesPackagingOptions
	     for more information

	* Try:
	> Run with --stacktrace option to get the stack trace.
	> Run with --info or --debug option to get more log output.
	> Run with --scan to get full insights.

	* Get more help at https://help.gradle.org

	BUILD FAILED in 8s
```

</details>