### PR TITLE
Fix reporting fail cause to native on ios in release mode

### DIFF
--- a/dev/e2e_app/pubspec.lock
+++ b/dev/e2e_app/pubspec.lock
@@ -406,7 +406,7 @@ packages:
       path: "../../packages/patrol"
       relative: true
     source: path
-    version: "3.4.0"
+    version: "3.5.1"
   patrol_finders:
     dependency: transitive
     description:

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2
+
+- Fix reporting fail cause to native on ios in release mode (#2114).
+
 ## 3.5.1
 
 - Make more `Selector` properties work on iOS (#2030).

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -49,11 +49,11 @@ class PatrolBinding extends LiveTestWidgetsFlutterBinding {
       final currentDartTest = _currentDartTest;
       if (currentDartTest != null) {
         assert(!constants.hotRestartEnabled);
-        // On iOS in release mode, diagnostics are compacted or truncated. So we
-        // use the exceptionAsString() method to get at least an information
+        // On iOS in release mode, diagnostics are compacted or truncated.
+        // We use the exceptionAsString() and stack to get the information
         // about the exception. See [DiagnosticLevel].
         final detailsAsString = (kReleaseMode && io.Platform.isIOS)
-            ? details.exceptionAsString()
+            ? '${details.exceptionAsString()} \n ${details.stack}'
             : details.toString();
         _testResults[currentDartTest] = Failure(
           testDescription,

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io' as io;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -41,11 +42,23 @@ class PatrolBinding extends LiveTestWidgetsFlutterBinding {
   PatrolBinding(NativeAutomatorConfig config)
       : _serviceExtensions = DevtoolsServiceExtensions(config) {
     final oldTestExceptionReporter = reportTestException;
+
+    /// Wraps the default test exception reporter to report the test results to
+    /// the native side of Patrol.
     reportTestException = (details, testDescription) {
       final currentDartTest = _currentDartTest;
       if (currentDartTest != null) {
         assert(!constants.hotRestartEnabled);
-        _testResults[currentDartTest] = Failure(testDescription, '$details');
+        // On iOS in release mode, diagnostics are compacted or truncated. So we
+        // use the exceptionAsString() method to get at least an information
+        // about the exception. See [DiagnosticLevel].
+        final detailsAsString = (kReleaseMode && io.Platform.isIOS)
+            ? details.exceptionAsString()
+            : details.toString();
+        _testResults[currentDartTest] = Failure(
+          testDescription,
+          detailsAsString,
+        );
       }
       oldTestExceptionReporter(details, testDescription);
     };

--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -2,7 +2,7 @@ name: patrol
 description: >
   Powerful Flutter-native UI testing framework overcoming limitations of
   existing Flutter testing tools. Ready for action!
-version: 3.5.1
+version: 3.5.2
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues


### PR DESCRIPTION
Closes #1886.
We can't get the same description of the fail cause for ios in release mode as according to documentation diagnostics in release mode are truncated. 
> /// In release mode, this level may not have any effect, as diagnostics in
/// release mode are compacted or truncated to reduce binary size.
enum DiagnosticLevel {

What we get with this PR is a short description of the cause and the stacktrace, i.e.:
```
Patrol action failed: NativeAutomatorClientException: tap() failed with Invalid response: 400 Nie można ukończyć tej operacji. (patrol.PatrolError 0.)

#0      NativeAutomator._wrapRequest (package:patrol/src/native/native_automator.dart:226)
	<asynchronous suspension>
	#1      NativeAutomator.tap (package:patrol/src/native/native_automator.dart:526)
	<asynchronous suspension>
	#2      main.<anonymous closure> (file:///user/Projects/patrol/packages/patrol/example/integration_test/example_test.dart:21)
	<asynchronous suspension>
	#3      patrolTest.<anonymous closure> (package:patrol/src/common.dart:130)
	<asynchronous suspension>
	#4      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:168)
	<asynchronous suspension>
	#5      TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1063)
	<asynchronous suspension>
	#6      TestWidgetsFlutterBinding._createTestCompletionHandler.<anonymous closure> (package:flutter_test/src/binding.dart:824)
	<asynchronous suspension>
```
For running tests in debug and release on Android the error stays the same 
