### PR TITLE
Implement enableBluetooth and disableBluetooth for Android > 11

### DIFF
--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -190,9 +190,21 @@ class Automator private constructor() {
 
     fun enableWifi() = executeShellCommand("svc wifi enable")
 
-    fun enableBluetooth(): Unit = throw NotImplementedError("enableBluetooth")
+    fun enableBluetooth() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            executeShellCommand("svc bluetooth enable")
+        } else {
+            throw PatrolException("enableBluetooth method is not available in Android lower than 12")
+        }
+    }
 
-    fun disableBluetooth(): Unit = throw NotImplementedError("disableBluetooth")
+    fun disableBluetooth() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            executeShellCommand("svc bluetooth disable")
+        } else {
+            throw PatrolException("disableBluetooth method is not available in Android lower than 12")
+        }
+    }
 
     fun getNativeViews(selector: BySelector): List<NativeView> {
         Logger.d("getNativeViews()")

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -541,11 +541,15 @@ class NativeAutomator {
   }
 
   /// Enables bluetooth.
+  ///
+  /// Doesn't work on Android versions lower than 12.
   Future<void> enableBluetooth() async {
     await _wrapRequest('enableBluetooth', _client.enableBluetooth);
   }
 
   /// Disables bluetooth.
+  ///
+  /// Doesn't work on Android versions lower than 12.
   Future<void> disableBluetooth() async {
     await _wrapRequest('disableBluetooth', _client.disableBluetooth);
   }

--- a/packages/patrol/lib/src/native/native_automator2.dart
+++ b/packages/patrol/lib/src/native/native_automator2.dart
@@ -419,11 +419,15 @@ class NativeAutomator2 {
   }
 
   /// Enables bluetooth.
+  ///
+  /// Doesn't work on Android versions lower than 12.
   Future<void> enableBluetooth() async {
     await _wrapRequest('enableBluetooth', _client.enableBluetooth);
   }
 
   /// Disables bluetooth.
+  ///
+  /// Doesn't work on Android versions lower than 12.
   Future<void> disableBluetooth() async {
     await _wrapRequest('disableBluetooth', _client.disableBluetooth);
   }


### PR DESCRIPTION
For Android 12 and higher we can use `svc bluetooth enable/disable` command but I couldn't find a way to implement it for lower versions. 