### PR TITLE
Fail faster when running on iOS fails due to bad destinations

### DIFF
--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -199,6 +199,7 @@ class IOSAppOptions {
         '-destination',
         'platform=${device.real ? 'iOS' : 'iOS Simulator'},name=${device.name}',
       ],
+      ...['-destination-timeout', '1'],
       ...['-resultBundlePath', resultBundlePath],
     ];
 

--- a/packages/patrol_cli/test/crossplatform/app_options_test.dart
+++ b/packages/patrol_cli/test/crossplatform/app_options_test.dart
@@ -176,6 +176,7 @@ void main() {
             ...['-xctestrun', xcTestRunPath],
             ...['-only-testing', 'RunnerUITests'],
             ...['-destination', 'platform=iOS,name=iPhone 13'],
+            ...['-destination-timeout', '1'],
             ...['-resultBundlePath', ''],
           ]),
         );


### PR DESCRIPTION
This will fail much faster when something bad with discovering destination happen, and won't have any effect when everything is all good.