### PR TITLE
iOS: fix webview_stackoverflow_test and disable webview_leancode_test from workflow

### DIFF
--- a/.github/workflows/test-ios-simulator-webview.yaml
+++ b/.github/workflows/test-ios-simulator-webview.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Set tests to include
         run: |
           TESTS_TO_INCLUDE="webview_hackernews_test,\
-          webview_leancode_test,\
+          # webview_leancode_test,\  # See https://github.com/leancodepl/patrol/issues/2353
           webview_stackoverflow_test"
 
           target_paths=""

--- a/dev/e2e_app/integration_test/webview_stackoverflow_test.dart
+++ b/dev/e2e_app/integration_test/webview_stackoverflow_test.dart
@@ -30,6 +30,7 @@ void main() {
         'ny4ncat',
         index: 1,
         keyboardBehavior: KeyboardBehavior.alternative,
+        tapLocation: Offset(0.5, 0.5),
       );
       await $.native.tap(Selector(text: 'Log in'));
     },
@@ -74,6 +75,7 @@ void main() {
         'ny4ncat',
         index: 1,
         keyboardBehavior: KeyboardBehavior.alternative,
+        tapLocation: Offset(0.5, 0.5),
       );
       await $.native2.tap(
         NativeSelector(


### PR DESCRIPTION
- Fix webview_stackoverflow_test on iOS Simulator,
- Disable webview_leancode_test from test-ios-simulator-webview.yaml due to [this issue](https://github.com/leancodepl/patrol/issues/2353). 