### PR TITLE
fix: Modify test names inside PatrolJUnitRunner to remove spaces

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.1
+
+- Replace whitespace in test case name in `PatrolJUnitRunner.java`. (#2361)
+
 ## 3.11.0
 
 - Add code coverage collection support. (#2294)

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
@@ -115,8 +115,9 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
             List<DartGroupEntry> dartTestCases = ContractsExtensionsKt.listTestsFlat(dartTestGroup, "");
             List<String> dartTestCaseNamesList = new ArrayList<>();
             for (DartGroupEntry dartTestCase : dartTestCases) {
-                dartTestCaseSkipMap.put(dartTestCase.getName(), dartTestCase.getSkip());
-                dartTestCaseNamesList.add(dartTestCase.getName());
+                final String testName = dartTestCase.getName().replace(" ", "__");
+                dartTestCaseSkipMap.put(testName, dartTestCase.getSkip());
+                dartTestCaseNamesList.add(testName);
             }
             Object[] dartTestCaseNames = dartTestCaseNamesList.toArray();
             Logger.INSTANCE.i(TAG + "Got Dart tests: " + Arrays.toString(dartTestCaseNames));
@@ -142,7 +143,7 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
 
         try {
             Logger.INSTANCE.i(TAG + "Requested execution");
-            RunDartTestResponse response = patrolAppServiceClient.runDartTest(name);
+            RunDartTestResponse response = patrolAppServiceClient.runDartTest(name.replace("__", " "));
             if (response.getResult() == Contracts.RunDartTestResponseResult.failure) {
                 throw new AssertionError("Dart test failed: " + name + "\n" + response.getDetails());
             }

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
@@ -35,6 +35,8 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
     public PatrolAppServiceClient patrolAppServiceClient;
     private Map<String, Boolean> dartTestCaseSkipMap = new HashMap<>();
 
+    private String spaceReplacement = "__";
+
     @Override
     protected boolean shouldWaitForActivitiesToComplete() {
         return false;
@@ -115,7 +117,7 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
             List<DartGroupEntry> dartTestCases = ContractsExtensionsKt.listTestsFlat(dartTestGroup, "");
             List<String> dartTestCaseNamesList = new ArrayList<>();
             for (DartGroupEntry dartTestCase : dartTestCases) {
-                final String testName = dartTestCase.getName().replace(" ", "__");
+                final String testName = sanitizeTestCaseName(dartTestCase.getName());
                 dartTestCaseSkipMap.put(testName, dartTestCase.getSkip());
                 dartTestCaseNamesList.add(testName);
             }
@@ -143,7 +145,7 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
 
         try {
             Logger.INSTANCE.i(TAG + "Requested execution");
-            RunDartTestResponse response = patrolAppServiceClient.runDartTest(name.replace("__", " "));
+            RunDartTestResponse response = patrolAppServiceClient.runDartTest(originalTestCaseName(name));
             if (response.getResult() == Contracts.RunDartTestResponseResult.failure) {
                 throw new AssertionError("Dart test failed: " + name + "\n" + response.getDetails());
             }
@@ -152,5 +154,20 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
             Logger.INSTANCE.e(TAG + e.getMessage(), e.getCause());
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * We need to remove whitespaces from test case name in order to make in compatible with Orchestrator 1.5.0.
+     * New requirement can be observed (<a href="https://github.com/android/android-test/commit/8383d784e51dd67972f79f7738e19e7e99706d23">here</a>).
+     * */
+    private String sanitizeTestCaseName(String name) {
+        return name.replace(" ", spaceReplacement);
+    }
+
+    /**
+     * When calling test on dart side, we need to bring back original test case name.
+    * */
+    private String originalTestCaseName(String name) {
+        return name.replace(spaceReplacement, " ");
     }
 }

--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -2,7 +2,7 @@ name: patrol
 description: >
   Powerful Flutter-native UI testing framework overcoming limitations of
   existing Flutter testing tools. Ready for action!
-version: 3.11.0
+version: 3.11.1
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues


### PR DESCRIPTION
Replaces spaces in the name returned by `listDartTest` with a version that does not contain spaces.
The change is also visible in the report, as it reflects the names of the tests (functions) that are executed as tests.

This PR is in fact slightly modified #2360 created by [tddang-linagora](https://github.com/tddang-linagora) so kudos to him for the initial work. 