### PR TITLE
Set up GitHub Actions to automatically close and lock issues

### DIFF
--- a/.github/workflows/close-inactive-issues.yaml
+++ b/.github/workflows/close-inactive-issues.yaml
@@ -32,6 +32,6 @@ jobs:
 
             [minimal, reproducible sample]: https://stackoverflow.com/help/minimal-reproducible-example
           # Number of days of inactivity before an issue is closed.
-          daysUntilClose: 14
+          daysUntilClose: 7
           # Only issues with this label will be closed (if they are inactive).
           responseRequiredLabel: waiting for response

--- a/.github/workflows/close-inactive-issues.yaml
+++ b/.github/workflows/close-inactive-issues.yaml
@@ -1,0 +1,37 @@
+# This workflow is based on a very similar one from Flutter
+# https://github.com/flutter/flutter/blob/3.16.0/.github/workflows/no-response.yaml
+
+name: close inactive issues
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: '0 * * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'leancodepl/patrol' }}
+    steps:
+      - uses: godofredoc/no-response@0ce2dc0e63e1c7d2b87752ceed091f6d32c9df09
+        with:
+          token: ${{ github.token }}
+          closeComment: >
+            Without additional information, we can't resolve this issue. We're
+            therefore reluctantly going to close it.
+
+            Feel free to open a new issue with all the required information
+            provided, including a [minimal, reproducible sample]. Make sure to
+            diligently fill out the issue template.
+
+            Thanks for your contribution.
+
+            [minimal, reproducible sample]: https://stackoverflow.com/help/minimal-reproducible-example
+          # Number of days of inactivity before an issue is closed.
+          daysUntilClose: 14
+          # Only issues with this label will be closed (if they are inactive).
+          responseRequiredLabel: waiting for response

--- a/.github/workflows/lock-closed-issues.yaml
+++ b/.github/workflows/lock-closed-issues.yaml
@@ -1,0 +1,31 @@
+# This workflow is copied from Flutter
+# https://github.com/flutter/flutter/blob/3.16.0/.github/workflows/lock.yaml
+
+name: lock closed issues
+
+permissions:
+  issues: write
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  lock:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'leancodepl/patrol' }}
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          process-only: issues
+          github-token: ${{ github.token }}
+          # Number of days of inactivity before a closed issue is locked.
+          issue-inactive-days: 14
+          issue-comment: >
+            This issue has been automatically locked since there has not been
+            any recent activity after it was closed. If you are still
+            experiencing a similar problem, please file a new issue. Make
+            sure to follow the template and provide all the information
+            necessary to reproduce the issue.

--- a/.github/workflows/lock-closed-issues.yaml
+++ b/.github/workflows/lock-closed-issues.yaml
@@ -22,7 +22,7 @@ jobs:
           process-only: issues
           github-token: ${{ github.token }}
           # Number of days of inactivity before a closed issue is locked.
-          issue-inactive-days: 14
+          issue-inactive-days: 7
           issue-comment: >
             This issue has been automatically locked since there has not been
             any recent activity after it was closed. If you are still


### PR DESCRIPTION
This PR adds 2 new scheduled workflows that run every hour.

### close inactive issues

This will **close** issues that:

- have the `waiting for customer response` label
- have been inactive for 7 days

### lock closed issues


This will **lock** issues that:
- are closed
- have been inactive (i.e. no comments) for 7 days