### PR TITLE
Lifecycle callbacks setupall investigation

### DIFF
--- a/packages/patrol/example/android/app/src/androidTest/java/pl/leancode/patrol/example/MainActivityTest.java
+++ b/packages/patrol/example/android/app/src/androidTest/java/pl/leancode/patrol/example/MainActivityTest.java
@@ -1,11 +1,15 @@
 package pl.leancode.patrol.example;
 
+import android.util.Log;
 import androidx.test.platform.app.InstrumentationRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import pl.leancode.patrol.PatrolJUnitRunner;
+
+import java.io.File;
+import java.io.IOException;
 
 @RunWith(Parameterized.class)
 public class MainActivityTest {
@@ -23,9 +27,33 @@ public class MainActivityTest {
 
     private final String dartTestName;
 
+    private void log(String text) {
+        Log.d("MainActivity log", text);
+    }
+
     @Test
-    public void runDartTest() {
+    public void runDartTest() throws IOException {
         PatrolJUnitRunner instrumentation = (PatrolJUnitRunner) InstrumentationRegistry.getInstrumentation();
+
+// targetContext (app under test) data is cleared on each test run
+//        File cacheDir = instrumentation.getTargetContext().getCacheDir();
+//        File externalCacheDir = instrumentation.getTargetContext().getExternalCacheDir();
+
+        File cacheDir = instrumentation.getContext().getCacheDir();
+        boolean exists = cacheDir.exists();
+        boolean created = cacheDir.mkdirs();
+        log("cacheDir.mkdir(): exists=" + exists + ", created=" + created);
+
+        log("cacheDir: " + cacheDir);
+
+        File cacheDirFile = new File(cacheDir, "patrol.txt");
+        created = cacheDirFile.createNewFile();
+        log("cacheDirFile.createNewFile(): created=" + created);
+//
+//        File externalCacheDirFile = new File(externalCacheDir, "patrol.txt");
+//        created = externalCacheDirFile.createNewFile();
+//        log("externalCacheDirFile.createNewFile(): created=" + created);
+
         instrumentation.runDartTest(dartTestName);
     }
 }

--- a/packages/patrol/test/callbacks_2_test.dart
+++ b/packages/patrol/test/callbacks_2_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/src/extensions.dart';
+// ignore: depend_on_referenced_packages
+import 'package:test_api/src/backend/invoker.dart';
+
+const String requestedTest = 'groupA testA';
+
+String get currentTest => Invoker.current!.fullCurrentTestName();
+
+// Idea for setUpAll and tearDownAll implementation:
+//
+// Let these callbacks run always, i.e. in a normal way (just like we do with
+// setUp and tearDown). But after the callback runs for a first time, send its
+// stable unique identifier to the native side. Then, if the callback tries to
+// run again, in a new app process, it'll ask the native side if it should
+// execute, and the native side will reply "no",
+
+void main() {
+  patrolSetUp(() {
+    print('setting up 1 before $currentTest');
+  });
+
+  group('groupA', () {
+    patrolSetUpAll(() {
+      final group = Invoker.current!.liveTest.groups.last.name;
+      print('setting up all before $currentTest, ID="$group 1"');
+    });
+
+    patrolSetUp(() {
+      print('setting up 2 before $currentTest');
+    });
+
+    patrolTest('testA', _body);
+    patrolTest('testB', _body);
+    patrolTest('testC', _body);
+
+    patrolTearDown(() {
+      print('tearing down 1 after $currentTest');
+    });
+  });
+
+  patrolTearDown(() {
+    print('tearing down 2 after $currentTest');
+  });
+}
+
+Future<void> _body() async => print(Invoker.current!.fullCurrentTestName());
+
+void patrolTest(String name, Future<void> Function() body) {
+  test(name, () async {
+    final currentTest = Invoker.current!.fullCurrentTestName();
+
+    if (currentTest == requestedTest) {
+      print('Requested test $currentTest, will execute it');
+      await body();
+    }
+  });
+}
+
+void patrolSetUp(dynamic Function() body) {
+  setUp(() {
+    final currentTest = Invoker.current!.fullCurrentTestName();
+
+    // TODO: Determine if requestedTest is inside this setUps scope?
+    // Hipothesis: package:test cares about this automatically!
+    if (currentTest == requestedTest) {
+      body();
+    }
+  });
+}
+
+void patrolTearDown(dynamic Function() body) {
+  tearDown(() {
+    final currentTest = Invoker.current!.fullCurrentTestName();
+
+    if (currentTest == requestedTest) {
+      body();
+    }
+  });
+}


### PR DESCRIPTION
Looks like it's not possible to for an instrumentation app to store cache/tmp files ([link](https://stackoverflow.com/questions/69236480/how-to-access-cache-in-android-for-instrumented-tests/70875214#70875214)).