### PR TITLE
Compare our value before setting `debugDefaultTargetPlatformOverride`

### DIFF
--- a/packages/patrol/lib/src/common.dart
+++ b/packages/patrol/lib/src/common.dart
@@ -137,8 +137,11 @@ void patrolTest(
       final waitSeconds = const int.fromEnvironment('PATROL_WAIT');
       final waitDuration = Duration(seconds: waitSeconds);
 
-      debugDefaultTargetPlatformOverride =
-          patrolBinding.workaroundDebugDefaultTargetPlatformOverride;
+      if (debugDefaultTargetPlatformOverride !=
+          patrolBinding.workaroundDebugDefaultTargetPlatformOverride) {
+        debugDefaultTargetPlatformOverride =
+            patrolBinding.workaroundDebugDefaultTargetPlatformOverride;
+      }
 
       if (waitDuration > Duration.zero) {
         final stopwatch = Stopwatch()..start();


### PR DESCRIPTION
This PR is related to #1930.

Since flutter/flutter@7ca4b7b, Flutter prevents changes to `debugDefaultTargetPlatformOverride` in non-debug mode so the test will fail when being run on a device farm like Firebase Test Lab. This PR compares the value before changing it, the logic should be the same as before:

- In debug mode, the value is reset as needed
- In production mode, the value should not be changed anyway so we will skip the setter and avoid the thrown error

