### PR TITLE
Add steps allowing conditional running test workflows on fork PRs

### DIFF
--- a/.github/workflows/test-android-emulator-webview.yaml
+++ b/.github/workflows/test-android-emulator-webview.yaml
@@ -4,8 +4,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 23 * * *"
-  pull_request:
-
+  pull_request_target:
+    types: [opened, synchronize]
+      
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -31,8 +32,27 @@ jobs:
         working-directory: dev/e2e_app
 
     steps:
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+
       - name: Clone repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{  github.event.pull_request.head.sha }}
 
       - name: Set up Java
         uses: actions/setup-java@v3

--- a/.github/workflows/test-android-emulator.yaml
+++ b/.github/workflows/test-android-emulator.yaml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 */12 * * *"
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -32,8 +33,27 @@ jobs:
         working-directory: dev/e2e_app
 
     steps:
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+
       - name: Clone repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{  github.event.pull_request.head.sha }}
 
       - name: Set up Java
         uses: actions/setup-java@v3


### PR DESCRIPTION
We want to be able to perform e2e tests on PRs that comes from forks. This change makes it possible but only when the workflow is triggered by someone with `write` access to the repository.

Inspired **heavily** by [this article](https://michaelheap.com/access-secrets-from-forks/).