### PR TITLE
EnterText TapLocation iOS

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.0
+
+- Add Option to select tap Location in enterText and enterTextByIndex (#2312)
+
 ## 3.10.0
 
 - Implement `enableBluetooth` and `disableBluetooth` methods for Android > 11. (#2254)

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -367,8 +367,9 @@ class Automator private constructor() {
         val uiObject = uiDevice.findObject(uiSelector)
 
         if (keyboardBehavior == KeyboardBehavior.showAndDismiss) {
-            val x = uiObject.width() * dx
-            val y = uiObject.height() * dy
+            val bounds = uiObject.visibleBounds
+            val x = bounds.width() * dx
+            val y = bounds.height() * dy
             uiObject.click(x, y)
         }
 
@@ -404,8 +405,9 @@ class Automator private constructor() {
         }
 
         if (keyboardBehavior == KeyboardBehavior.showAndDismiss) {
-            val x = uiObject.width() * dx
-            val y = uiObject.height() * dy
+            val bounds = uiObject.visibleBounds
+            val x = bounds.width() * dx
+            val y = bounds.height() * dy
             uiObject.click(x, y)
         }
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -367,9 +367,8 @@ class Automator private constructor() {
         val uiObject = uiDevice.findObject(uiSelector)
 
         if (keyboardBehavior == KeyboardBehavior.showAndDismiss) {
-            val rect = uiObject.bounds
-            val x = rect.width * dx
-            val y = rect.height * dy
+            val x = uiObject.width * dx
+            val y = uiObject.height * dy
             uiObject.click(x, y)
         }
 
@@ -405,9 +404,8 @@ class Automator private constructor() {
         }
 
         if (keyboardBehavior == KeyboardBehavior.showAndDismiss) {
-            val rect = uiObject.bounds
-            val x = rect.width * dx
-            val y = rect.height * dy
+            val x = uiObject.width * dx
+            val y = uiObject.height * dy
             uiObject.click(x, y)
         }
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -367,10 +367,10 @@ class Automator private constructor() {
         val uiObject = uiDevice.findObject(uiSelector)
 
         if (keyboardBehavior == KeyboardBehavior.showAndDismiss) {
-            val bounds = uiObject.visibleBounds
-            val x = bounds.width() * dx
-            val y = bounds.height() * dy
-            uiObject.click(x, y)
+            val rect = uiObject.visibleBounds
+            val x = rect.left + rect.width() * dx
+            val y = rect.top + rect.height() * dy
+            uiDevice.click(x.toInt(), y.toInt())
         }
 
         uiObject.text = text
@@ -405,10 +405,10 @@ class Automator private constructor() {
         }
 
         if (keyboardBehavior == KeyboardBehavior.showAndDismiss) {
-            val bounds = uiObject.visibleBounds
-            val x = bounds.width() * dx
-            val y = bounds.height() * dy
-            uiObject.click(x, y)
+            val rect = uiObject.visibleBounds
+            val x = rect.left + rect.width() * dx
+            val y = rect.top + rect.height() * dy
+            uiDevice.click(x.toInt(), y.toInt())
         }
 
         uiObject.text = text

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -367,8 +367,8 @@ class Automator private constructor() {
         val uiObject = uiDevice.findObject(uiSelector)
 
         if (keyboardBehavior == KeyboardBehavior.showAndDismiss) {
-            val x = uiObject.width * dx
-            val y = uiObject.height * dy
+            val x = uiObject.width() * dx
+            val y = uiObject.height() * dy
             uiObject.click(x, y)
         }
 
@@ -404,8 +404,8 @@ class Automator private constructor() {
         }
 
         if (keyboardBehavior == KeyboardBehavior.showAndDismiss) {
-            val x = uiObject.width * dx
-            val y = uiObject.height * dy
+            val x = uiObject.width() * dx
+            val y = uiObject.height() * dy
             uiObject.click(x, y)
         }
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -353,7 +353,7 @@ class Automator private constructor() {
         delay()
     }
 
-    fun enterText(text: String, index: Int, keyboardBehavior: KeyboardBehavior, timeout: Long? = null) {
+    fun enterText(text: String, index: Int, keyboardBehavior: KeyboardBehavior, timeout: Long? = null, dx: Float, dy: Float) {
         Logger.d("enterText(text: $text, index: $index)")
 
         val selector = By.clazz(EditText::class.java)
@@ -367,7 +367,10 @@ class Automator private constructor() {
         val uiObject = uiDevice.findObject(uiSelector)
 
         if (keyboardBehavior == KeyboardBehavior.showAndDismiss) {
-            uiObject.click()
+            val rect = uiObject.bounds
+            val x = rect.width * dx
+            val y = rect.height * dy
+            uiObject.click(x, y)
         }
 
         uiObject.text = text
@@ -383,7 +386,9 @@ class Automator private constructor() {
         bySelector: BySelector,
         index: Int,
         keyboardBehavior: KeyboardBehavior,
-        timeout: Long? = null
+        timeout: Long? = null,
+        dx: Float,
+        dy: Float
     ) {
         Logger.d("enterText($text): $uiSelector, $bySelector")
 
@@ -400,7 +405,10 @@ class Automator private constructor() {
         }
 
         if (keyboardBehavior == KeyboardBehavior.showAndDismiss) {
-            uiObject.click()
+            val rect = uiObject.bounds
+            val x = rect.width * dx
+            val y = rect.height * dy
+            uiObject.click(x, y)
         }
 
         uiObject.text = text

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
@@ -222,8 +222,8 @@ class AutomatorServer(private val automation: Automator) : NativeAutomatorServer
                 index = request.index.toInt(),
                 keyboardBehavior = request.keyboardBehavior,
                 timeout = request.timeoutMillis,
-                dx = request.dx?.toFloat() ?? 0.9f,
-                dy = request.dy?.toFloat() ?? 0.9f
+                dx = request.dx?.toFloat() ?: 0.9f,
+                dy = request.dy?.toFloat() ?: 0.9f
             )
         } else if (request.selector != null) {
             automation.enterText(
@@ -233,8 +233,8 @@ class AutomatorServer(private val automation: Automator) : NativeAutomatorServer
                 index = request.selector.instance?.toInt() ?: 0,
                 keyboardBehavior = request.keyboardBehavior,
                 timeout = request.timeoutMillis,
-                dx = request.dx?.toFloat() ?? 0.9f,
-                dy = request.dy?.toFloat() ?? 0.9f
+                dx = request.dx?.toFloat() ?: 0.9f,
+                dy = request.dy?.toFloat() ?: 0.9f
             )
         } else if (request.androidSelector != null) {
             automation.enterText(

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
@@ -221,7 +221,9 @@ class AutomatorServer(private val automation: Automator) : NativeAutomatorServer
                 text = request.data,
                 index = request.index.toInt(),
                 keyboardBehavior = request.keyboardBehavior,
-                timeout = request.timeoutMillis
+                timeout = request.timeoutMillis,
+                dx = request.dx,
+                dy = request.dy
             )
         } else if (request.selector != null) {
             automation.enterText(
@@ -230,7 +232,9 @@ class AutomatorServer(private val automation: Automator) : NativeAutomatorServer
                 bySelector = request.selector.toBySelector(),
                 index = request.selector.instance?.toInt() ?: 0,
                 keyboardBehavior = request.keyboardBehavior,
-                timeout = request.timeoutMillis
+                timeout = request.timeoutMillis,
+                dx = request.dx,
+                dy = request.dy
             )
         } else if (request.androidSelector != null) {
             automation.enterText(
@@ -239,7 +243,9 @@ class AutomatorServer(private val automation: Automator) : NativeAutomatorServer
                 bySelector = request.androidSelector.toBySelector(),
                 index = request.androidSelector.instance?.toInt() ?: 0,
                 keyboardBehavior = request.keyboardBehavior,
-                timeout = request.timeoutMillis
+                timeout = request.timeoutMillis,
+                dx = request.dx,
+                dy = request.dy
             )
         } else {
             throw PatrolException("enterText(): neither index nor selector are set")

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
@@ -222,8 +222,8 @@ class AutomatorServer(private val automation: Automator) : NativeAutomatorServer
                 index = request.index.toInt(),
                 keyboardBehavior = request.keyboardBehavior,
                 timeout = request.timeoutMillis,
-                dx = request.dx.toFloat(),
-                dy = request.dy.toFloat()
+                dx = request.dx?.toFloat() ?? 0.9f,
+                dy = request.dy?.toFloat() ?? 0.9f
             )
         } else if (request.selector != null) {
             automation.enterText(
@@ -233,8 +233,8 @@ class AutomatorServer(private val automation: Automator) : NativeAutomatorServer
                 index = request.selector.instance?.toInt() ?: 0,
                 keyboardBehavior = request.keyboardBehavior,
                 timeout = request.timeoutMillis,
-                dx = request.dx.toFloat(),
-                dy = request.dy.toFloat()
+                dx = request.dx?.toFloat() ?? 0.9f,
+                dy = request.dy?.toFloat() ?? 0.9f
             )
         } else if (request.androidSelector != null) {
             automation.enterText(

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
@@ -222,8 +222,8 @@ class AutomatorServer(private val automation: Automator) : NativeAutomatorServer
                 index = request.index.toInt(),
                 keyboardBehavior = request.keyboardBehavior,
                 timeout = request.timeoutMillis,
-                dx = request.dx,
-                dy = request.dy
+                dx = request.dx.toFloat(),
+                dy = request.dy.toFloat()
             )
         } else if (request.selector != null) {
             automation.enterText(
@@ -233,8 +233,8 @@ class AutomatorServer(private val automation: Automator) : NativeAutomatorServer
                 index = request.selector.instance?.toInt() ?: 0,
                 keyboardBehavior = request.keyboardBehavior,
                 timeout = request.timeoutMillis,
-                dx = request.dx,
-                dy = request.dy
+                dx = request.dx.toFloat(),
+                dy = request.dy.toFloat()
             )
         } else if (request.androidSelector != null) {
             automation.enterText(

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
@@ -244,8 +244,8 @@ class AutomatorServer(private val automation: Automator) : NativeAutomatorServer
                 index = request.androidSelector.instance?.toInt() ?: 0,
                 keyboardBehavior = request.keyboardBehavior,
                 timeout = request.timeoutMillis,
-                dx = request.dx,
-                dy = request.dy
+                dx = request.dx?.toFloat() ?: 0.9f,
+                dy = request.dy?.toFloat() ?: 0.9f
             )
         } else {
             throw PatrolException("enterText(): neither index nor selector are set")

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
@@ -539,6 +539,8 @@ class Contracts {
     val iosSelector: IOSSelector? = null,
     val keyboardBehavior: KeyboardBehavior,
     val timeoutMillis: Long? = null
+    val dx: Double? = null,
+    val dy: Double? = null,
   ){
     fun hasIndex(): Boolean {
       return index != null

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
@@ -538,7 +538,7 @@ class Contracts {
     val androidSelector: AndroidSelector? = null,
     val iosSelector: IOSSelector? = null,
     val keyboardBehavior: KeyboardBehavior,
-    val timeoutMillis: Long? = null
+    val timeoutMillis: Long? = null,
     val dx: Double? = null,
     val dy: Double? = null,
   ){

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
@@ -540,7 +540,7 @@ class Contracts {
     val keyboardBehavior: KeyboardBehavior,
     val timeoutMillis: Long? = null,
     val dx: Double? = null,
-    val dy: Double? = null,
+    val dy: Double? = null
   ){
     fun hasIndex(): Boolean {
       return index != null

--- a/packages/patrol/darwin/Classes/AutomatorServer/Automator/Automator.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Automator/Automator.swift
@@ -215,21 +215,27 @@ extension Selector {
       on selector: Selector,
       inApp bundleId: String,
       dismissKeyboard: Bool,
-      withTimeout timeout: TimeInterval?
+      withTimeout timeout: TimeInterval?,
+      dx: CGFloat,
+      dy: CGFloat
     ) throws
     func enterText(
       _ data: String,
       on selector: IOSSelector,
       inApp bundleId: String,
       dismissKeyboard: Bool,
-      withTimeout timeout: TimeInterval?
+      withTimeout timeout: TimeInterval?,
+      dx: CGFloat,
+      dy: CGFloat
     ) throws
     func enterText(
       _ data: String,
       byIndex index: Int,
       inApp bundleId: String,
       dismissKeyboard: Bool,
-      withTimeout timeout: TimeInterval?
+      withTimeout timeout: TimeInterval?,
+      dx: CGFloat,
+      dy: CGFloat
     ) throws
     func swipe(from start: CGVector, to end: CGVector, inApp bundleId: String) throws
     func waitUntilVisible(

--- a/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
@@ -855,7 +855,7 @@
       }
 
       // We need to tap at the end of the field to ensure the cursor is at the end
-      let coordinate = element.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.9))
+      let coordinate = element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
       coordinate.tap()
 
       element.typeText(delete + data)

--- a/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
@@ -182,7 +182,9 @@
       on selector: Selector,
       inApp bundleId: String,
       dismissKeyboard: Bool,
-      withTimeout timeout: TimeInterval?
+      withTimeout timeout: TimeInterval?,
+      dx: CGFloat,
+      dy: CGFloat
     ) throws {
       var data = data
       if dismissKeyboard {
@@ -223,7 +225,7 @@
           throw PatrolError.viewNotExists(view)
         }
 
-        self.clearAndEnterText(data: data, element: element)
+        self.clearAndEnterText(data: data, element: element, dx: dx, dy: dy)
       }
 
       // Prevent keyboard dismissal from happening too fast
@@ -235,7 +237,9 @@
       on selector: IOSSelector,
       inApp bundleId: String,
       dismissKeyboard: Bool,
-      withTimeout timeout: TimeInterval?
+      withTimeout timeout: TimeInterval?,
+      dx: CGFloat,
+      dy: CGFloat
     ) throws {
       var data = data
       if dismissKeyboard {
@@ -259,7 +263,7 @@
           throw PatrolError.viewNotExists(view)
         }
 
-        self.clearAndEnterText(data: data, element: element)
+        self.clearAndEnterText(data: data, element: element, dx: dx, dy: dy)
       }
 
       // Prevent keyboard dismissal from happening too fast
@@ -271,7 +275,9 @@
       byIndex index: Int,
       inApp bundleId: String,
       dismissKeyboard: Bool,
-      withTimeout timeout: TimeInterval?
+      withTimeout timeout: TimeInterval?,
+      dx: CGFloat,
+      dy: CGFloat
     ) throws {
       var data = data
       if dismissKeyboard {
@@ -302,7 +308,7 @@
           throw PatrolError.viewNotExists("text field at index \(index) in app \(bundleId)")
         }
 
-        self.clearAndEnterText(data: data, element: element)
+        self.clearAndEnterText(data: data, element: element, dx: dx, dy: dy)
       }
 
       // Prevent keyboard dismissal from happening too fast
@@ -847,7 +853,7 @@
     }
 
     // MARK: Private stuff
-    private func clearAndEnterText(data: String, element: XCUIElement) {
+    private func clearAndEnterText(data: String, element: XCUIElement, dx: CGFloat, dy: CGFloat) {
       let currentValue = element.value as? String
       var delete: String = ""
       if let value = currentValue {
@@ -855,7 +861,7 @@
       }
 
       // We need to tap at the end of the field to ensure the cursor is at the end
-      let coordinate = element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+      let coordinate = element.coordinate(withNormalizedOffset: CGVector(dx: dx, dy: dy))
       coordinate.tap()
 
       element.typeText(delete + data)

--- a/packages/patrol/darwin/Classes/AutomatorServer/AutomatorServer.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/AutomatorServer.swift
@@ -146,37 +146,46 @@
       }
     }
 
-    func enterText(request: EnterTextRequest) throws {
-      return try runCatching {
+func enterText(request: EnterTextRequest) throws {
+    return try runCatching {
+        let dx: CGFloat = request.dx ?? 0.9
+        let dy: CGFloat = request.dy ?? 0.9
+
         if let index = request.index {
-          try automator.enterText(
-            request.data,
-            byIndex: Int(index),
-            inApp: request.appId,
-            dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
-            withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) }
-          )
+            try automator.enterText(
+                request.data,
+                byIndex: Int(index),
+                inApp: request.appId,
+                dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
+                withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) },
+                dx: dx,
+                dy: dy
+            )
         } else if let selector = request.selector {
-          try automator.enterText(
-            request.data,
-            on: selector,
-            inApp: request.appId,
-            dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
-            withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) }
-          )
+            try automator.enterText(
+                request.data,
+                on: selector,
+                inApp: request.appId,
+                dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
+                withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) },
+                dx: dx,
+                dy: dy
+            )
         } else if let iosSelector = request.iosSelector {
-          try automator.enterText(
-            request.data,
-            on: iosSelector,
-            inApp: request.appId,
-            dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
-            withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) }
-          )
+            try automator.enterText(
+                request.data,
+                on: iosSelector,
+                inApp: request.appId,
+                dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
+                withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) },
+                dx: dx,
+                dy: dy
+            )
         } else {
-          throw PatrolError.internal("enterText(): neither index nor selector are set")
+            throw PatrolError.internal("enterText(): neither index nor selector are set")
         }
-      }
     }
+}
 
     func swipe(request: SwipeRequest) throws {
       return try runCatching {

--- a/packages/patrol/darwin/Classes/AutomatorServer/AutomatorServer.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/AutomatorServer.swift
@@ -148,9 +148,6 @@
 
 func enterText(request: EnterTextRequest) throws {
     return try runCatching {
-        let dx: CGFloat = request.dx ?? 0.9
-        let dy: CGFloat = request.dy ?? 0.9
-
         if let index = request.index {
             try automator.enterText(
                 request.data,
@@ -158,8 +155,8 @@ func enterText(request: EnterTextRequest) throws {
                 inApp: request.appId,
                 dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
                 withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) },
-                dx: dx,
-                dy: dy
+                dx: request.dx,
+                dy: request.dy
             )
         } else if let selector = request.selector {
             try automator.enterText(
@@ -168,8 +165,8 @@ func enterText(request: EnterTextRequest) throws {
                 inApp: request.appId,
                 dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
                 withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) },
-                dx: dx,
-                dy: dy
+                dx: request.dx,
+                dy: request.dy
             )
         } else if let iosSelector = request.iosSelector {
             try automator.enterText(
@@ -178,8 +175,8 @@ func enterText(request: EnterTextRequest) throws {
                 inApp: request.appId,
                 dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
                 withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) },
-                dx: dx,
-                dy: dy
+                dx: request.dx,
+                dy: request.dy
             )
         } else {
             throw PatrolError.internal("enterText(): neither index nor selector are set")

--- a/packages/patrol/darwin/Classes/AutomatorServer/AutomatorServer.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/AutomatorServer.swift
@@ -146,43 +146,43 @@
       }
     }
 
-func enterText(request: EnterTextRequest) throws {
-    return try runCatching {
+    func enterText(request: EnterTextRequest) throws {
+      return try runCatching {
         if let index = request.index {
-            try automator.enterText(
-                request.data,
-                byIndex: Int(index),
-                inApp: request.appId,
-                dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
-                withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) },
-                dx: request.dx,
-                dy: request.dy
-            )
+          try automator.enterText(
+            request.data,
+            byIndex: Int(index),
+            inApp: request.appId,
+            dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
+            withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) },
+            dx: request.dx,
+            dy: request.dy
+          )
         } else if let selector = request.selector {
-            try automator.enterText(
-                request.data,
-                on: selector,
-                inApp: request.appId,
-                dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
-                withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) },
-                dx: request.dx,
-                dy: request.dy
-            )
+          try automator.enterText(
+            request.data,
+            on: selector,
+            inApp: request.appId,
+            dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
+            withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) },
+            dx: request.dx,
+            dy: request.dy
+          )
         } else if let iosSelector = request.iosSelector {
-            try automator.enterText(
-                request.data,
-                on: iosSelector,
-                inApp: request.appId,
-                dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
-                withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) },
-                dx: request.dx,
-                dy: request.dy
-            )
+          try automator.enterText(
+            request.data,
+            on: iosSelector,
+            inApp: request.appId,
+            dismissKeyboard: request.keyboardBehavior == .showAndDismiss,
+            withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) },
+            dx: request.dx,
+            dy: request.dy
+          )
         } else {
-            throw PatrolError.internal("enterText(): neither index nor selector are set")
+          throw PatrolError.internal("enterText(): neither index nor selector are set")
         }
+      }
     }
-}
 
     func swipe(request: SwipeRequest) throws {
       return try runCatching {

--- a/packages/patrol/darwin/Classes/AutomatorServer/Contracts.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Contracts.swift
@@ -318,8 +318,8 @@ public struct EnterTextRequest: Codable {
   public var iosSelector: IOSSelector?
   public var keyboardBehavior: KeyboardBehavior
   public var timeoutMillis: Int?
-  public var dx: Double
-  public var dy: Double
+  public var dx: Double?
+  public var dy: Double?
 }
 
 public struct SwipeRequest: Codable {

--- a/packages/patrol/darwin/Classes/AutomatorServer/Contracts.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Contracts.swift
@@ -318,8 +318,8 @@ public struct EnterTextRequest: Codable {
   public var iosSelector: IOSSelector?
   public var keyboardBehavior: KeyboardBehavior
   public var timeoutMillis: Int?
-  public var dx: Double?
-  public var dy: Double?
+  public var dx: Double
+  public var dy: Double
 }
 
 public struct SwipeRequest: Codable {

--- a/packages/patrol/darwin/Classes/AutomatorServer/Contracts.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Contracts.swift
@@ -318,6 +318,8 @@ public struct EnterTextRequest: Codable {
   public var iosSelector: IOSSelector?
   public var keyboardBehavior: KeyboardBehavior
   public var timeoutMillis: Int?
+  public var dx: Double
+  public var dy: Double
 }
 
 public struct SwipeRequest: Codable {

--- a/packages/patrol/lib/src/native/contracts/contracts.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.dart
@@ -949,6 +949,8 @@ class EnterTextRequest with EquatableMixin {
     this.iosSelector,
     required this.keyboardBehavior,
     this.timeoutMillis,
+    this.dx,
+    this.dy,
   });
 
   factory EnterTextRequest.fromJson(Map<String, dynamic> json) =>
@@ -962,20 +964,24 @@ class EnterTextRequest with EquatableMixin {
   final IOSSelector? iosSelector;
   final KeyboardBehavior keyboardBehavior;
   final int? timeoutMillis;
+  final double? dx;
+  final double? dy;
 
   Map<String, dynamic> toJson() => _$EnterTextRequestToJson(this);
 
   @override
   List<Object?> get props => [
-        data,
-        appId,
-        index,
-        selector,
-        androidSelector,
-        iosSelector,
-        keyboardBehavior,
-        timeoutMillis,
-      ];
+    data,
+    appId,
+    index,
+    selector,
+    androidSelector,
+    iosSelector,
+    keyboardBehavior,
+    timeoutMillis,
+    dx,
+    dy,
+  ];
 }
 
 @JsonSerializable()

--- a/packages/patrol/lib/src/native/contracts/contracts.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.dart
@@ -971,17 +971,17 @@ class EnterTextRequest with EquatableMixin {
 
   @override
   List<Object?> get props => [
-    data,
-    appId,
-    index,
-    selector,
-    androidSelector,
-    iosSelector,
-    keyboardBehavior,
-    timeoutMillis,
-    dx,
-    dy,
-  ];
+        data,
+        appId,
+        index,
+        selector,
+        androidSelector,
+        iosSelector,
+        keyboardBehavior,
+        timeoutMillis,
+        dx,
+        dy,
+      ];
 }
 
 @JsonSerializable()

--- a/packages/patrol/lib/src/native/contracts/contracts.g.dart
+++ b/packages/patrol/lib/src/native/contracts/contracts.g.dart
@@ -587,6 +587,8 @@ EnterTextRequest _$EnterTextRequestFromJson(Map<String, dynamic> json) =>
       keyboardBehavior:
           $enumDecode(_$KeyboardBehaviorEnumMap, json['keyboardBehavior']),
       timeoutMillis: (json['timeoutMillis'] as num?)?.toInt(),
+      dx: (json['dx'] as num?)?.toDouble(),
+      dy: (json['dy'] as num?)?.toDouble(),
     );
 
 Map<String, dynamic> _$EnterTextRequestToJson(EnterTextRequest instance) =>
@@ -599,6 +601,8 @@ Map<String, dynamic> _$EnterTextRequestToJson(EnterTextRequest instance) =>
       'iosSelector': instance.iosSelector,
       'keyboardBehavior': _$KeyboardBehaviorEnumMap[instance.keyboardBehavior]!,
       'timeoutMillis': instance.timeoutMillis,
+      'dx': instance.dx,
+      'dy': instance.dy,
     };
 
 const _$KeyboardBehaviorEnumMap = {

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -18,7 +18,6 @@ class PatrolActionException implements Exception {
   @override
   String toString() => 'Patrol action failed: $message';
 }
-
 /// Specifies how the OS keyboard should behave when using
 /// [NativeAutomator.enterText] and [NativeAutomator.enterTextByIndex].
 enum KeyboardBehavior {
@@ -668,26 +667,31 @@ class NativeAutomator {
   /// See also:
   ///  * [enterTextByIndex], which is less flexible but also less verbose
   Future<void> enterText(
-    Selector selector, {
-    required String text,
-    String? appId,
-    KeyboardBehavior? keyboardBehavior,
-    Duration? timeout,
-  }) async {
+      Selector selector, {
+        required String text,
+        String? appId,
+        KeyboardBehavior? keyboardBehavior,
+        Duration? timeout,
+        double? dx,
+        double? dy,
+      }) async {
     await _wrapRequest(
       'enterText',
-      () => _client.enterText(
+          () => _client.enterText(
         EnterTextRequest(
           data: text,
           appId: appId ?? resolvedAppId,
           selector: selector,
           keyboardBehavior:
-              (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
+          (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
+          dx: dx,
+          dy: dy,
         ),
       ),
     );
   }
+
 
   /// Enters text to the [index]-th visible text field.
   ///
@@ -704,22 +708,26 @@ class NativeAutomator {
   ///  * [enterText], which allows for more precise specification of the text
   ///    field to enter text into
   Future<void> enterTextByIndex(
-    String text, {
-    required int index,
-    String? appId,
-    KeyboardBehavior? keyboardBehavior,
-    Duration? timeout,
-  }) async {
+      String text, {
+        required int index,
+        String? appId,
+        KeyboardBehavior? keyboardBehavior,
+        Duration? timeout,
+        double? dx,
+        double? dy,
+      }) async {
     await _wrapRequest(
       'enterTextByIndex',
-      () => _client.enterText(
+          () => _client.enterText(
         EnterTextRequest(
           data: text,
           appId: appId ?? resolvedAppId,
           index: index,
           keyboardBehavior:
-              (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
+          (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
+          dx: dx,
+          dy: dy,
         ),
       ),
     );

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -684,8 +684,8 @@ class NativeAutomator {
           keyboardBehavior:
           (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
-          dx: tapLocation?.dx,
-          dy: tapLocation?.dy,
+          dx: tapLocation?.dx ?? 0.9,
+          dy: tapLocation?.dy ?? 0.9,
         ),
       ),
     );
@@ -724,8 +724,8 @@ class NativeAutomator {
           keyboardBehavior:
           (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
-          dx: tapLocation?.dx,
-          dy: tapLocation?.dy,
+          dx: tapLocation?.dx ?? 0.9,
+          dy: tapLocation?.dy ?? 0.9,
         ),
       ),
     );

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -18,6 +18,7 @@ class PatrolActionException implements Exception {
   @override
   String toString() => 'Patrol action failed: $message';
 }
+
 /// Specifies how the OS keyboard should behave when using
 /// [NativeAutomator.enterText] and [NativeAutomator.enterTextByIndex].
 enum KeyboardBehavior {
@@ -65,11 +66,9 @@ class NativeAutomatorConfig {
       defaultValue: '8081',
     ),
     this.packageName = const String.fromEnvironment('PATROL_APP_PACKAGE_NAME'),
-    this.iosInstalledApps =
-        const String.fromEnvironment('PATROL_IOS_INSTALLED_APPS'),
+    this.iosInstalledApps = const String.fromEnvironment('PATROL_IOS_INSTALLED_APPS'),
     this.bundleId = const String.fromEnvironment('PATROL_APP_BUNDLE_ID'),
-    this.androidAppName =
-        const String.fromEnvironment('PATROL_ANDROID_APP_NAME'),
+    this.androidAppName = const String.fromEnvironment('PATROL_ANDROID_APP_NAME'),
     this.iosAppName = const String.fromEnvironment('PATROL_IOS_APP_NAME'),
     this.connectionTimeout = const Duration(seconds: 60),
     this.findTimeout = const Duration(seconds: 10),
@@ -667,30 +666,28 @@ class NativeAutomator {
   /// See also:
   ///  * [enterTextByIndex], which is less flexible but also less verbose
   Future<void> enterText(
-      Selector selector, {
-        required String text,
-        String? appId,
-        KeyboardBehavior? keyboardBehavior,
-        Duration? timeout,
-        Offset? tapLocation,
-      }) async {
+    Selector selector, {
+    required String text,
+    String? appId,
+    KeyboardBehavior? keyboardBehavior,
+    Duration? timeout,
+    Offset tapLocation = const Offset(0.9, 0.9),
+  }) async {
     await _wrapRequest(
       'enterText',
-          () => _client.enterText(
+      () => _client.enterText(
         EnterTextRequest(
           data: text,
           appId: appId ?? resolvedAppId,
           selector: selector,
-          keyboardBehavior:
-          (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
+          keyboardBehavior: (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
-          dx: tapLocation?.dx ?? 0.9,
-          dy: tapLocation?.dy ?? 0.9,
+          dx: tapLocation.dx,
+          dy: tapLocation.dy,
         ),
       ),
     );
   }
-
 
   /// Enters text to the [index]-th visible text field.
   ///
@@ -707,25 +704,24 @@ class NativeAutomator {
   ///  * [enterText], which allows for more precise specification of the text
   ///    field to enter text into
   Future<void> enterTextByIndex(
-      String text, {
-        required int index,
-        String? appId,
-        KeyboardBehavior? keyboardBehavior,
-        Duration? timeout,
-        Offset? tapLocation,
-      }) async {
+    String text, {
+    required int index,
+    String? appId,
+    KeyboardBehavior? keyboardBehavior,
+    Duration? timeout,
+    Offset tapLocation = const Offset(0.9, 0.9),
+  }) async {
     await _wrapRequest(
       'enterTextByIndex',
-          () => _client.enterText(
+      () => _client.enterText(
         EnterTextRequest(
           data: text,
           appId: appId ?? resolvedAppId,
           index: index,
-          keyboardBehavior:
-          (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
+          keyboardBehavior: (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
-          dx: tapLocation?.dx ?? 0.9,
-          dy: tapLocation?.dy ?? 0.9,
+          dx: tapLocation.dx,
+          dy: tapLocation.dy,
         ),
       ),
     );

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -672,8 +672,7 @@ class NativeAutomator {
         String? appId,
         KeyboardBehavior? keyboardBehavior,
         Duration? timeout,
-        double? dx,
-        double? dy,
+        Offset? tapLocation,
       }) async {
     await _wrapRequest(
       'enterText',
@@ -685,8 +684,8 @@ class NativeAutomator {
           keyboardBehavior:
           (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
-          dx: dx,
-          dy: dy,
+          dx: tapLocation?.dx,
+          dy: tapLocation?.dy,
         ),
       ),
     );
@@ -713,8 +712,7 @@ class NativeAutomator {
         String? appId,
         KeyboardBehavior? keyboardBehavior,
         Duration? timeout,
-        double? dx,
-        double? dy,
+        Offset? tapLocation,
       }) async {
     await _wrapRequest(
       'enterTextByIndex',
@@ -726,8 +724,8 @@ class NativeAutomator {
           keyboardBehavior:
           (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
-          dx: dx,
-          dy: dy,
+          dx: tapLocation?.dx,
+          dy: tapLocation?.dy,
         ),
       ),
     );

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -673,6 +673,9 @@ class NativeAutomator {
     Duration? timeout,
     Offset tapLocation = const Offset(0.9, 0.9),
   }) async {
+    assert(tapLocation.dx >= 0.0 && tapLocation.dx <= 1.0);
+    assert(tapLocation.dy >= 0.0 && tapLocation.dy <= 1.0);
+
     await _wrapRequest(
       'enterText',
       () => _client.enterText(
@@ -711,6 +714,9 @@ class NativeAutomator {
     Duration? timeout,
     Offset tapLocation = const Offset(0.9, 0.9),
   }) async {
+    assert(tapLocation.dx >= 0.0 && tapLocation.dx <= 1.0);
+    assert(tapLocation.dy >= 0.0 && tapLocation.dy <= 1.0);
+
     await _wrapRequest(
       'enterTextByIndex',
       () => _client.enterText(

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -66,9 +66,11 @@ class NativeAutomatorConfig {
       defaultValue: '8081',
     ),
     this.packageName = const String.fromEnvironment('PATROL_APP_PACKAGE_NAME'),
-    this.iosInstalledApps = const String.fromEnvironment('PATROL_IOS_INSTALLED_APPS'),
+    this.iosInstalledApps =
+        const String.fromEnvironment('PATROL_IOS_INSTALLED_APPS'),
     this.bundleId = const String.fromEnvironment('PATROL_APP_BUNDLE_ID'),
-    this.androidAppName = const String.fromEnvironment('PATROL_ANDROID_APP_NAME'),
+    this.androidAppName =
+        const String.fromEnvironment('PATROL_ANDROID_APP_NAME'),
     this.iosAppName = const String.fromEnvironment('PATROL_IOS_APP_NAME'),
     this.connectionTimeout = const Duration(seconds: 60),
     this.findTimeout = const Duration(seconds: 10),
@@ -683,7 +685,8 @@ class NativeAutomator {
           data: text,
           appId: appId ?? resolvedAppId,
           selector: selector,
-          keyboardBehavior: (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
+          keyboardBehavior:
+              (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
           dx: tapLocation.dx,
           dy: tapLocation.dy,
@@ -724,7 +727,8 @@ class NativeAutomator {
           data: text,
           appId: appId ?? resolvedAppId,
           index: index,
-          keyboardBehavior: (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
+          keyboardBehavior:
+              (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
           dx: tapLocation.dx,
           dy: tapLocation.dy,

--- a/packages/patrol/lib/src/native/native_automator2.dart
+++ b/packages/patrol/lib/src/native/native_automator2.dart
@@ -553,6 +553,8 @@ class NativeAutomator2 {
     String? appId,
     native_automator.KeyboardBehavior? keyboardBehavior,
     Duration? timeout,
+    double? dx,
+    double? dy,
   }) async {
     await _wrapRequest(
       'enterText',
@@ -565,6 +567,8 @@ class NativeAutomator2 {
           keyboardBehavior:
               (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
+          dx: dx,
+          dy: dy,
         ),
       ),
     );
@@ -590,6 +594,8 @@ class NativeAutomator2 {
     String? appId,
     native_automator.KeyboardBehavior? keyboardBehavior,
     Duration? timeout,
+    double? dx,
+    double? dy,
   }) async {
     await _wrapRequest(
       'enterTextByIndex',
@@ -601,6 +607,8 @@ class NativeAutomator2 {
           keyboardBehavior:
               (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
+          dx: dx,
+          dy: dy,
         ),
       ),
     );

--- a/packages/patrol/lib/src/native/native_automator2.dart
+++ b/packages/patrol/lib/src/native/native_automator2.dart
@@ -566,8 +566,8 @@ class NativeAutomator2 {
           keyboardBehavior:
               (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
-          dx: tapLocation?.dx,
-          dy: tapLocation?.dy,
+          dx: tapLocation?.dx ?? 0.9,
+          dy: tapLocation?.dy ?? 0.9,
         ),
       ),
     );
@@ -605,8 +605,8 @@ class NativeAutomator2 {
           keyboardBehavior:
               (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
-          dx: tapLocation?.dx,
-          dy: tapLocation?.dy,
+          dx: tapLocation?.dx ?? 0.9,
+          dy: tapLocation?.dy ?? 0.9,
         ),
       ),
     );

--- a/packages/patrol/lib/src/native/native_automator2.dart
+++ b/packages/patrol/lib/src/native/native_automator2.dart
@@ -553,8 +553,7 @@ class NativeAutomator2 {
     String? appId,
     native_automator.KeyboardBehavior? keyboardBehavior,
     Duration? timeout,
-    double? dx,
-    double? dy,
+    Offset? tapLocation,
   }) async {
     await _wrapRequest(
       'enterText',
@@ -567,8 +566,8 @@ class NativeAutomator2 {
           keyboardBehavior:
               (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
-          dx: dx,
-          dy: dy,
+          dx: tapLocation?.dx,
+          dy: tapLocation?.dy,
         ),
       ),
     );
@@ -594,8 +593,7 @@ class NativeAutomator2 {
     String? appId,
     native_automator.KeyboardBehavior? keyboardBehavior,
     Duration? timeout,
-    double? dx,
-    double? dy,
+    Offset? tapLocation,
   }) async {
     await _wrapRequest(
       'enterTextByIndex',
@@ -607,8 +605,8 @@ class NativeAutomator2 {
           keyboardBehavior:
               (keyboardBehavior ?? _config.keyboardBehavior).toContractsEnum,
           timeoutMillis: timeout?.inMilliseconds,
-          dx: dx,
-          dy: dy,
+          dx: tapLocation?.dx,
+          dy: tapLocation?.dy,
         ),
       ),
     );


### PR DESCRIPTION
Since I had problems inserting a text into a keycloak password field on iOS Emulator, I analyzed the problem and found that a button placed right above the input field was the problem (Toggle Password Visibility Button). 

![image](https://github.com/user-attachments/assets/27acd9bd-e8ff-4053-b6c4-e574a9ec6ded)

By default for iOS, Patrol clicks on the relative position x:0.9, y:0.9 of the text field to be entered. So at the bottom right of the text field by default. However, in my example there is a button that intercepts pointer input. I have created a possibility to determine the relative position where the click in the text field takes place.

I added an `Offset tapLocation` to `enterText` and `enterTextByIndex` for both NativeAutomators. 

This only affects iOS, because as far as I have seen, android does not simulate a click on a specific position.