### PR TITLE
Fix `enterText` not being able to interact with other than first textfield on Android

### DIFF
--- a/dev/e2e_app/integration_test/webview_hackernews_test.dart
+++ b/dev/e2e_app/integration_test/webview_hackernews_test.dart
@@ -12,9 +12,9 @@ void main() {
       index: 0,
       keyboardBehavior: KeyboardBehavior.showAndDismiss,
     );
-    await $.native.enterTextByIndex(
-      'ny4ncat',
-      index: 1,
+    await $.native.enterText(
+      Selector(className: 'android.widget.EditText'),
+      text: 'ny4ncat',
       keyboardBehavior: KeyboardBehavior.showAndDismiss,
     );
   });

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add optional timeout parameter to native methods (#2042).
 - Add `$.native.tapAt()` (#2053)
+- Fix `native.enterText` interacting with first EditText regardless of `Selector` passed (Android-only) (#2072)
 
 ## 3.4.0
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -250,7 +250,13 @@ class Automator private constructor() {
             throw UiObjectNotFoundException("$uiSelector")
         }
 
-        val uiObject = uiDevice.findObject(uiSelector).getFromParent(UiSelector().className(EditText::class.java))
+        var uiObject = uiDevice.findObject(uiSelector)
+
+        val uiObjectClassname = uiObject.getClassName()
+
+        if(uiObjectClassname != EditText::class.java.name) {
+            uiObject = uiObject.getChild(UiSelector().className(EditText::class.java))
+        }
 
         if (keyboardBehavior == KeyboardBehavior.showAndDismiss) {
             uiObject.click()

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -254,7 +254,7 @@ class Automator private constructor() {
 
         val uiObjectClassname = uiObject.getClassName()
 
-        if(uiObjectClassname != EditText::class.java.name) {
+        if (uiObjectClassname != EditText::class.java.name) {
             uiObject = uiObject.getChild(UiSelector().className(EditText::class.java))
         }
 


### PR DESCRIPTION
Story time:
The bug occured when there were multiple native textFields on the screen and all of them had the same direct parent. The process of finding the textfield was taking into account that dev might not use a selector to the textfield, but to its parent (eg. when textfield is wrapped with another element and only the wrapping element has resourceId, not textfield). So after finding the element by provided selector, `enterText` took element's parent, and looked for the first textfield among children of this parent. It resulted in the first textfield to be picked always, even if selector argument in `enterText` found another one (correct from the perspective of the dev).