### PR TITLE
Fix changing ports for macOS testing

### DIFF
--- a/packages/patrol_cli/lib/src/commands/build_macos.dart
+++ b/packages/patrol_cli/lib/src/commands/build_macos.dart
@@ -136,6 +136,8 @@ class BuildMacOSCommand extends PatrolCommand {
       flutter: flutterOpts,
       scheme: flutterOpts.buildMode.createScheme(flavor),
       configuration: flutterOpts.buildMode.createConfiguration(flavor),
+      appServerPort: super.appServerPort,
+      testServerPort: super.testServerPort,
     );
 
     try {

--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -217,6 +217,8 @@ class DevelopCommand extends PatrolCommand {
       flutter: flutterOpts,
       scheme: buildMode.createScheme(iosFlavor),
       configuration: buildMode.createConfiguration(iosFlavor),
+      appServerPort: super.appServerPort,
+      testServerPort: super.testServerPort,
     );
 
     await _build(androidOpts, iosOpts, macosOpts, device);

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -208,6 +208,8 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
       flutter: flutterOpts,
       scheme: buildMode.createScheme(macosFlavor),
       configuration: buildMode.createConfiguration(macosFlavor),
+      appServerPort: super.appServerPort,
+      testServerPort: super.testServerPort,
     );
 
     await _build(androidOpts, iosOpts, macosOpts, device);

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -232,12 +232,16 @@ class MacOSAppOptions {
     this.bundleId,
     required this.scheme,
     required this.configuration,
+    required this.appServerPort,
+    required this.testServerPort,
   });
 
   final FlutterAppOptions flutter;
   final String? bundleId;
   final String scheme;
   final String configuration;
+  final int appServerPort;
+  final int testServerPort;
 
   String get description {
     return 'app with entrypoint ${basename(flutter.target)} for macos';

--- a/packages/patrol_cli/lib/src/macos/macos_test_backend.dart
+++ b/packages/patrol_cli/lib/src/macos/macos_test_backend.dart
@@ -11,6 +11,7 @@ import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/base/process.dart';
 import 'package:patrol_cli/src/crossplatform/app_options.dart';
 import 'package:patrol_cli/src/devices.dart';
+import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 
 enum BuildMode {
@@ -51,10 +52,12 @@ enum BuildMode {
 class MacOSTestBackend {
   MacOSTestBackend({
     required ProcessManager processManager,
+    required Platform platform,
     required FileSystem fs,
     required DisposeScope parentDisposeScope,
     required Logger logger,
   })  : _processManager = processManager,
+        _platform = platform,
         _fs = fs,
         _disposeScope = DisposeScope(),
         _logger = logger {
@@ -64,6 +67,7 @@ class MacOSTestBackend {
   static const _xcodebuildInterrupted = -15;
 
   final ProcessManager _processManager;
+  final Platform _platform;
   final FileSystem _fs;
   final DisposeScope _disposeScope;
   final Logger _logger;
@@ -158,6 +162,11 @@ class MacOSTestBackend {
           resultBundlePath: resultsPath,
         ),
         runInShell: true,
+        environment: {
+          ..._platform.environment,
+          'TEST_RUNNER_PATROL_TEST_PORT': options.testServerPort.toString(),
+          'TEST_RUNNER_PATROL_APP_PORT': options.appServerPort.toString(),
+        },
         workingDirectory: _fs.currentDirectory.childDirectory('macos').path,
       )
         ..disposedBy(_disposeScope);

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -119,6 +119,7 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
 
     final macosTestBackend = MacOSTestBackend(
       processManager: _processManager,
+      platform: _platform,
       fs: _fs,
       parentDisposeScope: _disposeScope,
       logger: _logger,


### PR DESCRIPTION
Reported [here](https://github.com/leancodepl/patrol/issues/2168).
Changing ports from the default ones was not respected when running patrol tests for macOS.