### PR TITLE
Fix opening settings app with clean state on iOS

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Implement `enableBluetooth` and `disableBluetooth` methods for Android > 11. (#2254)
 - Implement `enableAirplaneMode` and `disableAirplaneMode` methods for Android. (#2254)
 - Implement `enableLocation` and `disableLocation` methods for Android. (#2259)
+- Fix opening settings app with clean state on iOS. (#2275)
 
 ## 3.9.0
 

--- a/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
@@ -1002,7 +1002,8 @@
     ) throws {
       try runAction(log) {
         self.springboard.activate()
-        self.preferences.launch()  // reset to a known state
+        self.preferences.activate() // Needed to make sure that settings will be opened with a clean state
+        self.preferences.launch()
 
         block()
 

--- a/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
@@ -1002,7 +1002,7 @@
     ) throws {
       try runAction(log) {
         self.springboard.activate()
-        self.preferences.activate() // Needed to make sure that settings will be opened with a clean state
+        self.preferences.activate()  // Needed to make sure that settings will be opened with a clean state
         self.preferences.launch()
 
         block()

--- a/packages/patrol/darwin/Classes/AutomatorServer/AutomatorServer.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/AutomatorServer.swift
@@ -283,13 +283,13 @@
       }
     }
 
-    func enableBluetooth() throws {
+    func enableLocation() throws {
       return try runCatching {
         try automator.enableLocation()
       }
     }
 
-    func disableBluetooth() throws {
+    func disableLocation() throws {
       return try runCatching {
         try automator.disableLocation()
       }


### PR DESCRIPTION
Closes #2273.
Seems like `XCUIApplication` `launch` method is not working as it is described in the documentation:
> Launches the application synchronously. On return the application ready to handle events. If the application is already running, the existing instance will be terminated to ensure a clean state for the launched instance.

What is even more strange, adding `self.preferences.activate()` before `self.preferences.launch()` fixes the issue. The flow looks kind of glitchy (settings app is opened twice in a row), but the whole flow completes successfully. 

Here's a recording of how it looks after the change:


https://github.com/user-attachments/assets/9fd68981-1ed8-41c2-a4f7-e82cb882eb0e



