### PR TITLE
Disable ios workflows on PR

### DIFF
--- a/.github/workflows/test-ios-simulator-webview.yaml
+++ b/.github/workflows/test-ios-simulator-webview.yaml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 23 * * *"
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 */12 * * *"
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
We don't want to run `test-ios-simulator-webview` and `test-ios-simulator` on every PR since they are not working currently.