### PR TITLE
Flutter command arg

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -96,7 +96,7 @@ Patrol UI tests. It is necessary to run UI tests (`flutter test` won't work! [He
 Patrol CLI invokes the Flutter CLI for certain commands. To override the command used,
 pass the `--flutter-command` argument or set the `PATROL_FLUTTER_COMMAND` environment
 variable. This supports FVM (by setting the value to `fvm flutter`), puro (`puro flutter`)
-and potentially others.
+and potentially other version managers.
 
 ### Integrate with native side
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -30,7 +30,7 @@ Check out our video version of this tutorial on YouTube!
 ### Add dependency on `patrol`
 
 If you haven't already, add a dependency on the `patrol` package in the
-`dev_dependencies` section of `pubspec.yaml`.  `patrol` package requires 
+`dev_dependencies` section of `pubspec.yaml`.  `patrol` package requires
 Android SDK version 21 or higher.
 
 ```
@@ -76,7 +76,7 @@ Patrol UI tests. It is necessary to run UI tests (`flutter test` won't work! [He
      It's explained how to do it in the [README](https://pub.dev/packages/patrol_cli#installation).
   </Info>
 
-2. Verify that installation was successful and your enviroment is set up properly:
+2. Verify that installation was successful and your environment is set up properly:
 
    ```
    patrol doctor
@@ -84,10 +84,10 @@ Patrol UI tests. It is necessary to run UI tests (`flutter test` won't work! [He
    Example output:
    ```
    Patrol CLI version: 2.3.1+1
-   Android: 
+   Android:
    • Program adb found in /Users/username/Library/Android/sdk/platform-tools/adb
    • Env var $ANDROID_HOME set to /Users/username/Library/Android/sdk
-   iOS / macOS: 
+   iOS / macOS:
    • Program xcodebuild found in /usr/bin/xcodebuild
    • Program ideviceinstaller found in /opt/homebrew/bin/ideviceinstaller
    ```
@@ -95,7 +95,8 @@ Patrol UI tests. It is necessary to run UI tests (`flutter test` won't work! [He
 
 Patrol CLI invokes the Flutter CLI for certain commands. To override the command used,
 pass the `--flutter-command` argument or set the `PATROL_FLUTTER_COMMAND` environment
-variable.
+variable. This supports FVM (by setting the value to `fvm flutter`), puro (`puro flutter`)
+and potentially others.
 
 ### Integrate with native side
 
@@ -106,7 +107,7 @@ Psst... Android is a bit easier to set up, so we recommend starting with it!
 <Accordion defaultOpen title="Android setup">
 
       1. Go to **android/app/src/androidTest/java/com/example/myapp/** in your project
-         directory. If there are no such folders, create them. **Remember to replace 
+         directory. If there are no such folders, create them. **Remember to replace
          `/com/example/myapp/` with the path created by your app's package name.**
 
       2. Create a file named `MainActivityTest.java` and copy there the code below.
@@ -178,21 +179,21 @@ Psst... Android is a bit easier to set up, so we recommend starting with it!
       
       2. Create a test target if you do not already have one (see the screenshot below
          for the reference). Select `File > New > Target...` and select `UI Testing Bundle`.
-         Change the `Product Name` to `RunnerUITests`. Set the `Organization Identifier` 
-         to be the same as for the `Runner` (no matter if you app has flavors or not). 
-         For our example app, it's `com.example.MyApp` just as in the `pubspec.yaml` file. 
+         Change the `Product Name` to `RunnerUITests`. Set the `Organization Identifier`
+         to be the same as for the `Runner` (no matter if you app has flavors or not).
+         For our example app, it's `com.example.MyApp` just as in the `pubspec.yaml` file.
          Make sure `Target to be Tested` is set to `Runner` and language is set to `Objective-C`.
-         Select `Finish`. 
+         Select `Finish`.
 
       ![Xcode iOS test target](/assets/ios_test_target.png)
 
       3. 2 files are created: `RunnerUITests.m` and `RunnerUITestsLaunchTests.m`.
-         Delete `RunnerUITestsLaunchTests.m` **through Xcode** by clicking on it and 
+         Delete `RunnerUITestsLaunchTests.m` **through Xcode** by clicking on it and
          selecting `Move to Trash`.
 
       4. Make sure that the **iOS Deployment Target** of `RunnerUITests` within the
          **Build Settings** section is the same as `Runner`.
-         The minimum supported **iOS Deployment Target** is `11.0`. For the 
+         The minimum supported **iOS Deployment Target** is `11.0`. For the
          [example app](https://github.com/leancodepl/patrol/tree/master/packages/patrol/example),
          we set it to `13.0` because it's required by the app dependencies.
 
@@ -269,14 +270,14 @@ Psst... Android is a bit easier to set up, so we recommend starting with it!
       <YouTube id="9LdEJR59fW4" />
 
       14. Go to **RunnerUITests** -> **Build Settings**, search for **User Script Sandboxing**
-         and make sure it's set to **No**. 
+         and make sure it's set to **No**.
 
 </Accordion>
 
 <Accordion title="macOS setup">
 
-      1. Open `macos/Runner.xcworkspace` in Xcode. 
-      
+      1. Open `macos/Runner.xcworkspace` in Xcode.
+
       2. Create a test target if you do not already have one via `File > New > Target...`
          and select `UI Testing Bundle`. Change the `Product Name` to `RunnerUITests`. Make
          sure `Target to be Tested` is set to `Runner` and language is set to `Objective-C`.
@@ -357,19 +358,19 @@ Psst... Android is a bit easier to set up, so we recommend starting with it!
       <YouTube id="9LdEJR59fW4" />
 
       13. Go to **RunnerUITests** -> **Build Settings**, search for **User Script Sandboxing**
-         and make sure it's set to **No**. 
-      
-      14. Go to **Runner** -> **Signing & Capabilities**. Make sure that in all **App Sandbox** 
+         and make sure it's set to **No**.
+
+      14. Go to **Runner** -> **Signing & Capabilities**. Make sure that in all **App Sandbox**
          sections, **Incoming Connections (Server)** and **Outgoing Connections (Client)** checkboxes
          are checked.
 
       ![Xcode entitlements setup](/assets/macos_entitlements.png)
 
-      15. **Copy** `DebugProfile.entitlements` and `Release.entitlements` files from `macos/Runner` 
+      15. **Copy** `DebugProfile.entitlements` and `Release.entitlements` files from `macos/Runner`
          to `macos/RunnerUITests` directory.
 
-      16. Go to **RunnerUITests** -> **Build Settings** and set **Code Signing Entitlements** to 
-         `RunnerUITests/DebugProfile.entitlements` for **Debug** and **Profile** configuration and to 
+      16. Go to **RunnerUITests** -> **Build Settings** and set **Code Signing Entitlements** to
+         `RunnerUITests/DebugProfile.entitlements` for **Debug** and **Profile** configuration and to
          `RunnerUITests/Release.entitlements` for **Release** configuration.
 
       ![Xcode RunnerUITests entitlements setup](/assets/macos_ui_entitlements.png)
@@ -425,7 +426,7 @@ up. To run `integration_test/example_test.dart` on a connected Android, iOS or m
       patrol test -t integration_test/example_test.dart
       ```
 
-      If the setup is successful, you should see a **TEST PASSED** message. 
+      If the setup is successful, you should see a **TEST PASSED** message.
       If something went wrong, please proceed to the [FAQ] section which might
       contain an answer to your issue.
 
@@ -476,17 +477,17 @@ up. To run `integration_test/example_test.dart` on a connected Android, iOS or m
   and make sure that the versions of `patrol` and `patrol_cli` you are using are compatible.
 </Accordion>
 
-<Accordion title="'example_test.dart' passed but I can't get my application to run 
+<Accordion title="'example_test.dart' passed but I can't get my application to run
 within the patrol test.">
   To run your application within the patrol test, you need to call `$.pumpWidgetAndSettle()`,
-  and pass your application's main widget to it. Be sure that you registered all the 
+  and pass your application's main widget to it. Be sure that you registered all the
   necessary services before calling `$.pumpWidgetAndSettle()`.
   Here's the example of running an app within the patrol test:
   ```dart
 
   void main() {
     patrolTest('real app test', ($) async {
-    
+
     // Do all the necessary setup here (DI, services, etc.)
 
     await $.pumpWidgetAndSettle(const MyApp()); // Your's app main widget
@@ -510,8 +511,8 @@ within the patrol test.">
 </Accordion>
 
 <Accordion title="Running patrol test fails containing 'Unsupported class file major version' error">
-  It's most likely caused by using incompatible JDK version. 
-  Run `javac -version` to check your JDK version. Patrol officially works on JDK 17, 
+  It's most likely caused by using incompatible JDK version.
+  Run `javac -version` to check your JDK version. Patrol officially works on JDK 17,
   so unexpected errors may occur on other versions.
   If you have AndroidStudio or Intellij IDEA installed, you can find the path to JDK by
   opening your project's android directory in AS/Intellij and going to
@@ -534,14 +535,14 @@ within the patrol test.">
 
 <Accordion title="Running test stops on 'Wait for com.example.myapp to idle'">
   Open your XCode project, go to **Runner** target -> **Build Settings**, search for `FLUTTER_TARGET`
-  and remove set path to targets for all configurations. 
+  and remove set path to targets for all configurations.
   Alternatively, you can search for a `FLUTTER_TARGET` in your project files and remove it (both value and key)
   from *.xcconfig and *.pbxproj files.
 </Accordion>
 
 <Accordion title="When running a test, real app without test is opened instead">
   Open your XCode project, go to **Runner** target -> **Build Settings**, search for `FLUTTER_TARGET`
-  and remove set path to targets for all configurations. 
+  and remove set path to targets for all configurations.
   Alternatively, you can search for a `FLUTTER_TARGET` in your project files and remove it (both value and key)
   from *.xcconfig and *.pbxproj files.
 </Accordion>
@@ -552,11 +553,11 @@ within the patrol test.">
   platform :ios, '11.0'
   ```
   If yes, then check if **iOS deployment version** in Xcode project's **Build Settings**
-  section for all targets (Runner and RunnerUITests) are set to the same value as in Podfile 
+  section for all targets (Runner and RunnerUITests) are set to the same value as in Podfile
   (in case presented in snippet above, all should be set to 11.0).
 </Accordion>
 
-If you couldn't find an answer to your question/problem, feel free to ask on 
+If you couldn't find an answer to your question/problem, feel free to ask on
 [Patrol Discord Server](https://discord.gg/ukBK5t4EZg).
 
 ### Going from here

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -93,6 +93,10 @@ Patrol UI tests. It is necessary to run UI tests (`flutter test` won't work! [He
    ```
    Be sure that for the platform you want to run the test on, all the checks are green.
 
+Patrol CLI invokes the Flutter CLI for certain commands. To override the command used,
+pass the `--flutter-command` argument or set the `PATROL_FLUTTER_COMMAND` environment
+variable.
+
 ### Integrate with native side
 
 The 3 first steps were common across platforms. The rest is platform-specific.

--- a/packages/patrol_cli/lib/src/analytics/analytics.dart
+++ b/packages/patrol_cli/lib/src/analytics/analytics.dart
@@ -188,6 +188,7 @@ class FlutterVersion {
         '--version',
         '--machine',
       ],
+      runInShell: true,
     );
 
     final versionData =

--- a/packages/patrol_cli/lib/src/commands/build_android.dart
+++ b/packages/patrol_cli/lib/src/commands/build_android.dart
@@ -58,7 +58,12 @@ class BuildAndroidCommand extends PatrolCommand {
 
   @override
   Future<int> run() async {
-    unawaited(_analytics.sendCommand('build_android'));
+    unawaited(
+      _analytics.sendCommand(
+        FlutterVersion.fromCLI(flutterCommand),
+        'build_android',
+      ),
+    );
 
     final config = _pubspecReader.read();
     final testFileSuffix = config.testFileSuffix;
@@ -117,6 +122,7 @@ class BuildAndroidCommand extends PatrolCommand {
     }
 
     final flutterOpts = FlutterAppOptions(
+      command: flutterCommand,
       target: entrypoint.path,
       flavor: flavor,
       buildMode: buildMode,

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -63,7 +63,12 @@ class BuildIOSCommand extends PatrolCommand {
 
   @override
   Future<int> run() async {
-    unawaited(_analytics.sendCommand('build_ios'));
+    unawaited(
+      _analytics.sendCommand(
+        FlutterVersion.fromCLI(flutterCommand),
+        'build_ios',
+      ),
+    );
 
     final config = _pubspecReader.read();
     final testFileSuffix = config.testFileSuffix;
@@ -124,6 +129,7 @@ class BuildIOSCommand extends PatrolCommand {
     }
 
     final flutterOpts = FlutterAppOptions(
+      command: flutterCommand,
       target: entrypoint.path,
       flavor: flavor,
       buildMode: buildMode,

--- a/packages/patrol_cli/lib/src/commands/build_macos.dart
+++ b/packages/patrol_cli/lib/src/commands/build_macos.dart
@@ -59,7 +59,12 @@ class BuildMacOSCommand extends PatrolCommand {
 
   @override
   Future<int> run() async {
-    unawaited(_analytics.sendCommand('build_macos'));
+    unawaited(
+      _analytics.sendCommand(
+        FlutterVersion.fromCLI(flutterCommand),
+        'build_macos',
+      ),
+    );
 
     final config = _pubspecReader.read();
     final testFileSuffix = config.testFileSuffix;
@@ -120,6 +125,7 @@ class BuildMacOSCommand extends PatrolCommand {
     }
 
     final flutterOpts = FlutterAppOptions(
+      command: flutterCommand,
       target: entrypoint.path,
       flavor: flavor,
       buildMode: buildMode,

--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -92,7 +92,9 @@ class DevelopCommand extends PatrolCommand {
       ),
     );
 
-    await _compatibilityChecker.checkVersionsCompatibility();
+    await _compatibilityChecker.checkVersionsCompatibility(
+      flutterCommand: flutterCommand,
+    );
 
     final targets = stringsArg('target');
     if (targets.isEmpty) {

--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -85,7 +85,12 @@ class DevelopCommand extends PatrolCommand {
 
   @override
   Future<int> run() async {
-    unawaited(_analytics.sendCommand(name));
+    unawaited(
+      _analytics.sendCommand(
+        FlutterVersion.fromCLI(flutterCommand),
+        name,
+      ),
+    );
 
     await _compatibilityChecker.checkVersionsCompatibility();
 
@@ -119,7 +124,10 @@ class DevelopCommand extends PatrolCommand {
       _logger.detail('Received iOS flavor: $iosFlavor');
     }
 
-    final devices = await _deviceFinder.find(stringsArg('device'));
+    final devices = await _deviceFinder.find(
+      stringsArg('device'),
+      flutterCommand: flutterCommand,
+    );
     final device = devices.single;
 
     // `flutter logs` doesn't work on macOS, so we don't support it for now
@@ -179,6 +187,7 @@ class DevelopCommand extends PatrolCommand {
     }
 
     final flutterOpts = FlutterAppOptions(
+      command: flutterCommand,
       target: entrypoint.path,
       flavor: androidFlavor,
       buildMode: buildMode,
@@ -328,6 +337,7 @@ class DevelopCommand extends PatrolCommand {
     try {
       final future = action();
       await _flutterTool.attachForHotRestart(
+        flutterCommand: flutterCommand,
         deviceId: device.id,
         target: flutterOpts.target,
         appId: appId,

--- a/packages/patrol_cli/lib/src/commands/devices.dart
+++ b/packages/patrol_cli/lib/src/commands/devices.dart
@@ -20,7 +20,8 @@ class DevicesCommand extends PatrolCommand {
 
   @override
   Future<int> run() async {
-    final devices = await _deviceFinder.getAttachedDevices();
+    final devices =
+        await _deviceFinder.getAttachedDevices(flutterCommand: flutterCommand);
 
     if (devices.isEmpty) {
       _logger.err('No devices attached');

--- a/packages/patrol_cli/lib/src/commands/doctor.dart
+++ b/packages/patrol_cli/lib/src/commands/doctor.dart
@@ -1,5 +1,6 @@
 import 'dart:io' as io;
 
+import 'package:patrol_cli/src/analytics/analytics.dart';
 import 'package:patrol_cli/src/base/constants.dart' as constants;
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/base/process.dart';
@@ -26,6 +27,7 @@ class DoctorCommand extends PatrolCommand {
   Future<int> run() async {
     _printHeader();
     _printVersion();
+    _printFlutterInfo();
     _printAndroidSpecifics();
 
     if (_platform.isMacOS) {
@@ -41,6 +43,26 @@ class DoctorCommand extends PatrolCommand {
 
   void _printVersion() {
     _logger.info('Patrol CLI version: ${constants.version}');
+  }
+
+  void _printFlutterInfo() {
+    final cmd = flutterCommand;
+    final result = io.Process.runSync(
+      flutterCommand.executable,
+      flutterCommand.arguments,
+    );
+
+    final success = result.exitCode == 0;
+
+    if (!success) {
+      _logger.err('Invalid Flutter command: $cmd');
+    } else {
+      _logger.success('Flutter command: $cmd');
+      final flutterVersion = FlutterVersion.fromCLI(cmd);
+      _logger.info(
+        '  Flutter ${flutterVersion.version} • channel ${flutterVersion.channel}',
+      );
+    }
   }
 
   void _printAndroidSpecifics() {

--- a/packages/patrol_cli/lib/src/commands/doctor.dart
+++ b/packages/patrol_cli/lib/src/commands/doctor.dart
@@ -48,8 +48,9 @@ class DoctorCommand extends PatrolCommand {
   void _printFlutterInfo() {
     final cmd = flutterCommand;
     final result = io.Process.runSync(
-      flutterCommand.executable,
-      flutterCommand.arguments,
+      cmd.executable,
+      cmd.arguments,
+      runInShell: true,
     );
 
     final success = result.exitCode == 0;

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -82,7 +82,9 @@ class TestCommand extends PatrolCommand {
       ),
     );
 
-    await _compatibilityChecker.checkVersionsCompatibility();
+    await _compatibilityChecker.checkVersionsCompatibility(
+      flutterCommand: flutterCommand,
+    );
 
     final config = _pubspecReader.read();
     final testFileSuffix = config.testFileSuffix;

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -75,7 +75,12 @@ class TestCommand extends PatrolCommand {
 
   @override
   Future<int> run() async {
-    unawaited(_analytics.sendCommand(name));
+    unawaited(
+      _analytics.sendCommand(
+        FlutterVersion.fromCLI(flutterCommand),
+        name,
+      ),
+    );
 
     await _compatibilityChecker.checkVersionsCompatibility();
 
@@ -113,7 +118,10 @@ class TestCommand extends PatrolCommand {
       _logger.detail('Received macOS flavor: $macosFlavor');
     }
 
-    final devices = await _deviceFinder.find(stringsArg('device'));
+    final devices = await _deviceFinder.find(
+      stringsArg('device'),
+      flutterCommand: flutterCommand,
+    );
     _logger.detail('Received ${devices.length} device(s) to run on');
     for (final device in devices) {
       _logger.detail('Received device: ${device.resolvedName}');
@@ -170,6 +178,7 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
     }
 
     final flutterOpts = FlutterAppOptions(
+      command: flutterCommand,
       target: entrypoint.path,
       flavor: androidFlavor,
       buildMode: buildMode,

--- a/packages/patrol_cli/lib/src/commands/update.dart
+++ b/packages/patrol_cli/lib/src/commands/update.dart
@@ -37,7 +37,12 @@ class UpdateCommand extends PatrolCommand {
 
   @override
   Future<int> run() async {
-    unawaited(_analytics.sendCommand(name));
+    unawaited(
+      _analytics.sendCommand(
+        FlutterVersion.fromCLI(flutterCommand),
+        name,
+      ),
+    );
 
     await _updatePatrolCliPackage();
 

--- a/packages/patrol_cli/lib/src/compatibility_checker.dart
+++ b/packages/patrol_cli/lib/src/compatibility_checker.dart
@@ -7,6 +7,7 @@ import 'package:patrol_cli/src/base/constants.dart' as constants;
 import 'package:patrol_cli/src/base/exceptions.dart';
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/base/process.dart';
+import 'package:patrol_cli/src/runner/flutter_command.dart';
 import 'package:process/process.dart';
 import 'package:version/version.dart';
 
@@ -25,7 +26,9 @@ class CompatibilityChecker {
   final DisposeScope _disposeScope;
   final Logger _logger;
 
-  Future<void> checkVersionsCompatibility() async {
+  Future<void> checkVersionsCompatibility({
+    required FlutterCommand flutterCommand,
+  }) async {
     if (io.Platform.isAndroid) {
       await _checkJavaVersion(
         _disposeScope,
@@ -41,7 +44,8 @@ class CompatibilityChecker {
     await _disposeScope.run((scope) async {
       final process = await _processManager.start(
         [
-          'flutter',
+          flutterCommand.executable,
+          ...flutterCommand.arguments,
           '--suppress-analytics',
           '--no-version-check',
           'pub',

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -4,15 +4,18 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' show basename;
 import 'package:patrol_cli/src/devices.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
+import 'package:patrol_cli/src/runner/flutter_command.dart';
 
 class FlutterAppOptions {
   const FlutterAppOptions({
+    required this.command,
     required this.target,
     required this.flavor,
     required this.buildMode,
     required this.dartDefines,
   });
 
+  final FlutterCommand command;
   final String target;
   final String? flavor;
   final BuildMode buildMode;
@@ -22,7 +25,8 @@ class FlutterAppOptions {
   @nonVirtual
   List<String> toFlutterAttachInvocation() {
     final cmd = [
-      ...['flutter', 'attach'],
+      ...[command.executable, ...command.arguments],
+      'attach',
       '--no-version-check',
       '--suppress-analytics',
       '--debug',
@@ -157,7 +161,8 @@ class IOSAppOptions {
   /// runs before xcodebuild and performs configuration.
   List<String> toFlutterBuildInvocation(BuildMode buildMode) {
     final cmd = [
-      ...['flutter', 'build', 'ios'],
+      ...[flutter.command.executable, ...flutter.command.arguments],
+      ...['build', 'ios'],
       '--no-version-check',
       '--suppress-analytics',
       ...[
@@ -242,7 +247,8 @@ class MacOSAppOptions {
   /// runs before xcodebuild and performs configuration.
   List<String> toFlutterBuildInvocation(BuildMode buildMode) {
     final cmd = [
-      ...['flutter', 'build', 'macos'],
+      ...[flutter.command.executable, ...flutter.command.arguments],
+      ...['build', 'macos'],
       '--no-version-check',
       '--suppress-analytics',
       ...[

--- a/packages/patrol_cli/lib/src/devices.dart
+++ b/packages/patrol_cli/lib/src/devices.dart
@@ -153,9 +153,9 @@ class DeviceFinder {
     process.listenStdOut((line) => output += line).disposedBy(_disposeScope);
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
-      throwToolExit('`flutter devices` exited with code $exitCode');
+      throwToolExit('`$flutterCommand devices` exited with code $exitCode');
     } else if (flutterKilled) {
-      throwToolInterrupted('`flutter devices` was interrupted');
+      throwToolInterrupted('`$flutterCommand devices` was interrupted');
     } else {
       return output;
     }

--- a/packages/patrol_cli/lib/src/devices.dart
+++ b/packages/patrol_cli/lib/src/devices.dart
@@ -5,6 +5,7 @@ import 'package:meta/meta.dart';
 import 'package:patrol_cli/src/base/exceptions.dart';
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/base/process.dart';
+import 'package:patrol_cli/src/runner/flutter_command.dart';
 import 'package:process/process.dart';
 
 class DeviceFinder {
@@ -22,8 +23,10 @@ class DeviceFinder {
   final DisposeScope _disposeScope;
   final Logger _logger;
 
-  Future<List<Device>> getAttachedDevices() async {
-    final output = await _getCommandOutput();
+  Future<List<Device>> getAttachedDevices({
+    required FlutterCommand flutterCommand,
+  }) async {
+    final output = await _getCommandOutput(flutterCommand: flutterCommand);
     final jsonOutput = jsonDecode(output) as List<dynamic>;
 
     final devices = <Device>[];
@@ -50,8 +53,12 @@ class DeviceFinder {
     return devices;
   }
 
-  Future<List<Device>> find(List<String> devices) async {
-    final attachedDevices = await getAttachedDevices();
+  Future<List<Device>> find(
+    List<String> devices, {
+    required FlutterCommand flutterCommand,
+  }) async {
+    final attachedDevices =
+        await getAttachedDevices(flutterCommand: flutterCommand);
 
     return findDevicesToUse(
       attachedDevices: attachedDevices,
@@ -122,11 +129,14 @@ class DeviceFinder {
     return attachedDevices.where(predicate).toList();
   }
 
-  Future<String> _getCommandOutput() async {
+  Future<String> _getCommandOutput({
+    required FlutterCommand flutterCommand,
+  }) async {
     var flutterKilled = false;
     final process = await _processManager.start(
       [
-        'flutter',
+        flutterCommand.executable,
+        ...flutterCommand.arguments,
         '--no-version-check',
         '--suppress-analytics',
         'devices',

--- a/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
+++ b/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
@@ -103,12 +103,13 @@ class IOSTestBackend {
       process.listenStdOut((l) => _logger.detail('\t$l')).disposedBy(scope);
       process.listenStdErr((l) => _logger.err('\t$l')).disposedBy(scope);
       var exitCode = await process.exitCode;
+      final flutterCommand = options.flutter.command;
       if (exitCode != 0) {
-        final cause = '`flutter build ios` exited with code $exitCode';
+        final cause = '`$flutterCommand build ios` exited with code $exitCode';
         task.fail('Failed to build $subject ($cause)');
         throwToolExit(cause);
       } else if (flutterBuildKilled) {
-        const cause = '`flutter build ios` was interrupted';
+        final cause = '`$flutterCommand build ios` was interrupted';
         task.fail('Failed to build $subject ($cause)');
         throwToolInterrupted(cause);
       }

--- a/packages/patrol_cli/lib/src/macos/macos_test_backend.dart
+++ b/packages/patrol_cli/lib/src/macos/macos_test_backend.dart
@@ -91,12 +91,14 @@ class MacOSTestBackend {
       process.listenStdOut((l) => _logger.detail('\t$l')).disposedBy(scope);
       process.listenStdErr((l) => _logger.err('\t$l')).disposedBy(scope);
       var exitCode = await process.exitCode;
+      final flutterCommand = options.flutter.command;
       if (exitCode != 0) {
-        final cause = '`flutter build macos` exited with code $exitCode';
+        final cause =
+            '`$flutterCommand build macos` exited with code $exitCode';
         task.fail('Failed to build $subject ($cause)');
         throwToolExit(cause);
       } else if (flutterBuildKilled) {
-        const cause = '`flutter build macos` was interrupted';
+        final cause = '`$flutterCommand build macos` was interrupted';
         task.fail('Failed to build $subject ($cause)');
         throwToolInterrupted(cause);
       }

--- a/packages/patrol_cli/lib/src/runner/flutter_command.dart
+++ b/packages/patrol_cli/lib/src/runner/flutter_command.dart
@@ -1,0 +1,14 @@
+class FlutterCommand {
+  const FlutterCommand(this.executable, [this.arguments = const []]);
+
+  factory FlutterCommand.parse(String command) {
+    final parts = command.split(RegExp(r'\s'));
+    if (parts.isEmpty) {
+      return FlutterCommand(command);
+    }
+    return FlutterCommand(parts[0], parts.skip(1).toList());
+  }
+
+  final String executable;
+  final List<String> arguments;
+}

--- a/packages/patrol_cli/lib/src/runner/flutter_command.dart
+++ b/packages/patrol_cli/lib/src/runner/flutter_command.dart
@@ -2,7 +2,7 @@ class FlutterCommand {
   const FlutterCommand(this.executable, [this.arguments = const []]);
 
   factory FlutterCommand.parse(String command) {
-    final parts = command.split(RegExp(r'\s'));
+    final parts = command.split(RegExp(r'\s+'));
     if (parts.isEmpty) {
       return FlutterCommand(command);
     }
@@ -11,4 +11,7 @@ class FlutterCommand {
 
   final String executable;
   final List<String> arguments;
+
+  @override
+  String toString() => '$executable ${arguments.join(" ")}';
 }

--- a/packages/patrol_cli/lib/src/runner/patrol_command.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command.dart
@@ -1,6 +1,7 @@
 import 'package:args/command_runner.dart';
 import 'package:patrol_cli/src/base/exceptions.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
+import 'package:patrol_cli/src/runner/flutter_command.dart';
 
 abstract class PatrolCommand extends Command<int> {
   /// Seconds to wait after the individual test case finishes executing.
@@ -177,6 +178,21 @@ abstract class PatrolCommand extends Command<int> {
   /// Gets the parsed command-line option named [name] as `List<String>`.
   List<String> stringsArg(String name) {
     return argResults![name]! as List<String>? ?? <String>[];
+  }
+
+  FlutterCommand get flutterCommand {
+    final arg = globalResults!['flutter-command'] as String?;
+
+    var cmd = arg;
+    if (cmd == null || cmd.isEmpty) {
+      cmd = const String.fromEnvironment('PATROL_FLUTTER_COMMAND');
+    }
+
+    if (cmd.isEmpty) {
+      cmd = 'flutter';
+    }
+
+    return FlutterCommand.parse(cmd);
   }
 
   BuildMode get buildMode {

--- a/packages/patrol_cli/lib/src/runner/patrol_command.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:args/command_runner.dart';
 import 'package:patrol_cli/src/base/exceptions.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
@@ -185,10 +187,10 @@ abstract class PatrolCommand extends Command<int> {
 
     var cmd = arg;
     if (cmd == null || cmd.isEmpty) {
-      cmd = const String.fromEnvironment('PATROL_FLUTTER_COMMAND');
+      cmd = Platform.environment['PATROL_FLUTTER_COMMAND'];
     }
 
-    if (cmd.isEmpty) {
+    if (cmd == null || cmd.isEmpty) {
       cmd = 'flutter';
     }
 

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -220,6 +220,12 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
     );
 
     argParser
+      ..addOption(
+        'flutter-command',
+        help: 'Command to use to run the Flutter CLI. Alternatively set the PATROL_FLUTTER_COMMAND environment variable.',
+        defaultsTo: 'flutter',
+        valueHelp: 'fvm flutter',
+      )
       ..addFlag(
         'verbose',
         abbr: 'v',

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -224,7 +224,6 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
         'flutter-command',
         help:
             'Command to use to run the Flutter CLI. Alternatively set the PATROL_FLUTTER_COMMAND environment variable.',
-        defaultsTo: 'flutter',
         valueHelp: 'fvm flutter',
       )
       ..addFlag(

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -222,7 +222,8 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
     argParser
       ..addOption(
         'flutter-command',
-        help: 'Command to use to run the Flutter CLI. Alternatively set the PATROL_FLUTTER_COMMAND environment variable.',
+        help:
+            'Command to use to run the Flutter CLI. Alternatively set the PATROL_FLUTTER_COMMAND environment variable.',
         defaultsTo: 'flutter',
         valueHelp: 'fvm flutter',
       )

--- a/packages/patrol_cli/test/analytics/analytics_test.dart
+++ b/packages/patrol_cli/test/analytics/analytics_test.dart
@@ -35,7 +35,6 @@ void main() {
         fs: fs,
         platform: fakePlatform('/Users/john'),
         httpClient: httpClient,
-        getFlutterVersion: FlutterVersion.test,
         isCI: false,
       );
     });
@@ -45,7 +44,8 @@ void main() {
       _createFakeFileSystem(fs, analyticsEnabled: true);
 
       // when
-      final sent = await analytics.sendCommand('test command');
+      final sent =
+          await analytics.sendCommand(FlutterVersion.test(), 'test command');
 
       // then
       expect(sent, true);
@@ -56,7 +56,8 @@ void main() {
       _createFakeFileSystem(fs, analyticsEnabled: false);
 
       // when
-      final sent = await analytics.sendCommand('test command');
+      final sent =
+          await analytics.sendCommand(FlutterVersion.test(), 'test command');
 
       // then
       expect(sent, false);

--- a/packages/patrol_cli/test/crossplatform/app_options_test.dart
+++ b/packages/patrol_cli/test/crossplatform/app_options_test.dart
@@ -1,16 +1,20 @@
 import 'package:patrol_cli/src/crossplatform/app_options.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
+import 'package:patrol_cli/src/runner/flutter_command.dart';
 import 'package:test/test.dart';
 
 import '../src/fixtures.dart';
 
 void main() {
+  const flutterCommand = FlutterCommand('flutter');
+
   group('AndroidAppOptions', () {
     late AndroidAppOptions options;
 
     group('correctly encodes default invocation', () {
       test('on Windows', () {
         const flutterOptions = FlutterAppOptions(
+          command: flutterCommand,
           target: r'C:\Users\john\app\integration_test\app_test.dart',
           buildMode: BuildMode.debug,
           flavor: null,
@@ -38,6 +42,7 @@ void main() {
 
       test('on macOS', () {
         const flutterOpts = FlutterAppOptions(
+          command: flutterCommand,
           target: '/Users/john/app/integration_test/app_test.dart',
           buildMode: BuildMode.release,
           flavor: null,
@@ -73,6 +78,7 @@ void main() {
 
       test('on Windows', () {
         const flutterOpts = FlutterAppOptions(
+          command: flutterCommand,
           target: r'C:\Users\john\app\integration_test\app_test.dart',
           buildMode: BuildMode.release,
           flavor: 'dev',
@@ -101,6 +107,7 @@ void main() {
 
       test('on macOS', () {
         const flutterOpts = FlutterAppOptions(
+          command: flutterCommand,
           target: '/Users/john/app/integration_test/app_test.dart',
           buildMode: BuildMode.debug,
           flavor: 'dev',
@@ -134,6 +141,7 @@ void main() {
 
     group('correctly encodes default xcodebuild invocation for simulator', () {
       const flutterOpts = FlutterAppOptions(
+        command: flutterCommand,
         target: 'integration_test/app_test.dart',
         buildMode: BuildMode.debug,
         flavor: null,
@@ -213,6 +221,7 @@ void main() {
       'correctly encodes customized xcodebuild invocation for real device',
       () {
         const flutterOpts = FlutterAppOptions(
+          command: flutterCommand,
           target: 'integration_test/app_test.dart',
           buildMode: BuildMode.release,
           flavor: 'prod',

--- a/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
@@ -3,12 +3,15 @@ import 'dart:async';
 import 'package:dispose_scope/dispose_scope.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:patrol_cli/src/crossplatform/flutter_tool.dart';
+import 'package:patrol_cli/src/runner/flutter_command.dart';
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import '../src/mocks.dart';
 
 void main() {
+  const flutterCommand = FlutterCommand('flutter');
+
   late FlutterTool flutterTool;
   late MockProcessManager processManager;
   late Platform platform;
@@ -43,6 +46,7 @@ void main() {
               .thenAnswer((_) async => process);
 
           flutterTool.attach(
+            flutterCommand: flutterCommand,
             deviceId: 'testDeviceId',
             target: 'target',
             appId: 'appId',

--- a/packages/patrol_cli/test/src/mocks.dart
+++ b/packages/patrol_cli/test/src/mocks.dart
@@ -39,6 +39,7 @@ class MockAnalytics extends Mock implements Analytics {
 
   @override
   Future<bool> sendCommand(
+    FlutterVersion flutterVersion,
     String name, {
     Map<String, Object?> eventData = const {},
   }) async {


### PR DESCRIPTION
Aims to address #1482 

This PR builds on top of the [amazing work by Jjagg](https://github.com/leancodepl/patrol/issues/1482#issuecomment-1956208862). It introduces a new CLI flag `--flutter-command` which may be used to provide a custom command used when running the Flutter CLI to support version managers like puro and fvm. It also supports a matching env-Variable `PATROL_FLUTTER_COMMAND`.

I believe all occurences where `flutter` was previously used directly in the `patrol_cli` package are now replaced with usage of the `FlutterCommand` instance. If I missed any, let me know!