### PR TITLE
Add support for running tagged test files

### DIFF
--- a/packages/patrol_cli/lib/src/runner/patrol_command.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command.dart
@@ -43,6 +43,14 @@ abstract class PatrolCommand extends Command<int> {
       );
   }
 
+  void usesTagsOption() {
+    argParser.addOption(
+      'tags',
+      help: 'A comma-separated list of tags to use for finding test targets.',
+      valueHelp: 'mobile,integration',
+    );
+  }
+
   /// A command that expects only one device but got more should throw.
   void usesDeviceOption() {
     argParser.addMultiOption(

--- a/packages/patrol_cli/lib/src/test_bundler.dart
+++ b/packages/patrol_cli/lib/src/test_bundler.dart
@@ -38,7 +38,7 @@ ${generateImports(testFilePaths)}
 Future<void> main() async {
   // This is the entrypoint of the bundled Dart test.
   //
-  // Its responsibilies are:
+  // Its responsibilities are:
   //  * Running a special Dart test that runs before all the other tests and
   //    explores the hierarchy of groups and tests.
   //  * Hosting a PatrolAppService, which the native side of Patrol uses to get

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -16,6 +16,7 @@ environment:
 
 dependencies:
   adb: ^0.3.0
+  analyzer: any
   ansi_styles: ^0.3.2+1
   args: ^2.4.2
   ci: ^0.1.0

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 
 dependencies:
   adb: ^0.3.0
-  analyzer: any
+  analyzer: ^6.0.0
   ansi_styles: ^0.3.2+1
   args: ^2.4.2
   ci: ^0.1.0


### PR DESCRIPTION
Hello.

This PR adds support for `--tags` option for the `test` command.
This way we can tag test files with the `@Tags` annotation like dart's test suite does.
Using this option we can now run only the test files matching a given tag or a list of tags.