### PR TITLE
Fix closing keyboard when unfocusing from a textfield

### DIFF
--- a/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart
@@ -347,6 +347,10 @@ class PatrolTester {
         timeout: visibleTimeout,
       );
       await tester.enterText(resolvedFinder.first, text);
+      if (!kIsWeb) {
+        // When registering `testTextInput`, we have to unregister it
+        tester.testTextInput.unregister();
+      }
       await _performPump(
         settlePolicy: settlePolicy,
         settleTimeout: settleTimeout,


### PR DESCRIPTION
This PR fixes #2313.
Credits to @RepliedSage11, who created bug report and proposed this fix.