### PR TITLE
Add target build apk command

### DIFF
--- a/packages/patrol_cli/lib/src/android/android_test_backend.dart
+++ b/packages/patrol_cli/lib/src/android/android_test_backend.dart
@@ -160,6 +160,8 @@ class AndroidTestBackend {
         'build',
         'apk',
         '--config-only',
+        '-t',
+        'integration_test/test_bundle.dart',
       ],
       runInShell: true,
     );


### PR DESCRIPTION
In #2293 I've add `flutter build apk --config-only`, to create `./android/gradlew` file during running patrol test on android. But it does not work, if app has different target than `main.dart`. So in this PR I'm adding `-t integration_test/test_bundle.dart` to avoid this problem.