### PR TITLE
Fix test name for androidx.test:orchestrator:1.5.0

### DIFF
--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
@@ -115,8 +115,8 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
             List<DartGroupEntry> dartTestCases = ContractsExtensionsKt.listTestsFlat(dartTestGroup, "");
             List<String> dartTestCaseNamesList = new ArrayList<>();
             for (DartGroupEntry dartTestCase : dartTestCases) {
-                dartTestCaseSkipMap.put(dartTestCase.getName(), dartTestCase.getSkip());
-                dartTestCaseNamesList.add(dartTestCase.getName());
+                dartTestCaseSkipMap.put(dartTestCase.getName().replace(" ", "-"), dartTestCase.getSkip());
+                dartTestCaseNamesList.add(dartTestCase.getName().replace(" ", "-"));
             }
             Object[] dartTestCaseNames = dartTestCaseNamesList.toArray();
             Logger.INSTANCE.i(TAG + "Got Dart tests: " + Arrays.toString(dartTestCaseNames));
@@ -142,7 +142,7 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
 
         try {
             Logger.INSTANCE.i(TAG + "Requested execution");
-            RunDartTestResponse response = patrolAppServiceClient.runDartTest(name);
+            RunDartTestResponse response = patrolAppServiceClient.runDartTest(name.replace("-", " "));
             if (response.getResult() == Contracts.RunDartTestResponseResult.failure) {
                 throw new AssertionError("Dart test failed: " + name + "\n" + response.getDetails());
             }


### PR DESCRIPTION
## Why?
- https://github.com/android/android-test/issues/2255
- Test name is currently under the form of `test_file test_group Test description` which contain spaces
- According to https://firebase.google.com/docs/test-lab/android/instrumentation-test#orchestrator: `Test Lab always uses the latest version of Orchestrator.`, which is 1.5.0 at the time of creating this PR
- Our Firebase Test Lab always throw the exact same exception and stacktrace as https://github.com/android/android-test/issues/2255, confirming that Firebase Test Lab ignore androidx.test:orchestrator version in app:build.gradle
- You can reproduce this error by using the Patrol example, with the latest version of both CLI and pub.dev dependency, by updating androidx.test:orchestrator from 1.4.2 to 1.5.0
