### PR TITLE
feat: Support customization of doubleTap delay

### DIFF
--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -220,7 +220,7 @@ class Automator private constructor() {
         delay()
     }
 
-    fun doubleTap(uiSelector: UiSelector, bySelector: BySelector, index: Int, timeout: Long? = null) {
+    fun doubleTap(uiSelector: UiSelector, bySelector: BySelector, index: Int, timeout: Long? = null, delayBetweenTaps: Long? = null) {
         Logger.d("doubleTap(): $uiSelector, $bySelector")
 
         val uiObject = uiDevice.findObject(uiSelector)
@@ -229,13 +229,24 @@ class Automator private constructor() {
             throw UiObjectNotFoundException("$uiSelector")
         }
 
-        Logger.d("Double clicking on UIObject with text: ${uiObject.text}")
-        uiObject.click()
+        Logger.d("Performing double tap on UIObject with text: ${uiObject.text}")
+
+        // Get the bounds of the UI element
+        val rect = uiObject.bounds
+        // Calculate the center point
+        val centerX = rect.centerX()
+        val centerY = rect.centerY()
+
+        // Perform double click at the center
         Logger.d("After first click")
-        delay(ms = 300)
-        uiObject.click()
+
+        uiDevice.click(centerX, centerY)
+
+        // Customizable Delay between taps
+        delay(ms = delayBetweenTaps ?: 300)
+
         Logger.d("After second click")
-        delay()
+        uiDevice.click(centerX, centerY)
     }
 
     fun tapAt(x: Float, y: Float) {

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
@@ -172,14 +172,16 @@ class AutomatorServer(private val automation: Automator) : NativeAutomatorServer
                 uiSelector = request.selector.toUiSelector(),
                 bySelector = request.selector.toBySelector(),
                 index = request.selector.instance?.toInt() ?: 0,
-                timeout = request.timeoutMillis
+                timeout = request.timeoutMillis,
+                delayBetweenTaps = request.delayBetweenTapsMillis
             )
         } else if (request.androidSelector != null) {
             automation.doubleTap(
                 uiSelector = request.androidSelector.toUiSelector(),
                 bySelector = request.androidSelector.toBySelector(),
                 index = request.androidSelector.instance?.toInt() ?: 0,
-                timeout = request.timeoutMillis
+                timeout = request.timeoutMillis,
+                delayBetweenTaps = request.delayBetweenTapsMillis
             )
         } else {
             throw PatrolException("doubleTap(): neither selector nor androidSelector are set")

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
@@ -513,7 +513,6 @@ class Contracts {
     fun hasTimeoutMillis(): Boolean {
       return timeoutMillis != null
     }
-
     fun hasDelayBetweenTapsMillis(): Boolean {
       return delayBetweenTapsMillis != null
     }

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
@@ -498,7 +498,8 @@ class Contracts {
     val androidSelector: AndroidSelector? = null,
     val iosSelector: IOSSelector? = null,
     val appId: String,
-    val timeoutMillis: Long? = null
+    val timeoutMillis: Long? = null,
+    val delayBetweenTapsMillis: Long? = null
   ){
     fun hasSelector(): Boolean {
       return selector != null
@@ -511,6 +512,10 @@ class Contracts {
     }
     fun hasTimeoutMillis(): Boolean {
       return timeoutMillis != null
+    }
+
+    fun hasDelayBetweenTapsMillis(): Boolean {
+      return delayBetweenTapsMillis != null
     }
   }
 

--- a/packages/patrol/darwin/Classes/AutomatorServer/Contracts.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Contracts.swift
@@ -294,6 +294,7 @@ public struct TapRequest: Codable {
   public var iosSelector: IOSSelector?
   public var appId: String
   public var timeoutMillis: Int?
+  public var delayBetweenTapsMillis: Int?
 }
 
 public struct TapAtRequest: Codable {

--- a/packages/patrol/lib/src/native/contracts/contracts.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.dart
@@ -429,6 +429,7 @@ class AndroidSelector with EquatableMixin {
 @JsonSerializable()
 class IOSSelector with EquatableMixin {
   IOSSelector({
+    this.value,
     this.instance,
     this.elementType,
     this.identifier,
@@ -449,6 +450,7 @@ class IOSSelector with EquatableMixin {
   factory IOSSelector.fromJson(Map<String, dynamic> json) =>
       _$IOSSelectorFromJson(json);
 
+  final String? value;
   final int? instance;
   final IOSElementType? elementType;
   final String? identifier;
@@ -469,6 +471,7 @@ class IOSSelector with EquatableMixin {
 
   @override
   List<Object?> get props => [
+        value,
         instance,
         elementType,
         identifier,

--- a/packages/patrol/lib/src/native/contracts/contracts.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.dart
@@ -859,6 +859,7 @@ class TapRequest with EquatableMixin {
     this.iosSelector,
     required this.appId,
     this.timeoutMillis,
+    this.delayBetweenTapsMillis,
   });
 
   factory TapRequest.fromJson(Map<String, dynamic> json) =>
@@ -869,6 +870,7 @@ class TapRequest with EquatableMixin {
   final IOSSelector? iosSelector;
   final String appId;
   final int? timeoutMillis;
+  final int? delayBetweenTapsMillis;
 
   Map<String, dynamic> toJson() => _$TapRequestToJson(this);
 
@@ -879,6 +881,7 @@ class TapRequest with EquatableMixin {
         iosSelector,
         appId,
         timeoutMillis,
+        delayBetweenTapsMillis,
       ];
 }
 

--- a/packages/patrol/lib/src/native/contracts/contracts.g.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.g.dart
@@ -70,7 +70,7 @@ const _$RunDartTestResponseResultEnumMap = {
 
 ConfigureRequest _$ConfigureRequestFromJson(Map<String, dynamic> json) =>
     ConfigureRequest(
-      findTimeoutMillis: json['findTimeoutMillis'] as int,
+      findTimeoutMillis: (json['findTimeoutMillis'] as num).toInt(),
     );
 
 Map<String, dynamic> _$ConfigureRequestToJson(ConfigureRequest instance) =>
@@ -117,7 +117,7 @@ AndroidSelector _$AndroidSelectorFromJson(Map<String, dynamic> json) =>
       textStartsWith: json['textStartsWith'] as String?,
       textContains: json['textContains'] as String?,
       resourceName: json['resourceName'] as String?,
-      instance: json['instance'] as int?,
+      instance: (json['instance'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$AndroidSelectorToJson(AndroidSelector instance) =>
@@ -144,7 +144,8 @@ Map<String, dynamic> _$AndroidSelectorToJson(AndroidSelector instance) =>
     };
 
 IOSSelector _$IOSSelectorFromJson(Map<String, dynamic> json) => IOSSelector(
-      instance: json['instance'] as int?,
+      value: json['value'] as String?,
+      instance: (json['instance'] as num?)?.toInt(),
       elementType:
           $enumDecodeNullable(_$IOSElementTypeEnumMap, json['elementType']),
       identifier: json['identifier'] as String?,
@@ -164,6 +165,7 @@ IOSSelector _$IOSSelectorFromJson(Map<String, dynamic> json) => IOSSelector(
 
 Map<String, dynamic> _$IOSSelectorToJson(IOSSelector instance) =>
     <String, dynamic>{
+      'value': instance.value,
       'instance': instance.instance,
       'elementType': _$IOSElementTypeEnumMap[instance.elementType],
       'identifier': instance.identifier,
@@ -277,7 +279,7 @@ Selector _$SelectorFromJson(Map<String, dynamic> json) => Selector(
           json['contentDescriptionStartsWith'] as String?,
       contentDescriptionContains: json['contentDescriptionContains'] as String?,
       resourceId: json['resourceId'] as String?,
-      instance: json['instance'] as int?,
+      instance: (json['instance'] as num?)?.toInt(),
       enabled: json['enabled'] as bool?,
       focused: json['focused'] as bool?,
       pkg: json['pkg'] as String?,
@@ -368,7 +370,7 @@ AndroidNativeView _$AndroidNativeViewFromJson(Map<String, dynamic> json) =>
       className: json['className'] as String?,
       contentDescription: json['contentDescription'] as String?,
       applicationPackage: json['applicationPackage'] as String?,
-      childCount: json['childCount'] as int,
+      childCount: (json['childCount'] as num).toInt(),
       isCheckable: json['isCheckable'] as bool,
       isChecked: json['isChecked'] as bool,
       isClickable: json['isClickable'] as bool,
@@ -471,7 +473,7 @@ NativeView _$NativeViewFromJson(Map<String, dynamic> json) => NativeView(
       contentDescription: json['contentDescription'] as String?,
       focused: json['focused'] as bool,
       enabled: json['enabled'] as bool,
-      childCount: json['childCount'] as int?,
+      childCount: (json['childCount'] as num?)?.toInt(),
       resourceName: json['resourceName'] as String?,
       applicationPackage: json['applicationPackage'] as String?,
       children: (json['children'] as List<dynamic>)
@@ -526,8 +528,8 @@ TapRequest _$TapRequestFromJson(Map<String, dynamic> json) => TapRequest(
           ? null
           : IOSSelector.fromJson(json['iosSelector'] as Map<String, dynamic>),
       appId: json['appId'] as String,
-      timeoutMillis: json['timeoutMillis'] as int?,
-      delayBetweenTapsMillis: json['delayBetweenTapsMillis'] as int?,
+      timeoutMillis: (json['timeoutMillis'] as num?)?.toInt(),
+      delayBetweenTapsMillis: (json['delayBetweenTapsMillis'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$TapRequestToJson(TapRequest instance) =>
@@ -557,7 +559,7 @@ EnterTextRequest _$EnterTextRequestFromJson(Map<String, dynamic> json) =>
     EnterTextRequest(
       data: json['data'] as String,
       appId: json['appId'] as String,
-      index: json['index'] as int?,
+      index: (json['index'] as num?)?.toInt(),
       selector: json['selector'] == null
           ? null
           : Selector.fromJson(json['selector'] as Map<String, dynamic>),
@@ -570,7 +572,7 @@ EnterTextRequest _$EnterTextRequestFromJson(Map<String, dynamic> json) =>
           : IOSSelector.fromJson(json['iosSelector'] as Map<String, dynamic>),
       keyboardBehavior:
           $enumDecode(_$KeyboardBehaviorEnumMap, json['keyboardBehavior']),
-      timeoutMillis: json['timeoutMillis'] as int?,
+      timeoutMillis: (json['timeoutMillis'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$EnterTextRequestToJson(EnterTextRequest instance) =>
@@ -596,7 +598,7 @@ SwipeRequest _$SwipeRequestFromJson(Map<String, dynamic> json) => SwipeRequest(
       startY: (json['startY'] as num).toDouble(),
       endX: (json['endX'] as num).toDouble(),
       endY: (json['endY'] as num).toDouble(),
-      steps: json['steps'] as int,
+      steps: (json['steps'] as num).toInt(),
     );
 
 Map<String, dynamic> _$SwipeRequestToJson(SwipeRequest instance) =>
@@ -623,7 +625,7 @@ WaitUntilVisibleRequest _$WaitUntilVisibleRequestFromJson(
           ? null
           : IOSSelector.fromJson(json['iosSelector'] as Map<String, dynamic>),
       appId: json['appId'] as String,
-      timeoutMillis: json['timeoutMillis'] as int?,
+      timeoutMillis: (json['timeoutMillis'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$WaitUntilVisibleRequestToJson(
@@ -686,7 +688,7 @@ Map<String, dynamic> _$GetNotificationsRequestToJson(
 TapOnNotificationRequest _$TapOnNotificationRequestFromJson(
         Map<String, dynamic> json) =>
     TapOnNotificationRequest(
-      index: json['index'] as int?,
+      index: (json['index'] as num?)?.toInt(),
       selector: json['selector'] == null
           ? null
           : Selector.fromJson(json['selector'] as Map<String, dynamic>),
@@ -697,7 +699,7 @@ TapOnNotificationRequest _$TapOnNotificationRequestFromJson(
       iosSelector: json['iosSelector'] == null
           ? null
           : IOSSelector.fromJson(json['iosSelector'] as Map<String, dynamic>),
-      timeoutMillis: json['timeoutMillis'] as int?,
+      timeoutMillis: (json['timeoutMillis'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$TapOnNotificationRequestToJson(
@@ -725,7 +727,7 @@ Map<String, dynamic> _$PermissionDialogVisibleResponseToJson(
 PermissionDialogVisibleRequest _$PermissionDialogVisibleRequestFromJson(
         Map<String, dynamic> json) =>
     PermissionDialogVisibleRequest(
-      timeoutMillis: json['timeoutMillis'] as int,
+      timeoutMillis: (json['timeoutMillis'] as num).toInt(),
     );
 
 Map<String, dynamic> _$PermissionDialogVisibleRequestToJson(

--- a/packages/patrol/lib/src/native/contracts/contracts.g.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.g.dart
@@ -527,6 +527,7 @@ TapRequest _$TapRequestFromJson(Map<String, dynamic> json) => TapRequest(
           : IOSSelector.fromJson(json['iosSelector'] as Map<String, dynamic>),
       appId: json['appId'] as String,
       timeoutMillis: json['timeoutMillis'] as int?,
+      delayBetweenTapsMillis: json['delayBetweenTapsMillis'] as int?,
     );
 
 Map<String, dynamic> _$TapRequestToJson(TapRequest instance) =>
@@ -536,6 +537,7 @@ Map<String, dynamic> _$TapRequestToJson(TapRequest instance) =>
       'iosSelector': instance.iosSelector,
       'appId': instance.appId,
       'timeoutMillis': instance.timeoutMillis,
+      'delayBetweenTapsMillis': instance.delayBetweenTapsMillis,
     };
 
 TapAtRequest _$TapAtRequestFromJson(Map<String, dynamic> json) => TapAtRequest(

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -544,6 +544,7 @@ class NativeAutomator {
     Selector selector, {
     String? appId,
     Duration? timeout,
+    Duration? delayBetweenTaps,
   }) async {
     await _wrapRequest(
       'doubleTap',
@@ -552,6 +553,7 @@ class NativeAutomator {
           selector: selector,
           appId: appId ?? resolvedAppId,
           timeoutMillis: timeout?.inMilliseconds,
+          delayBetweenTapsMillis: delayBetweenTaps?.inMilliseconds,
         ),
       ),
     );

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -540,6 +540,15 @@ class NativeAutomator {
   /// [timeout] is not specified, it utilizes the
   /// [NativeAutomatorConfig.findTimeout] duration from the configuration.
   /// If the native view is not found, an exception is thrown.
+  ///
+  /// The [delayBetweenTapsMillis] parameter allows you to specify the duration
+  /// between consecutive taps in milliseconds. This can be useful in scenarios
+  /// where the target view requires a certain delay between taps to register
+  /// the action correctly, such as in cases of UI responsiveness or animations.
+  /// The default delay between taps is 300 milliseconds.
+  ///
+  /// Note: The [delayBetweenTapsMillis] parameter is currently respected only
+  /// for Android.
   Future<void> doubleTap(
     Selector selector, {
     String? appId,

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -541,13 +541,13 @@ class NativeAutomator {
   /// [NativeAutomatorConfig.findTimeout] duration from the configuration.
   /// If the native view is not found, an exception is thrown.
   ///
-  /// The [delayBetweenTapsMillis] parameter allows you to specify the duration
+  /// The [delayBetweenTaps] parameter allows you to specify the duration
   /// between consecutive taps in milliseconds. This can be useful in scenarios
   /// where the target view requires a certain delay between taps to register
   /// the action correctly, such as in cases of UI responsiveness or animations.
   /// The default delay between taps is 300 milliseconds.
   ///
-  /// Note: The [delayBetweenTapsMillis] parameter is currently respected only
+  /// Note: The [delayBetweenTaps] parameter is currently respected only
   /// for Android.
   Future<void> doubleTap(
     Selector selector, {

--- a/packages/patrol/lib/src/native/native_automator2.dart
+++ b/packages/patrol/lib/src/native/native_automator2.dart
@@ -425,6 +425,15 @@ class NativeAutomator2 {
   /// [timeout] is not specified, it utilizes the
   /// [NativeAutomatorConfig.findTimeout] duration from the configuration.
   /// If the native view is not found, an exception is thrown.
+  ///
+  /// The [delayBetweenTapsMillis] parameter allows you to specify the duration
+  /// between consecutive taps in milliseconds. This can be useful in scenarios
+  /// where the target view requires a certain delay between taps to register
+  /// the action correctly, such as in cases of UI responsiveness or animations.
+  /// The default delay between taps is 300 milliseconds.
+  ///
+  /// Note: The [delayBetweenTapsMillis] parameter is currently respected only
+  /// for Android.
   Future<void> doubleTap(
     NativeSelector selector, {
     String? appId,

--- a/packages/patrol/lib/src/native/native_automator2.dart
+++ b/packages/patrol/lib/src/native/native_automator2.dart
@@ -426,13 +426,13 @@ class NativeAutomator2 {
   /// [NativeAutomatorConfig.findTimeout] duration from the configuration.
   /// If the native view is not found, an exception is thrown.
   ///
-  /// The [delayBetweenTapsMillis] parameter allows you to specify the duration
+  /// The [delayBetweenTaps] parameter allows you to specify the duration
   /// between consecutive taps in milliseconds. This can be useful in scenarios
   /// where the target view requires a certain delay between taps to register
   /// the action correctly, such as in cases of UI responsiveness or animations.
   /// The default delay between taps is 300 milliseconds.
   ///
-  /// Note: The [delayBetweenTapsMillis] parameter is currently respected only
+  /// Note: The [delayBetweenTaps] parameter is currently respected only
   /// for Android.
   Future<void> doubleTap(
     NativeSelector selector, {

--- a/packages/patrol/lib/src/native/native_automator2.dart
+++ b/packages/patrol/lib/src/native/native_automator2.dart
@@ -429,6 +429,7 @@ class NativeAutomator2 {
     NativeSelector selector, {
     String? appId,
     Duration? timeout,
+    Duration? delayBetweenTaps,
   }) async {
     await _wrapRequest(
       'doubleTap',
@@ -437,6 +438,7 @@ class NativeAutomator2 {
           androidSelector: selector.android,
           appId: appId ?? resolvedAppId,
           timeoutMillis: timeout?.inMilliseconds,
+          delayBetweenTapsMillis: delayBetweenTaps?.inMilliseconds,
           iosSelector: selector.ios,
         ),
       ),

--- a/packages/patrol_devtools_extension/lib/api/contracts.dart
+++ b/packages/patrol_devtools_extension/lib/api/contracts.dart
@@ -429,6 +429,7 @@ class AndroidSelector with EquatableMixin {
 @JsonSerializable()
 class IOSSelector with EquatableMixin {
   IOSSelector({
+    this.value,
     this.instance,
     this.elementType,
     this.identifier,
@@ -449,6 +450,7 @@ class IOSSelector with EquatableMixin {
   factory IOSSelector.fromJson(Map<String, dynamic> json) =>
       _$IOSSelectorFromJson(json);
 
+  final String? value;
   final int? instance;
   final IOSElementType? elementType;
   final String? identifier;
@@ -469,6 +471,7 @@ class IOSSelector with EquatableMixin {
 
   @override
   List<Object?> get props => [
+        value,
         instance,
         elementType,
         identifier,
@@ -859,6 +862,7 @@ class TapRequest with EquatableMixin {
     this.iosSelector,
     required this.appId,
     this.timeoutMillis,
+    this.delayBetweenTapsMillis,
   });
 
   factory TapRequest.fromJson(Map<String, dynamic> json) =>
@@ -869,6 +873,7 @@ class TapRequest with EquatableMixin {
   final IOSSelector? iosSelector;
   final String appId;
   final int? timeoutMillis;
+  final int? delayBetweenTapsMillis;
 
   Map<String, dynamic> toJson() => _$TapRequestToJson(this);
 
@@ -879,6 +884,7 @@ class TapRequest with EquatableMixin {
         iosSelector,
         appId,
         timeoutMillis,
+        delayBetweenTapsMillis,
       ];
 }
 

--- a/packages/patrol_devtools_extension/lib/api/contracts.g.dart
+++ b/packages/patrol_devtools_extension/lib/api/contracts.g.dart
@@ -70,7 +70,7 @@ const _$RunDartTestResponseResultEnumMap = {
 
 ConfigureRequest _$ConfigureRequestFromJson(Map<String, dynamic> json) =>
     ConfigureRequest(
-      findTimeoutMillis: json['findTimeoutMillis'] as int,
+      findTimeoutMillis: (json['findTimeoutMillis'] as num).toInt(),
     );
 
 Map<String, dynamic> _$ConfigureRequestToJson(ConfigureRequest instance) =>
@@ -117,7 +117,7 @@ AndroidSelector _$AndroidSelectorFromJson(Map<String, dynamic> json) =>
       textStartsWith: json['textStartsWith'] as String?,
       textContains: json['textContains'] as String?,
       resourceName: json['resourceName'] as String?,
-      instance: json['instance'] as int?,
+      instance: (json['instance'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$AndroidSelectorToJson(AndroidSelector instance) =>
@@ -144,7 +144,8 @@ Map<String, dynamic> _$AndroidSelectorToJson(AndroidSelector instance) =>
     };
 
 IOSSelector _$IOSSelectorFromJson(Map<String, dynamic> json) => IOSSelector(
-      instance: json['instance'] as int?,
+      value: json['value'] as String?,
+      instance: (json['instance'] as num?)?.toInt(),
       elementType:
           $enumDecodeNullable(_$IOSElementTypeEnumMap, json['elementType']),
       identifier: json['identifier'] as String?,
@@ -164,6 +165,7 @@ IOSSelector _$IOSSelectorFromJson(Map<String, dynamic> json) => IOSSelector(
 
 Map<String, dynamic> _$IOSSelectorToJson(IOSSelector instance) =>
     <String, dynamic>{
+      'value': instance.value,
       'instance': instance.instance,
       'elementType': _$IOSElementTypeEnumMap[instance.elementType],
       'identifier': instance.identifier,
@@ -277,7 +279,7 @@ Selector _$SelectorFromJson(Map<String, dynamic> json) => Selector(
           json['contentDescriptionStartsWith'] as String?,
       contentDescriptionContains: json['contentDescriptionContains'] as String?,
       resourceId: json['resourceId'] as String?,
-      instance: json['instance'] as int?,
+      instance: (json['instance'] as num?)?.toInt(),
       enabled: json['enabled'] as bool?,
       focused: json['focused'] as bool?,
       pkg: json['pkg'] as String?,
@@ -368,7 +370,7 @@ AndroidNativeView _$AndroidNativeViewFromJson(Map<String, dynamic> json) =>
       className: json['className'] as String?,
       contentDescription: json['contentDescription'] as String?,
       applicationPackage: json['applicationPackage'] as String?,
-      childCount: json['childCount'] as int,
+      childCount: (json['childCount'] as num).toInt(),
       isCheckable: json['isCheckable'] as bool,
       isChecked: json['isChecked'] as bool,
       isClickable: json['isClickable'] as bool,
@@ -471,7 +473,7 @@ NativeView _$NativeViewFromJson(Map<String, dynamic> json) => NativeView(
       contentDescription: json['contentDescription'] as String?,
       focused: json['focused'] as bool,
       enabled: json['enabled'] as bool,
-      childCount: json['childCount'] as int?,
+      childCount: (json['childCount'] as num?)?.toInt(),
       resourceName: json['resourceName'] as String?,
       applicationPackage: json['applicationPackage'] as String?,
       children: (json['children'] as List<dynamic>)
@@ -526,7 +528,8 @@ TapRequest _$TapRequestFromJson(Map<String, dynamic> json) => TapRequest(
           ? null
           : IOSSelector.fromJson(json['iosSelector'] as Map<String, dynamic>),
       appId: json['appId'] as String,
-      timeoutMillis: json['timeoutMillis'] as int?,
+      timeoutMillis: (json['timeoutMillis'] as num?)?.toInt(),
+      delayBetweenTapsMillis: (json['delayBetweenTapsMillis'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$TapRequestToJson(TapRequest instance) =>
@@ -536,6 +539,7 @@ Map<String, dynamic> _$TapRequestToJson(TapRequest instance) =>
       'iosSelector': instance.iosSelector,
       'appId': instance.appId,
       'timeoutMillis': instance.timeoutMillis,
+      'delayBetweenTapsMillis': instance.delayBetweenTapsMillis,
     };
 
 TapAtRequest _$TapAtRequestFromJson(Map<String, dynamic> json) => TapAtRequest(
@@ -555,7 +559,7 @@ EnterTextRequest _$EnterTextRequestFromJson(Map<String, dynamic> json) =>
     EnterTextRequest(
       data: json['data'] as String,
       appId: json['appId'] as String,
-      index: json['index'] as int?,
+      index: (json['index'] as num?)?.toInt(),
       selector: json['selector'] == null
           ? null
           : Selector.fromJson(json['selector'] as Map<String, dynamic>),
@@ -568,7 +572,7 @@ EnterTextRequest _$EnterTextRequestFromJson(Map<String, dynamic> json) =>
           : IOSSelector.fromJson(json['iosSelector'] as Map<String, dynamic>),
       keyboardBehavior:
           $enumDecode(_$KeyboardBehaviorEnumMap, json['keyboardBehavior']),
-      timeoutMillis: json['timeoutMillis'] as int?,
+      timeoutMillis: (json['timeoutMillis'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$EnterTextRequestToJson(EnterTextRequest instance) =>
@@ -594,7 +598,7 @@ SwipeRequest _$SwipeRequestFromJson(Map<String, dynamic> json) => SwipeRequest(
       startY: (json['startY'] as num).toDouble(),
       endX: (json['endX'] as num).toDouble(),
       endY: (json['endY'] as num).toDouble(),
-      steps: json['steps'] as int,
+      steps: (json['steps'] as num).toInt(),
     );
 
 Map<String, dynamic> _$SwipeRequestToJson(SwipeRequest instance) =>
@@ -621,7 +625,7 @@ WaitUntilVisibleRequest _$WaitUntilVisibleRequestFromJson(
           ? null
           : IOSSelector.fromJson(json['iosSelector'] as Map<String, dynamic>),
       appId: json['appId'] as String,
-      timeoutMillis: json['timeoutMillis'] as int?,
+      timeoutMillis: (json['timeoutMillis'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$WaitUntilVisibleRequestToJson(
@@ -684,7 +688,7 @@ Map<String, dynamic> _$GetNotificationsRequestToJson(
 TapOnNotificationRequest _$TapOnNotificationRequestFromJson(
         Map<String, dynamic> json) =>
     TapOnNotificationRequest(
-      index: json['index'] as int?,
+      index: (json['index'] as num?)?.toInt(),
       selector: json['selector'] == null
           ? null
           : Selector.fromJson(json['selector'] as Map<String, dynamic>),
@@ -695,7 +699,7 @@ TapOnNotificationRequest _$TapOnNotificationRequestFromJson(
       iosSelector: json['iosSelector'] == null
           ? null
           : IOSSelector.fromJson(json['iosSelector'] as Map<String, dynamic>),
-      timeoutMillis: json['timeoutMillis'] as int?,
+      timeoutMillis: (json['timeoutMillis'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$TapOnNotificationRequestToJson(
@@ -723,7 +727,7 @@ Map<String, dynamic> _$PermissionDialogVisibleResponseToJson(
 PermissionDialogVisibleRequest _$PermissionDialogVisibleRequestFromJson(
         Map<String, dynamic> json) =>
     PermissionDialogVisibleRequest(
-      timeoutMillis: json['timeoutMillis'] as int,
+      timeoutMillis: (json['timeoutMillis'] as num).toInt(),
     );
 
 Map<String, dynamic> _$PermissionDialogVisibleRequestToJson(

--- a/schema.dart
+++ b/schema.dart
@@ -196,6 +196,7 @@ class TapRequest {
   IOSSelector? iosSelector;
   late String appId;
   int? timeoutMillis;
+  int? delayBetweenTapsMillis;
 }
 
 class TapAtRequest {


### PR DESCRIPTION
## Resolves: #2164 

## Issue:
Wanted to have a test where my use-case was replication of user behaviour who quickly click on back button twice. Thought of using doubleTap() but it doesn't serve the purpose due to the 300 ms delay given by default according to the below code snippet.

## Changes Made:
Implemented a way that the delay between the doubleTap can be customized by the user itself. Also used a different logic for doubleTap instead of directly using `uiObject.click()` twice as it was having a bit of delay in functioning by default.

# Tests Covered (Patrol Tests)
<table>
<tr>
<th>Test</th>
<th>Outcome</th>
<th>

</th>
</tr>
<tr>
<td>Used file picker and clicked on images button using patrol's doubleTap with no delayBetweenTaps set</td>
<td>Works fine (Once the image button is tapped and it turns to a selected button, again the second tap happens after 300ms [default delay value] and the image button gets unselected)</td>
<td>

:white_check_mark: 

https://github.com/leancodepl/patrol/assets/73401649/b9f9f812-bab1-43ad-b2ea-141b1aee2005


</th>
</tr>
<tr>
<td>Used file picker and clicked on images button using patrol's doubleTap with delayBetweenTaps set to 0 ms</td>
<td>Works fine (Once the image button is tapped and it turns to a selected button, again the second tap happens quicklt without any delay as delayBetweenTaps is set to 0 ms and the image button gets unselected)</td>
<td>

:white_check_mark: 

https://github.com/leancodepl/patrol/assets/73401649/be7f8381-bf2e-4c98-af10-e75b29c4ce08


</th>
</tr>
<tr>
<td>Used file picker and clicked on images button using patrol's doubleTap with delayBetweenTaps set to 2000 ms</td>
<td>Works fine (Once the image button is tapped and it turns to a selected button, again the second tap happens after 2000ms and the image button gets unselected)</td>
<td>

:white_check_mark: 

https://github.com/leancodepl/patrol/assets/73401649/a6662518-b803-4ac0-bf4b-68078d7b552f

</tr>
<tr>
<td>Used file picker and clicked on images button using patrol's doubleTap with delayBetweenTaps set to 2000 ms and nativeAutomator2 used</td>
<td>Works fine (Once the image button is tapped and it turns to a selected button, again the second tap happens after 2000ms and the image button gets unselected)</td>
<td>

:white_check_mark: 

https://github.com/leancodepl/patrol/assets/73401649/86c356c3-7aa3-480c-abb0-e66c9ad0a041

</table>

# Other Informations:
- The reason why uiObject.click() is directly used twice is that it was by default creating some delay in between the two taps and the point of having two very quick taps when delayBetweenTaps is set to 0 ms.
- If the tests mentioned above to verify the changes are also required to be pushed then let me know that as well and I will be happy to do that.