### PR TITLE
Fix handling denying Android permissions when invoked second time

### DIFF
--- a/dev/e2e_app/integration_test/permissions/deny_many_permissions_twice_test.dart
+++ b/dev/e2e_app/integration_test/permissions/deny_many_permissions_twice_test.dart
@@ -5,7 +5,7 @@ import '../common.dart';
 const _timeout = Duration(seconds: 5); // to avoid timeouts on CI
 
 void main() {
-  patrol('grants various permissions', ($) async {
+  patrol('denies various permissions', ($) async {
     await createApp($);
 
     await $('Open permissions screen').scrollTo().tap();

--- a/dev/e2e_app/integration_test/permissions/deny_many_permissions_twice_test.dart
+++ b/dev/e2e_app/integration_test/permissions/deny_many_permissions_twice_test.dart
@@ -1,0 +1,65 @@
+import 'package:permission_handler/permission_handler.dart';
+
+import '../common.dart';
+
+const _timeout = Duration(seconds: 5); // to avoid timeouts on CI
+
+void main() {
+  patrol('grants various permissions', ($) async {
+    await createApp($);
+
+    await $('Open permissions screen').scrollTo().tap();
+
+    await _requestAndDenyCameraPermission($);
+    await _requestAndDenyCameraPermission($);
+
+    await _requestAndDenyMicrophonePermission($);
+    await _requestAndDenyMicrophonePermission($);
+
+    await _requestAndDenyContactsPermission($);
+    await _requestAndDenyContactsPermission($);
+  });
+}
+
+Future<void> _requestAndDenyCameraPermission(PatrolIntegrationTester $) async {
+  if (!await Permission.camera.isGranted) {
+    expect($(#camera).$(#statusText).text, 'Not granted');
+    await $('Request camera permission').tap();
+    if (await $.native.isPermissionDialogVisible(timeout: _timeout)) {
+      await $.native.denyPermission();
+      await $.pump();
+    }
+  }
+
+  expect($(#camera).$(#statusText).text, 'Not granted');
+}
+
+Future<void> _requestAndDenyMicrophonePermission(
+  PatrolIntegrationTester $,
+) async {
+  if (!await Permission.microphone.isGranted) {
+    expect($(#microphone).$(#statusText).text, 'Not granted');
+    await $('Request microphone permission').tap();
+    if (await $.native.isPermissionDialogVisible(timeout: _timeout)) {
+      await $.native.denyPermission();
+      await $.pump();
+    }
+  }
+
+  expect($(#microphone).$(#statusText).text, 'Not granted');
+}
+
+Future<void> _requestAndDenyContactsPermission(
+  PatrolIntegrationTester $,
+) async {
+  if (!await Permission.contacts.isGranted) {
+    expect($(#contacts).$(#statusText).text, 'Not granted');
+    await $('Request contacts permission').tap();
+    if (await $.native.isPermissionDialogVisible(timeout: _timeout)) {
+      await $.native.denyPermission();
+      await $.pump();
+    }
+  }
+
+  expect($(#contacts).$(#statusText).text, 'Not granted');
+}

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -433,7 +433,8 @@ class Automator private constructor() {
             "com.android.permissioncontroller:id/permission_allow_one_time_button",
             // deny
             "com.android.packageinstaller:id/permission_deny_button",
-            "com.android.permissioncontroller:id/permission_deny_button"
+            "com.android.permissioncontroller:id/permission_deny_button",
+            "com.android.permissioncontroller:id/permission_deny_and_dont_ask_again_button"
         )
 
         val uiObject = waitForUiObjectByResourceId(*identifiers, timeout = timeout)
@@ -474,7 +475,8 @@ class Automator private constructor() {
     fun denyPermission() {
         val identifiers = arrayOf(
             "com.android.packageinstaller:id/permission_deny_button", // API <= 28
-            "com.android.permissioncontroller:id/permission_deny_button" // API >= 29
+            "com.android.permissioncontroller:id/permission_deny_button", // API >= 29 (first invocation)
+            "com.android.permissioncontroller:id/permission_deny_and_dont_ask_again_button" // API >= 29 (second invocation)
         )
 
         val uiObject = waitForUiObjectByResourceId(*identifiers, timeout = timeoutMillis)


### PR DESCRIPTION
When Android native permission is invoked second time there's different `resourceId` for Android API >= 29