### PR TITLE
Bump dependencies to match Flutter 3.22

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.7.0-dev.2
 
 - Bump `test_api` dependency to 0.7.0.
+- Bump `patrol_devtools_extension` dependencies. 
 
 ## 3.6.1
 

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.0-dev.2
+
+- Bump `test_api` dependency to 0.7.0.
+
 ## 3.6.1
 
 - Fix clearing textfield before entering text on iOS (#2158).

--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -2,7 +2,7 @@ name: patrol
 description: >
   Powerful Flutter-native UI testing framework overcoming limitations of
   existing Flutter testing tools. Ready for action!
-version: 3.6.1
+version: 3.7.0-dev.2
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues
@@ -27,7 +27,7 @@ dependencies:
   meta: ^1.10.0
   patrol_finders: ^2.0.1
   shelf: ^1.4.1
-  test_api: '^0.6.1'
+  test_api: '^0.7.0'
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/packages/patrol_devtools_extension/lib/native_inspector/native_inspector.dart
+++ b/packages/patrol_devtools_extension/lib/native_inspector/native_inspector.dart
@@ -24,8 +24,8 @@ class NativeInspector extends HookWidget {
     final fullNodeNames = useState(false);
     final nativeDetails = useState(false);
 
-    final splitAxis = Split.axisFor(context, 0.85);
-    final child = Split(
+    final splitAxis = SplitPane.axisFor(context, 0.85);
+    final child = SplitPane(
       axis: splitAxis,
       initialFractions: const [0.6, 0.4],
       children: [

--- a/packages/patrol_devtools_extension/lib/native_inspector/native_view_details.dart
+++ b/packages/patrol_devtools_extension/lib/native_inspector/native_view_details.dart
@@ -66,7 +66,7 @@ class _HeaderDecoration extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: defaultHeaderHeight(isDense: _isDense()),
+      height: defaultHeaderHeight,
       decoration: BoxDecoration(
         border: Border(
           bottom: defaultBorderSide(Theme.of(context)),
@@ -74,10 +74,6 @@ class _HeaderDecoration extends StatelessWidget {
       ),
       child: child,
     );
-  }
-
-  bool _isDense() {
-    return ideTheme.embed;
   }
 }
 

--- a/packages/patrol_devtools_extension/lib/native_inspector/widgets/header_decoration.dart
+++ b/packages/patrol_devtools_extension/lib/native_inspector/widgets/header_decoration.dart
@@ -9,7 +9,7 @@ class HeaderDecoration extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: defaultHeaderHeight(isDense: _isDense()),
+      height: defaultHeaderHeight,
       decoration: BoxDecoration(
         border: Border(
           bottom: defaultBorderSide(Theme.of(context)),
@@ -17,9 +17,5 @@ class HeaderDecoration extends StatelessWidget {
       ),
       child: child,
     );
-  }
-
-  bool _isDense() {
-    return ideTheme.embed;
   }
 }

--- a/packages/patrol_devtools_extension/pubspec.lock
+++ b/packages/patrol_devtools_extension/pubspec.lock
@@ -157,26 +157,34 @@ packages:
     dependency: "direct main"
     description:
       name: devtools_app_shared
-      sha256: "2ba4cbc1e863d25ddc89ac367c3361a806be613bc2cc90d978f884029f179052"
+      sha256: ce205ca88895e2d44321e6f92f33db761132e2927f4edcc63221cc10267c2f61
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.4"
+    version: "0.1.1"
   devtools_extensions:
     dependency: "direct main"
     description:
       name: devtools_extensions
-      sha256: db51af213b7b5413ad8fcf37bdccc6defbb6cce109e536a9b3d8261062f71956
+      sha256: "109355b1e66c6a806d9166953c0ce0cd45a008c5b53b5a0479dfb428887d18c6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.6"
+    version: "0.1.1"
   devtools_shared:
     dependency: transitive
     description:
       name: devtools_shared
-      sha256: "81528e760c89f0e9e093e8a01135bb067e4ea7beab509e8effc2916452c4a4c1"
+      sha256: e5fa35a08b7728bb835982784f4b261f35cec0eec897698cc91e815caa92d10e
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "8.1.1"
+  dtd:
+    dependency: transitive
+    description:
+      name: dtd
+      sha256: "0d4a51ab223090d2d6b86477f414052db78cad1b2de020619f454a2a39369fec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   equatable:
     dependency: "direct main"
     description:
@@ -247,10 +255,18 @@ packages:
     dependency: transitive
     description:
       name: hotreloader
-      sha256: "94ee21a60ea2836500799f3af035dc3212b1562027f1e0031c14e087f0231449"
+      sha256: ed56fdc1f3a8ac924e717257621d09e9ec20e308ab6352a73a50a1d7a4d9158e
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -259,6 +275,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -283,6 +307,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
+  json_rpc_2:
+    dependency: transitive
+    description:
+      name: json_rpc_2
+      sha256: "5e469bffa23899edacb7b22787780068d650b106a21c76db3c49218ab7ca447e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   leancode_lint:
     dependency: "direct dev"
     description:
@@ -303,26 +359,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.12.0"
   package_config:
     dependency: transitive
     description:
@@ -335,10 +391,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   pointer_interceptor:
     dependency: transitive
     description:
@@ -460,10 +516,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -472,6 +528,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  unified_analytics:
+    dependency: transitive
+    description:
+      name: unified_analytics
+      sha256: "57f594f2eff970a74e43aedc9bdec8eb8e3d3c860da8e9e6bcdf7594a07dba6b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.8+1"
   usage:
     dependency: transitive
     description:
@@ -500,10 +564,10 @@ packages:
     dependency: "direct main"
     description:
       name: vm_service
-      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "11.10.0"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:
@@ -516,10 +580,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: "4188706108906f002b3a293509234588823c8c979dc83304e229ff400c996b05"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   web_socket_channel:
     dependency: transitive
     description:
@@ -553,5 +617,5 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
-  flutter: ">=3.16.0"
+  dart: ">=3.4.0-282.1.beta <4.0.0"
+  flutter: ">=3.22.0-0.1.pre"

--- a/packages/patrol_devtools_extension/pubspec.yaml
+++ b/packages/patrol_devtools_extension/pubspec.yaml
@@ -2,7 +2,7 @@ name: patrol_devtools_extension
 description: A new Flutter project.
 publish_to: none
 
-version: 0.1.0
+version: 0.2.0
 
 environment:
   sdk: '>=3.2.0 <4.0.0'
@@ -11,14 +11,14 @@ environment:
 dependencies:
   collection: ^1.18.0
   cupertino_icons: ^1.0.6
-  devtools_app_shared: ^0.0.4
-  devtools_extensions: ^0.0.6
+  devtools_app_shared: ^0.1.0
+  devtools_extensions: ^0.1.0
   equatable: ^2.0.5
   flutter:
     sdk: flutter
   flutter_hooks: ^0.20.3
   json_annotation: ^4.8.1
-  vm_service: ^11.0.0
+  vm_service: ^14.2.1
 
 dev_dependencies:
   custom_lint: ^0.5.7

--- a/packages/patrol_finders/CHANGELOG.md
+++ b/packages/patrol_finders/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3-dev.1
+
+- Adjust `pumpWidget` to new `flutter_test` API.
+
 ## 2.0.2
 
 - Add registering text input. (#2111)

--- a/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart
@@ -145,7 +145,7 @@ class PatrolTester {
     Duration? duration,
     EnginePhase phase = EnginePhase.sendSemanticsUpdate,
   ]) async {
-    await tester.pumpWidget(widget, duration, phase);
+    await tester.pumpWidget(widget, duration: duration, phase: phase);
   }
 
   /// See [WidgetTester.pump].
@@ -205,7 +205,7 @@ class PatrolTester {
     EnginePhase phase = EnginePhase.sendSemanticsUpdate,
     Duration? timeout,
   }) async {
-    await tester.pumpWidget(widget, duration, phase);
+    await tester.pumpWidget(widget, duration: duration, phase: phase);
     await _performPump(
       settlePolicy: SettlePolicy.settle,
       settleTimeout: timeout,

--- a/packages/patrol_finders/pubspec.yaml
+++ b/packages/patrol_finders/pubspec.yaml
@@ -1,6 +1,6 @@
 name: patrol_finders
 description: Streamlined, high-level API on top of flutter_test.
-version: 2.0.2
+version: 2.0.3-dev.1
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol_finders
 issue_tracker: https://github.com/leancodepl/patrol/issues?q=is%3Aopen+is%3Aissue+label%3Apackage%3Apatrol_finders


### PR DESCRIPTION
Upcoming version of Flutter depends on `test_api` 0.7.0. It also makes `duration` and `phase` parameters in `pumpWidget` method named so we have to adjust or implementation of `patrol_finders` and bump the dependencies. 