### PR TITLE
fix: misleading error message

### DIFF
--- a/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
@@ -697,7 +697,7 @@
             timeout: self.timeout
           )
         else {
-          throw PatrolError.viewNotExists("button to allow permission only once")
+          throw PatrolError.viewNotExists("button to allow permission while using app")
         }
 
         button.tap()


### PR DESCRIPTION
This PR fixes a misleading error message in the `allowPermissionWhileUsingApp` function for iOS that makes it look like it was trying to find the "Allow Once" button.