### PR TITLE
Bump Flutter version in android emulator e2e tests to 3.24

### DIFF
--- a/.github/workflows/test-android-emulator-webview.yaml
+++ b/.github/workflows/test-android-emulator-webview.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flutter-version: ["3.22.x"]
+        flutter-version: ["3.24.x"]
         flutter-channel: ["stable"]
 
     defaults:

--- a/.github/workflows/test-android-emulator.yaml
+++ b/.github/workflows/test-android-emulator.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flutter-version: ["3.22.x"]
+        flutter-version: ["3.24.x"]
         flutter-channel: ["stable"]
 
     defaults:


### PR DESCRIPTION
I need to bump Flutter version in [test-android-emulator-webview.yaml](https://github.com/leancodepl/patrol/compare/chore/android-test-workflow?expand=1#diff-79bfedabaea22e255619e388faf93d102726f0ff2196351b3a5bf1c775211bbe) and [test-android-emulator.yaml](https://github.com/leancodepl/patrol/compare/chore/android-test-workflow?expand=1#diff-eee533b42fc62e5ab49931f2aea1ae9b61cb71fc551a53a848e78b0a51e6be18) in order to be able to run those workflows on #2343.