### PR TITLE
Fix checking java version

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Fix checking `java` version (#2301)
+
 ## 3.1.0
 - Add `tags` and `exclude-tags`. (#2286)
 - Run `flutter build apk --config-only` during android build.(#2293)


### PR DESCRIPTION
Closes #2301
Due to flutter command arguments not being passed, `fvm doctor` was run instead of `fvm flutter doctor` when using patrol with fvm. 
When listening to `javac` process, completers could have been completed multiple times (due to `onDone`, `onError` listeners), which eventually led to the error.