### PR TITLE
[docs]: fix front matter formatting

### DIFF
--- a/docs/debugging-patrol-tests.mdx
+++ b/docs/debugging-patrol-tests.mdx
@@ -1,3 +1,4 @@
+---
 title: Debugging Patrol tests
 ---
 


### PR DESCRIPTION
This PR fixes a funny-looking title on the [debugging patrol tests page](https://patrol.leancode.co/debugging-patrol-tests)