### PR TITLE
Accept dynamic functions instead of Futures in lifecycle callbacks

### DIFF
--- a/packages/patrol/lib/src/common.dart
+++ b/packages/patrol/lib/src/common.dart
@@ -21,7 +21,7 @@ import 'custom_finders/patrol_integration_tester.dart';
 typedef PatrolTesterCallback = Future<void> Function(PatrolIntegrationTester $);
 
 /// A modification of [setUp] that works with Patrol's native automation.
-void patrolSetUp(Future<void> Function() body) {
+void patrolSetUp(dynamic Function() body) {
   setUp(() async {
     if (global_state.hotRestartEnabled) {
       await body();
@@ -45,7 +45,7 @@ void patrolSetUp(Future<void> Function() body) {
 }
 
 /// A modification of [tearDown] that works with Patrol's native automation.
-void patrolTearDown(Future<void> Function() body) {
+void patrolTearDown(dynamic Function() body) {
   tearDown(() async {
     if (global_state.hotRestartEnabled) {
       await body();
@@ -71,7 +71,7 @@ void patrolTearDown(Future<void> Function() body) {
 /// A modification of [setUpAll] that works with Patrol's native automation.
 ///
 /// It keeps track of calls made to setUpAll.
-void patrolSetUpAll(Future<void> Function() body) {
+void patrolSetUpAll(dynamic Function() body) {
   setUpAll(() async {
     final patrolAppService = PatrolBinding.instance.patrolAppService;
     final parentGroupsName = global_state.currentGroupFullName;


### PR DESCRIPTION
Sometimes lifecycle callbacks don't need to be awaited