### PR TITLE
Use custom lints from `package:leancode_lint` in `package:patrol`

### DIFF
--- a/packages/patrol/analysis_options.yaml
+++ b/packages/patrol/analysis_options.yaml
@@ -1,5 +1,7 @@
 include: package:leancode_lint/analysis_options_package.yaml
 
 analyzer:
+  plugins:
+    - custom_lint
   exclude:
     - lib/**/*.g.dart

--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.6
+  custom_lint: ^0.5.7
   json_serializable: ^6.7.1
   leancode_lint: ^7.0.0+1
 


### PR DESCRIPTION
To reproduce bug https://github.com/invertase/dart_custom_lint/issues/148, run `dart run custom_lint` in `packages/patrol`.