### PR TITLE
[patrol_cli] fix(compatibility_checker.dart): it get's stuck when it can't find patrol

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.4
+
+- Fix compatibility_checker getting stuck (#2091).
+
 ## 2.6.3
 
 - Fix invalid JSON output of version check command (#2087).

--- a/packages/patrol_cli/lib/src/base/constants.dart
+++ b/packages/patrol_cli/lib/src/base/constants.dart
@@ -1,3 +1,3 @@
 /// Version of Patrol CLI. Must be kept in sync with pubspec.yaml.
 /// If you update this, make sure that compatibility-table.mdx is updated (if needed)
-const version = '2.6.3';
+const version = '2.6.4';

--- a/packages/patrol_cli/lib/src/compatibility_checker.dart
+++ b/packages/patrol_cli/lib/src/compatibility_checker.dart
@@ -53,24 +53,27 @@ class CompatibilityChecker {
       )
         ..disposedBy(scope);
 
-      process.listenStdOut((line) async {
-        if (line.startsWith('- patrol ')) {
-          packageCompleter.complete(line.split(' ').last);
-        }
-      }).disposedBy(scope);
+      process.listenStdOut(
+        (line) async {
+          if (line.startsWith('- patrol ')) {
+            packageCompleter.complete(line.split(' ').last);
+          }
+        },
+        onDone: () {
+          if (!packageCompleter.isCompleted) {
+            throwToolExit(
+              'Failed to read patrol version. Make sure you have patrol '
+              'dependency in your pubspec.yaml file',
+            );
+          }
+        },
+      ).disposedBy(scope);
     });
 
     packageVersion = await packageCompleter.future;
 
-    if (packageVersion == null) {
-      throwToolExit(
-        'Failed to read patrol version. Make sure you have patrol '
-        'dependency in your pubspec.yaml file',
-      );
-    }
-
     final cliVersion = Version.parse(constants.version);
-    final patrolVersion = Version.parse(packageVersion);
+    final patrolVersion = Version.parse(packageVersion!);
 
     final isCompatible = cliVersion.isCompatibleWith(patrolVersion);
 

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: patrol_cli
 description: >
   Command-line tool for Patrol, a powerful Flutter-native UI testing framework.
-version: 2.6.3 # Must be kept in sync with constants.dart
+version: 2.6.4 # Must be kept in sync with constants.dart
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol_cli
 issue_tracker: https://github.com/leancodepl/patrol/issues?q=is%3Aopen+is%3Aissue+label%3A%22package%3A+patrol_cli%22


### PR DESCRIPTION
closes #2091

The packageCompleter.future never returns the way it was before, causing patrol to get stuck.

packageCompleter.future: `The future that is completed when [complete] or [completeError] is called.`

If patrol can't be found, `complete` is never called. It would be possible to call `completeError` in `onDone` instead of `throwToolExit` and keep the rest of the implementation, but since this would just delay the `throwToolExit`, I implemented it this way.