### PR TITLE
Enable selecting individual tests with `xcodebuild`'s `-only-testing` option

### DIFF
--- a/packages/patrol/darwin/Classes/AutomatorServer/PatrolServer.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/PatrolServer.swift
@@ -52,8 +52,8 @@ import Foundation
       Logger.shared.i("Starting server...")
 
       let provider = AutomatorServer(automator: automator) { appReady in
-        Logger.shared.i("App reported that it is ready")
         self.appReady = appReady
+        Logger.shared.i("App reported its ready status, value: \(self.appReady)")
       }
 
       provider.setupRoutes(server: server)

--- a/packages/patrol/darwin/Classes/ObjCPatrolAppServiceClient.swift
+++ b/packages/patrol/darwin/Classes/ObjCPatrolAppServiceClient.swift
@@ -52,7 +52,7 @@
     // We should wait for appReady in the dynamically created test case method,
     // before calling runDartTest() (in PATROL_INTEGRATION_TEST_[IOS/MACOS]_MACRO)
     DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-      NSLog("PatrolAppServiceClient.runDartTest(\(name))")
+      NSLog("PatrolAppServiceClient.runDartTest(\(format: name))")
 
       let request = RunDartTestRequest(name: name)
       self.client.runDartTest(request: request) { result in
@@ -85,7 +85,7 @@ extension DartGroupEntry {
           // This case is invalid, because every test will have at least
           // 1 named group - its filename.
 
-          fatalError("Invariant violated: test \(test.name) has no named parent group")
+          fatalError("Invariant violated: test \(format: test.name) has no named parent group")
         }
 
         test.name = "\(parentGroupName) \(test.name)"

--- a/packages/patrol/darwin/Classes/PatrolTestCaseBase.h
+++ b/packages/patrol/darwin/Classes/PatrolTestCaseBase.h
@@ -1,13 +1,17 @@
 @import Foundation;
 @import XCTest;
 
-NS_ASSUME_NONNULL_BEGIN
+#import "PatrolUtils.h"
+#import "patrol/patrol-Swift.h"
 
 @interface PatrolTestCaseBase : XCTestCase
 
-+ (NSArray<NSString *> *)_ptr_testMethodSelectors;
+@property(class, nonatomic, readwrite) PatrolServer *server;
+@property(class, nonatomic, readwrite) ObjCPatrolAppServiceClient *appServiceClient;
+@property(class, strong, nonatomic) NSString *selectedTest;
+
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
++ (NSArray<NSString *> *)_ptr_testMethodSelectors;
++ (IMP)_ptr_testMethodImplementation:(NSString *)testName;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/packages/patrol/darwin/Classes/PatrolTestCaseBase.h
+++ b/packages/patrol/darwin/Classes/PatrolTestCaseBase.h
@@ -1,0 +1,13 @@
+@import Foundation;
+@import XCTest;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PatrolTestCaseBase : XCTestCase
+
++ (NSArray<NSString *> *)_ptr_testMethodSelectors;
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/patrol/darwin/Classes/PatrolTestCaseBase.h
+++ b/packages/patrol/darwin/Classes/PatrolTestCaseBase.h
@@ -2,16 +2,19 @@
 @import XCTest;
 
 #import "PatrolUtils.h"
-#import "patrol/patrol-Swift.h"
+
+@class PatrolServer;
+@class ObjCPatrolAppServiceClient;
 
 @interface PatrolTestCaseBase : XCTestCase
 
-@property(class, nonatomic, readwrite) PatrolServer *server;
-@property(class, nonatomic, readwrite) ObjCPatrolAppServiceClient *appServiceClient;
-@property(class, strong, nonatomic) NSString *selectedTest;
+@property(class, nonatomic, readwrite, strong) PatrolServer *server;
+@property(class, nonatomic, readwrite, strong) ObjCPatrolAppServiceClient *appServiceClient;
+@property(class, nonatomic, readwrite, copy) NSString *selectedTest;
+@property(class, nonatomic, readwrite, strong) Class runnerClass;
 
-- (instancetype)init NS_DESIGNATED_INITIALIZER;
-+ (NSArray<NSString *> *)_ptr_testMethodSelectors;
+// - (instancetype)init;
++ (NSArray<NSString *> *)_ptr_dartTests;
 + (IMP)_ptr_testMethodImplementation:(NSString *)testName;
 
 @end

--- a/packages/patrol/darwin/Classes/PatrolTestCaseBase.h
+++ b/packages/patrol/darwin/Classes/PatrolTestCaseBase.h
@@ -13,7 +13,6 @@
 @property(class, nonatomic, readwrite, copy) NSString *selectedDartTest;
 @property(class, nonatomic, readwrite, strong) Class runnerClass;
 
-// - (instancetype)init;
 + (NSArray<NSString *> *)_ptr_listDartTests;
 + (IMP)_ptr_methodIplementationForDartTest:(NSString *)testName;
 

--- a/packages/patrol/darwin/Classes/PatrolTestCaseBase.h
+++ b/packages/patrol/darwin/Classes/PatrolTestCaseBase.h
@@ -10,11 +10,11 @@
 
 @property(class, nonatomic, readwrite, strong) PatrolServer *server;
 @property(class, nonatomic, readwrite, strong) ObjCPatrolAppServiceClient *appServiceClient;
-@property(class, nonatomic, readwrite, copy) NSString *selectedTest;
+@property(class, nonatomic, readwrite, copy) NSString *selectedDartTest;
 @property(class, nonatomic, readwrite, strong) Class runnerClass;
 
 // - (instancetype)init;
-+ (NSArray<NSString *> *)_ptr_dartTests;
-+ (IMP)_ptr_testMethodImplementation:(NSString *)testName;
++ (NSArray<NSString *> *)_ptr_listDartTests;
++ (IMP)_ptr_methodIplementationForDartTest:(NSString *)testName;
 
 @end

--- a/packages/patrol/darwin/Classes/PatrolTestCaseBase.m
+++ b/packages/patrol/darwin/Classes/PatrolTestCaseBase.m
@@ -1,0 +1,34 @@
+@import Foundation;
+@import ObjectiveC.runtime;
+#import "PatrolTestCaseBase.h"
+
+@implementation PatrolTestCaseBase
+
+- (instancetype)init {
+  self = [super initWithInvocation:nil];
+  return self;
+}
+
++ (NSArray<NSInvocation *> *)testInvocations {
+  NSArray<NSString *> *selectors  = [self _ptr_testMethodSelectors];
+  NSArray<NSInvocation *> *invocations = [NSMutableArray arrayWithCapacity:selectors.count];
+  
+  for (NSString *selectorStr in selectors) {
+    SEL selector = NSSelectorFromString(selectorStr);
+    
+    NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    invocation.selector = selector;
+    
+    // TODO: Re-add
+    // class_addMethod(self, selector, implementation, "v@:");
+  }
+  
+  return invocations;
+}
+
++ (NSArray<NSString *> *)_ptr_testMethodSelectors {
+  return @[];
+}
+
+@end

--- a/packages/patrol/darwin/Classes/PatrolTestCaseBase.m
+++ b/packages/patrol/darwin/Classes/PatrolTestCaseBase.m
@@ -4,6 +4,20 @@
 #import "PatrolTestCaseBase.h"
 #import "patrol/patrol-Swift.h"
 
+@interface PTRInvocation : NSInvocation
+// + (NSInvocation *)invocationWithMethodSignature:(NSMethodSignature *)sig;
+@end
+
+@implementation PTRInvocation
+
++ (NSInvocation *)invocationWithMethodSignature:(NSMethodSignature *)sig {
+  NSLog(@"DEBUG PTRInvocation.invocationWithMethodSignature: sig return type: %s", sig.methodReturnType);
+  
+  return [super invocationWithMethodSignature:sig];
+}
+
+@end
+
 
 @implementation PatrolTestCaseBase
 
@@ -115,11 +129,7 @@ static Class _runnerClass = nil;
 
   for (NSString *dartTest in dartTests) {
     NSString *selectorStr = [dartTest copy];
-    //if ([self selectedDartTest] == nil) {
-    if (true) {
-      NSLog(@"DEBUG: selectedDartTest is nil!");
-      selectorStr = [PatrolUtils createMethodNameFromPatrolGeneratedGroup:dartTest];
-    }
+    selectorStr = [PatrolUtils createMethodNameFromPatrolGeneratedGroup:dartTest];
     SEL selector = NSSelectorFromString(selectorStr);
     
     NSString *classStr = NSStringFromClass([self runnerClass]);
@@ -134,7 +144,7 @@ static Class _runnerClass = nil;
     
     NSMethodSignature *signature = [[self runnerClass] instanceMethodSignatureForSelector:selector];
     NSLog(@"NSMethodSignature for selector %@: %@", selectorStr, signature);
-    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    NSInvocation *invocation = [PTRInvocation invocationWithMethodSignature:signature];
     invocation.selector = selector;
     
     [invocations addObject:invocation];
@@ -230,4 +240,5 @@ static Class _runnerClass = nil;
 }
 
 @end
+
 

--- a/packages/patrol/darwin/Classes/PatrolTestCaseBase.m
+++ b/packages/patrol/darwin/Classes/PatrolTestCaseBase.m
@@ -4,31 +4,155 @@
 
 @implementation PatrolTestCaseBase
 
+// MARK: Class properties
+
+static PatrolServer *_server = nil;
++ (PatrolServer *)server {
+  return _server;
+}
++ (void)setServer:(PatrolServer *)newServer {
+  if (newServer != _server) {
+    _server = newServer;
+  }
+}
+
+static ObjCPatrolAppServiceClient *_appServiceClient = nil;
++ (ObjCPatrolAppServiceClient *)appServiceClient {
+  return _appServiceClient;
+}
++ (void)setAppServiceClient:(ObjCPatrolAppServiceClient *)newAppServiceClient {
+  if (newAppServiceClient != _appServiceClient) {
+    _appServiceClient = newAppServiceClient;
+  }
+}
+
+static NSString *_selectedTest = nil;
++ (NSString *)selectedTest {
+  return _selectedTest;
+}
++ (void)setSelectedTest:(NSString *)newSelectedTest {
+  if (newSelectedTest != _selectedTest) {
+    _selectedTest = [newSelectedTest copy];
+  }
+}
+
+// MARK: Initializer
+
 - (instancetype)init {
   self = [super initWithInvocation:nil];
+
   return self;
 }
 
+// MARK: Header implementation
+
++ (NSArray<NSString *> *)_ptr_testMethodSelectors {
+  if ([self selectedTest] != nil) {
+    // A single test was specified with the -only-testing option of xcodebuild
+    NSLog(@"selectedTest: %@", [self selectedTest]);
+    return [NSArray arrayWithObject:[self selectedTest]];
+  }
+
+  // No test was specified. Run app under test and perform test discovery
+
+  /* Allow the Local Network permission required by Dart Observatory */
+  XCUIApplication *springboard = [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
+  XCUIElementQuery *systemAlerts = springboard.alerts;
+  if (systemAlerts.buttons[@"Allow"].exists) {
+    [systemAlerts.buttons[@"Allow"] tap];
+  }
+
+  __block NSArray<NSString *> *dartTests = NULL;
+  /* Run the app for the first time to gather Dart tests */
+  [[[XCUIApplication alloc] init] launch];
+
+  /* Spin the runloop waiting until the app reports that it is ready to report Dart tests */
+  while (![self server].appReady) {
+    [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
+  }
+
+  [[self appServiceClient] listDartTestsWithCompletion:^(NSArray<NSString *> *_Nullable tests, NSError *_Nullable err) {
+    if (err != NULL) {
+      NSLog(@"listDartTests(): failed, err: %@", err);
+    }
+
+    dartTests = tests;
+  }];
+
+  /* Spin the runloop waiting until the app reports the Dart tests it contains */
+  while (!dartTests) {
+    [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
+  }
+
+  NSLog(@"Got %lu Dart tests: %@", dartTests.count, dartTests);
+
+  return dartTests;
+}
+
++ (IMP)_ptr_testMethodImplementation:(NSString *)testName {
+  IMP implementation = imp_implementationWithBlock(^(id _self) {
+    [[[XCUIApplication alloc] init] launch];
+
+    __block ObjCRunDartTestResponse *response = NULL;
+    [[self appServiceClient] runDartTestWithName:testName
+                                      completion:^(ObjCRunDartTestResponse *_Nullable r, NSError *_Nullable err) {
+                                        if (err != NULL) {
+                                          NSLog(@"runDartTestWithName(%@): failed, err: %@", testName, err);
+                                        }
+                                        response = r;
+                                      }];
+
+    /* Wait until Dart test finishes */
+    while (!response) {
+      [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
+    }
+
+    XCTAssertTrue(response.passed, @"%@", response.details);
+  });
+
+  return implementation;
+}
+
+// MARK: Core logic
+
++ (BOOL)instancesRespondToSelector:(SEL)aSelector {
+  NSString *selectedTest = [PatrolUtils createMethodNameFromPatrolGeneratedGroup:NSStringFromSelector(aSelector)];
+
+  NSLog(@"instancesRespondToSelector: selected test \"%@\"", selectedTest);
+
+  [self setSelectedTest:selectedTest];
+  [self defaultTestSuite];  // calls testInvocations
+
+  BOOL result = [super instancesRespondToSelector:aSelector];
+  return true;  // TODO: return real result
+}
+
 + (NSArray<NSInvocation *> *)testInvocations {
-  NSArray<NSString *> *selectors  = [self _ptr_testMethodSelectors];
+  [self setServer:[[PatrolServer alloc] init]];
+
+  NSError *_Nullable __autoreleasing *_Nullable err = NULL;
+  [[self server] startAndReturnError:err];
+  if (err != NULL) {
+    NSLog(@"patrolServer.start(): failed, err: %@", err);
+  }
+
+  [self setAppServiceClient:[[ObjCPatrolAppServiceClient alloc] init]];
+
+  NSArray<NSString *> *selectors = [self _ptr_testMethodSelectors];
   NSArray<NSInvocation *> *invocations = [NSMutableArray arrayWithCapacity:selectors.count];
-  
+
   for (NSString *selectorStr in selectors) {
     SEL selector = NSSelectorFromString(selectorStr);
-    
+
     NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
     invocation.selector = selector;
-    
+
     // TODO: Re-add
     // class_addMethod(self, selector, implementation, "v@:");
   }
-  
-  return invocations;
-}
 
-+ (NSArray<NSString *> *)_ptr_testMethodSelectors {
-  return @[];
+  return invocations;
 }
 
 @end

--- a/packages/patrol/example/integration_test/main_test.dart
+++ b/packages/patrol/example/integration_test/main_test.dart
@@ -9,6 +9,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
 
 void main() {
+  patrolTest('flow that fails', ($) async {
+    await $.pumpWidgetAndSettle(const MyApp());
+
+    await $('Go to the quiz').tap();
+
+    await $('Start').tap();
+
+    await $(TextField).enterText('I am going to crash now!');
+
+    expect(1, 2);
+  });
+
   patrolTest('main flow', ($) async {
     await $.pumpWidgetAndSettle(const MyApp());
 

--- a/packages/patrol/example/ios/RunnerUITests/RunnerUITests.m
+++ b/packages/patrol/example/ios/RunnerUITests/RunnerUITests.m
@@ -8,6 +8,13 @@
 
 @implementation RunnerUITests
 
++ (instancetype)testCaseWithSelector:(SEL)selector {
+  NSLog(@"DEBUG: testCaseWithSelector CALLED with \"%@\"", NSStringFromSelector(selector));
+  return [super testCaseWithSelector:selector];
+}
+
+// - (instancetype)initWithSelector:(SEL)selector {}
+
 + (XCTestSuite *)defaultTestSuite {
   NSLog(@"DEBUG: defaultTestSuite CALLED");
   [super setRunnerClass:self];

--- a/packages/patrol/example/ios/RunnerUITests/RunnerUITests.m
+++ b/packages/patrol/example/ios/RunnerUITests/RunnerUITests.m
@@ -2,4 +2,140 @@
 @import patrol;
 @import ObjectiveC.runtime;
 
-PATROL_INTEGRATION_TEST_IOS_RUNNER(RunnerUITests)
+@interface RunnerUITests : XCTestCase
+
+@property (class, strong, nonatomic) NSString *selectedTest;
+
+@end
+                                                                                                                  
+@implementation RunnerUITests
+
+static NSString *_selectedTest = nil;
+
++ (NSString *)selectedTest {
+  return _selectedTest;
+}
+
++ (void)setSelectedTest:(NSString *)newSelectedTest {
+  if (newSelectedTest != _selectedTest) {
+    _selectedTest = [newSelectedTest copy];
+  }
+}
+
++ (BOOL)instancesRespondToSelector:(SEL)aSelector {
+  NSLog(@"DBG: Called instancesRespondToSelector with arg: %@", NSStringFromSelector(aSelector));
+
+  [self setSelectedTest:NSStringFromSelector(aSelector)];
+  [self defaultTestSuite]; // calls testInvocations
+
+  BOOL result = [super instancesRespondToSelector:aSelector];
+  NSLog(@"DBG: instancesRespondToSelector will return: %d", result);
+  return true;
+}
+
++(NSArray<NSInvocation *> *)testInvocations {
+  /* Start native automation server */
+  PatrolServer *server = [[PatrolServer alloc] init];
+  
+  NSError *_Nullable __autoreleasing *_Nullable err = NULL;
+  [server startAndReturnError:err];
+  if (err != NULL) {
+    NSLog(@"patrolServer.start(): failed, err: %@", err);
+  }
+  
+  /* Create a client for PatrolAppService, which lets us list and run Dart tests */
+  __block ObjCPatrolAppServiceClient *appServiceClient = [[ObjCPatrolAppServiceClient alloc] init];
+  
+  /* Allow the Local Network permission required by Dart Observatory */
+  XCUIApplication *springboard = [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
+  XCUIElementQuery *systemAlerts = springboard.alerts;
+  if (systemAlerts.buttons[@"Allow"].exists) {
+    [systemAlerts.buttons[@"Allow"] tap];
+  }
+  
+  __block NSArray<NSString *> *dartTests = NULL;
+  if ([self selectedTest] != nil) {
+    NSLog(@"selectedTest: %@", [self selectedTest]);
+    dartTests = [NSArray arrayWithObject:[self selectedTest]];
+  } else {
+    /* Run the app for the first time to gather Dart tests */
+    [[[XCUIApplication alloc] init] launch];
+    
+    
+    /* Spin the runloop waiting until the app reports that it is ready to report Dart tests */
+    while (!server.appReady) {
+      [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
+    }
+    
+    
+    [appServiceClient listDartTestsWithCompletion:^(NSArray<NSString *> *_Nullable tests, NSError *_Nullable err) {
+      if (err != NULL) {
+        NSLog(@"listDartTests(): failed, err: %@", err);
+      }
+      
+      dartTests = tests;
+    }];
+    
+    /* Spin the runloop waiting until the app reports the Dart tests it contains */
+    while (!dartTests) {
+      [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
+    }
+    
+    NSLog(@"Got %lu Dart tests: %@", dartTests.count, dartTests);
+  }
+
+                                                                                                                  
+  NSMutableArray<NSInvocation *> *invocations = [[NSMutableArray alloc] init];
+                                                                                                                  
+  /**
+   * Once Dart tests are available, we:
+   *
+   *  Step 1. Dynamically add test case methods that request execution of an individual Dart test file.
+   *
+   *  Step 2. Create invocations to the generated methods and return them
+   */
+                                                                                                                  
+  for (NSString * dartTest in dartTests) {
+    /* Step 1 - dynamically create test cases */
+                                                                                                                  
+    IMP implementation = imp_implementationWithBlock(^(id _self) {
+      [[[XCUIApplication alloc] init] launch];
+                                                                                                                  
+      __block ObjCRunDartTestResponse *response = NULL;
+      [appServiceClient runDartTestWithName:dartTest
+                                 completion:^(ObjCRunDartTestResponse *_Nullable r, NSError *_Nullable err) {
+                                   if (err != NULL) {
+                                     NSLog(@"runDartTestWithName(%@): failed, err: %@", dartTest, err);
+                                   }
+                                                                                                                  
+                                   response = r;
+                                 }];
+                                                                                                                  
+      /* Wait until Dart test finishes */
+      while (!response) {
+        [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
+      }
+                                                                                                                  
+      XCTAssertTrue(response.passed, @"%@", response.details);
+    });
+    NSString *selectorName = dartTest;
+    if ([self selectedTest] == nil) {
+       selectorName = [PatrolUtils createMethodNameFromPatrolGeneratedGroup:dartTest];
+    }
+    SEL selector = NSSelectorFromString(selectorName);
+    class_addMethod(self, selector, implementation, "v@:");
+                                                                                                                  
+    /* Step 2 – create invocations to the dynamically created methods */
+    NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    invocation.selector = selector;
+                                                                                                                  
+    NSLog(@"RunnerUITests.testInvocations(): selectorName = %@, signature: %@", selectorName, signature);
+                                                                                                                  
+    [invocations addObject:invocation];
+  }
+                                                                                                                  
+  return invocations;
+}
+                                                                                                                  
+@end

--- a/packages/patrol/example/ios/RunnerUITests/RunnerUITests.m
+++ b/packages/patrol/example/ios/RunnerUITests/RunnerUITests.m
@@ -23,13 +23,10 @@ static NSString *_selectedTest = nil;
 }
 
 + (BOOL)instancesRespondToSelector:(SEL)aSelector {
-  NSLog(@"DBG: Called instancesRespondToSelector with arg: %@", NSStringFromSelector(aSelector));
-
   [self setSelectedTest:NSStringFromSelector(aSelector)];
   [self defaultTestSuite]; // calls testInvocations
 
   BOOL result = [super instancesRespondToSelector:aSelector];
-  NSLog(@"DBG: instancesRespondToSelector will return: %d", result);
   return true;
 }
 

--- a/packages/patrol/example/ios/RunnerUITests/RunnerUITests.m
+++ b/packages/patrol/example/ios/RunnerUITests/RunnerUITests.m
@@ -2,137 +2,20 @@
 @import patrol;
 @import ObjectiveC.runtime;
 
-@interface RunnerUITests : XCTestCase
-
-@property (class, strong, nonatomic) NSString *selectedTest;
+@interface RunnerUITests : PatrolTestCaseBase
 
 @end
-                                                                                                                  
+
 @implementation RunnerUITests
 
-static NSString *_selectedTest = nil;
-
-+ (NSString *)selectedTest {
-  return _selectedTest;
++ (XCTestSuite *)defaultTestSuite {
+  NSLog(@"DEBUG: defaultTestSuite CALLED");
+  [super setRunnerClass:self];
+  return [super defaultTestSuite];
 }
 
-+ (void)setSelectedTest:(NSString *)newSelectedTest {
-  if (newSelectedTest != _selectedTest) {
-    _selectedTest = [newSelectedTest copy];
-  }
-}
-
-+ (BOOL)instancesRespondToSelector:(SEL)aSelector {
-  [self setSelectedTest:NSStringFromSelector(aSelector)];
-  [self defaultTestSuite]; // calls testInvocations
-
-  BOOL result = [super instancesRespondToSelector:aSelector];
-  return true;
-}
-
-+(NSArray<NSInvocation *> *)testInvocations {
-  /* Start native automation server */
-  PatrolServer *server = [[PatrolServer alloc] init];
-  
-  NSError *_Nullable __autoreleasing *_Nullable err = NULL;
-  [server startAndReturnError:err];
-  if (err != NULL) {
-    NSLog(@"patrolServer.start(): failed, err: %@", err);
-  }
-  
-  /* Create a client for PatrolAppService, which lets us list and run Dart tests */
-  __block ObjCPatrolAppServiceClient *appServiceClient = [[ObjCPatrolAppServiceClient alloc] init];
-  
-  /* Allow the Local Network permission required by Dart Observatory */
-  XCUIApplication *springboard = [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
-  XCUIElementQuery *systemAlerts = springboard.alerts;
-  if (systemAlerts.buttons[@"Allow"].exists) {
-    [systemAlerts.buttons[@"Allow"] tap];
-  }
-  
-  __block NSArray<NSString *> *dartTests = NULL;
-  if ([self selectedTest] != nil) {
-    NSLog(@"selectedTest: %@", [self selectedTest]);
-    dartTests = [NSArray arrayWithObject:[self selectedTest]];
-  } else {
-    /* Run the app for the first time to gather Dart tests */
-    [[[XCUIApplication alloc] init] launch];
-    
-    
-    /* Spin the runloop waiting until the app reports that it is ready to report Dart tests */
-    while (!server.appReady) {
-      [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
-    }
-    
-    
-    [appServiceClient listDartTestsWithCompletion:^(NSArray<NSString *> *_Nullable tests, NSError *_Nullable err) {
-      if (err != NULL) {
-        NSLog(@"listDartTests(): failed, err: %@", err);
-      }
-      
-      dartTests = tests;
-    }];
-    
-    /* Spin the runloop waiting until the app reports the Dart tests it contains */
-    while (!dartTests) {
-      [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
-    }
-    
-    NSLog(@"Got %lu Dart tests: %@", dartTests.count, dartTests);
-  }
-
-                                                                                                                  
-  NSMutableArray<NSInvocation *> *invocations = [[NSMutableArray alloc] init];
-                                                                                                                  
-  /**
-   * Once Dart tests are available, we:
-   *
-   *  Step 1. Dynamically add test case methods that request execution of an individual Dart test file.
-   *
-   *  Step 2. Create invocations to the generated methods and return them
-   */
-                                                                                                                  
-  for (NSString * dartTest in dartTests) {
-    /* Step 1 - dynamically create test cases */
-                                                                                                                  
-    IMP implementation = imp_implementationWithBlock(^(id _self) {
-      [[[XCUIApplication alloc] init] launch];
-                                                                                                                  
-      __block ObjCRunDartTestResponse *response = NULL;
-      [appServiceClient runDartTestWithName:dartTest
-                                 completion:^(ObjCRunDartTestResponse *_Nullable r, NSError *_Nullable err) {
-                                   if (err != NULL) {
-                                     NSLog(@"runDartTestWithName(%@): failed, err: %@", dartTest, err);
-                                   }
-                                                                                                                  
-                                   response = r;
-                                 }];
-                                                                                                                  
-      /* Wait until Dart test finishes */
-      while (!response) {
-        [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
-      }
-                                                                                                                  
-      XCTAssertTrue(response.passed, @"%@", response.details);
-    });
-    NSString *selectorName = dartTest;
-    if ([self selectedTest] == nil) {
-       selectorName = [PatrolUtils createMethodNameFromPatrolGeneratedGroup:dartTest];
-    }
-    SEL selector = NSSelectorFromString(selectorName);
-    class_addMethod(self, selector, implementation, "v@:");
-                                                                                                                  
-    /* Step 2 – create invocations to the dynamically created methods */
-    NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];
-    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
-    invocation.selector = selector;
-                                                                                                                  
-    NSLog(@"RunnerUITests.testInvocations(): selectorName = %@, signature: %@", selectorName, signature);
-                                                                                                                  
-    [invocations addObject:invocation];
-  }
-                                                                                                                  
-  return invocations;
-}
-                                                                                                                  
+// Maybe this will have to be uncommented?
+//+ (BOOL)instancesRespondToSelector:(SEL)aSelector {
+//  return [super instancesRespondToSelector:aSelector];
+//}
 @end


### PR DESCRIPTION
To debug, git clone this repo, checkout this branch, and:

```
cd packages/patrol/example
```

then run the tests for the first time but do not uninstall them:


```
patrol test -t integration_test/main_test.dart --verbose --no-uninstall
```

After the initial run finishes, cd to the `ios` directory. You can run again but selecting only a specific test to run:

```
xcodebuild test-without-building \
  -xctestrun ../build/ios_integ/Build/Products/Runner_TestPlan_iphonesimulator17.0-arm64-x86_64.xctestrun \
  -only-testing 'RunnerUITests/RunnerUITests/main_test flow that fails' \
  -destination 'platform=iOS Simulator,name=iPhone 15'
```

or

```
xcodebuild test-without-building \
  -xctestrun ../build/ios_integ/Build/Products/Runner_TestPlan_iphonesimulator17.0-arm64-x86_64.xctestrun \
  -only-testing 'RunnerUITests/RunnerUITests/main_test main flow' \
  -destination 'platform=iOS Simulator,name=iPhone 15'
```

Environment:
- Latest [Patrol CLI](https://pub.dev/packages/patrol_cli) (`2.3.1+1`)
- Flutter 3.16.x
- Xcode 15.0.1
