### PR TITLE
Add rule to retry tests

### DIFF
--- a/packages/patrol/example/android/app/build.gradle
+++ b/packages/patrol/example/android/app/build.gradle
@@ -83,4 +83,5 @@ flutter {
 
 dependencies {
     androidTestUtil 'androidx.test:orchestrator:1.4.2'
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/packages/patrol/example/android/app/src/androidTest/java/pl/leancode/patrol/example/MainActivityTest.java
+++ b/packages/patrol/example/android/app/src/androidTest/java/pl/leancode/patrol/example/MainActivityTest.java
@@ -1,6 +1,9 @@
 package pl.leancode.patrol.example;
 
+import pl.leancode.patrol.example.RetryTestRule;
+
 import androidx.test.platform.app.InstrumentationRegistry;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -22,6 +25,9 @@ public class MainActivityTest {
     }
 
     private final String dartTestName;
+
+    @Rule
+    public RetryTestRule retryTestRule = new RetryTestRule(3);
 
     @Test
     public void runDartTest() {

--- a/packages/patrol/example/android/app/src/androidTest/java/pl/leancode/patrol/example/RetryTestRule.java
+++ b/packages/patrol/example/android/app/src/androidTest/java/pl/leancode/patrol/example/RetryTestRule.java
@@ -1,0 +1,42 @@
+package pl.leancode.patrol.example;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class RetryTestRule implements TestRule {
+
+    private int maxRetries;
+
+    public RetryTestRule(int maxRetries) {
+        this.maxRetries = maxRetries;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return statement(base, description);
+    }
+
+    private Statement statement(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Throwable caughtThrowable = null;
+
+                for (int i = 0; i <= maxRetries; i++) {
+                    try {
+                        base.evaluate();
+                        return;
+                    } catch (Throwable t) {
+                        caughtThrowable = t;
+                        System.err.println(
+                                description.getDisplayName() + ": run " + (i + 1) + " failed"
+                                        + "error:" + t);
+                    }
+                }
+                System.err.println(description.getDisplayName() + ": giving up after " + maxRetries + " failures");
+                throw caughtThrowable;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Currently it doesn't work because some adjustments in patrol's package are needed, error message:
```
01-29 09:33:02.611  7398  7468 I flutter : [ERROR] 2024-01-29 09:33:02.610806	0:00:00.000275	POST	/runDartTest
01-29 09:33:02.611  7398  7468 I flutter : 'package:patrol/src/native/patrol_app_service.dart': Failed assertion: line 147 pos 12: '_testExecutionCompleted.isCompleted == false': is not true.
01-29 09:33:02.611  7398  7468 I flutter : dart:core                                                                 _AssertionError._throwNew
01-29 09:33:02.611  7398  7468 I flutter : package:patrol/src/native/patrol_app_service.dart 147:12                  PatrolAppService.runDartTest
01-29 09:33:02.611  7398  7468 I flutter : package:patrol/src/native/contracts/patrol_app_service_server.dart 27:28  PatrolAppServiceServer.handle
01-29 09:33:02.613  7398  7449 E PatrolServer: PatrolJUnitRunner.runDartTest(test name): Invalid response 500, Internal Server Error
```