### PR TITLE
Clear permissions between tests on iOS

### DIFF
--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -104,7 +104,7 @@ jobs:
           sleep 10 # See https://github.com/leancodepl/patrol/issues/1282
 
           TESTS_EXIT_CODE=0
-          patrol test --exclude ${{ env.EXCLUDED_TESTS }} --verbose || TESTS_EXIT_CODE=$?
+          patrol test --exclude ${{ env.EXCLUDED_TESTS }} --verbose --clear-permissions || TESTS_EXIT_CODE=$?
 
           kill -SIGINT $recordingpid
           kill -SIGINT $logpid

--- a/dev/e2e_app/integration_test/permissions/clear_permissions_test.dart
+++ b/dev/e2e_app/integration_test/permissions/clear_permissions_test.dart
@@ -9,6 +9,7 @@ void main() {
     await $('Open permissions screen').scrollTo().tap();
 
     await _requestAndGrantCameraPermission($);
+    await _requestAndGrantMicrophonePermission($);
   });
   patrol('grants various permissions 2', ($) async {
     await createApp($);
@@ -16,6 +17,7 @@ void main() {
     await $('Open permissions screen').scrollTo().tap();
 
     await _requestAndGrantCameraPermission($);
+    await _requestAndGrantMicrophonePermission($);
   });
 }
 
@@ -24,6 +26,17 @@ Future<void> _requestAndGrantCameraPermission(PatrolIntegrationTester $) async {
   await $('Request camera permission').tap();
   if (await $.native.isPermissionDialogVisible(timeout: _timeout)) {
     await $.native.grantPermissionWhenInUse();
+    await $.pump();
+  }
+}
+
+Future<void> _requestAndGrantMicrophonePermission(
+  PatrolIntegrationTester $,
+) async {
+  expect($(#microphone).$(#statusText).text, 'Not granted');
+  await $('Request microphone permission').tap();
+  if (await $.native.isPermissionDialogVisible(timeout: _timeout)) {
+    await $.native.grantPermissionOnlyThisTime();
     await $.pump();
   }
 }

--- a/dev/e2e_app/integration_test/permissions/clear_permissions_test.dart
+++ b/dev/e2e_app/integration_test/permissions/clear_permissions_test.dart
@@ -10,6 +10,7 @@ void main() {
 
     await _requestAndGrantCameraPermission($);
     await _requestAndGrantMicrophonePermission($);
+    await _requestAndGrantLocationPermission($);
   });
   patrol('grants various permissions 2', ($) async {
     await createApp($);
@@ -18,6 +19,7 @@ void main() {
 
     await _requestAndGrantCameraPermission($);
     await _requestAndGrantMicrophonePermission($);
+    await _requestAndGrantLocationPermission($);
   });
 }
 
@@ -35,6 +37,17 @@ Future<void> _requestAndGrantMicrophonePermission(
 ) async {
   expect($(#microphone).$(#statusText).text, 'Not granted');
   await $('Request microphone permission').tap();
+  if (await $.native.isPermissionDialogVisible(timeout: _timeout)) {
+    await $.native.grantPermissionOnlyThisTime();
+    await $.pump();
+  }
+}
+
+Future<void> _requestAndGrantLocationPermission(
+  PatrolIntegrationTester $,
+) async {
+  expect($(#location).$(#statusText).text, 'Not granted');
+  await $('Request location permission').tap();
   if (await $.native.isPermissionDialogVisible(timeout: _timeout)) {
     await $.native.grantPermissionOnlyThisTime();
     await $.pump();

--- a/dev/e2e_app/integration_test/permissions/clear_permissions_test.dart
+++ b/dev/e2e_app/integration_test/permissions/clear_permissions_test.dart
@@ -1,0 +1,29 @@
+import '../common.dart';
+
+const _timeout = Duration(seconds: 5); // to avoid timeouts on CI
+
+void main() {
+  patrol('grants various permissions', ($) async {
+    await createApp($);
+
+    await $('Open permissions screen').scrollTo().tap();
+
+    await _requestAndGrantCameraPermission($);
+  });
+  patrol('grants various permissions 2', ($) async {
+    await createApp($);
+
+    await $('Open permissions screen').scrollTo().tap();
+
+    await _requestAndGrantCameraPermission($);
+  });
+}
+
+Future<void> _requestAndGrantCameraPermission(PatrolIntegrationTester $) async {
+  expect($(#camera).$(#statusText).text, 'Not granted');
+  await $('Request camera permission').tap();
+  if (await $.native.isPermissionDialogVisible(timeout: _timeout)) {
+    await $.native.grantPermissionWhenInUse();
+    await $.pump();
+  }
+}

--- a/dev/e2e_app/integration_test/permissions/deny_many_permissions_twice_test.dart
+++ b/dev/e2e_app/integration_test/permissions/deny_many_permissions_twice_test.dart
@@ -16,8 +16,8 @@ void main() {
     await _requestAndDenyMicrophonePermission($);
     await _requestAndDenyMicrophonePermission($);
 
-    await _requestAndDenyContactsPermission($);
-    await _requestAndDenyContactsPermission($);
+    await _requestAndDenyLocationPermission($);
+    await _requestAndDenyLocationPermission($);
   });
 }
 
@@ -49,11 +49,11 @@ Future<void> _requestAndDenyMicrophonePermission(
   expect($(#microphone).$(#statusText).text, 'Not granted');
 }
 
-Future<void> _requestAndDenyContactsPermission(
+Future<void> _requestAndDenyLocationPermission(
   PatrolIntegrationTester $,
 ) async {
   if (!await Permission.contacts.isGranted) {
-    expect($(#contacts).$(#statusText).text, 'Not granted');
+    expect($(#location).$(#statusText).text, 'Not granted');
     await $('Request contacts permission').tap();
     if (await $.native.isPermissionDialogVisible(timeout: _timeout)) {
       await $.native.denyPermission();
@@ -61,5 +61,5 @@ Future<void> _requestAndDenyContactsPermission(
     }
   }
 
-  expect($(#contacts).$(#statusText).text, 'Not granted');
+  expect($(#location).$(#statusText).text, 'Not granted');
 }

--- a/dev/e2e_app/integration_test/permissions/deny_many_permissions_twice_test.dart
+++ b/dev/e2e_app/integration_test/permissions/deny_many_permissions_twice_test.dart
@@ -52,9 +52,9 @@ Future<void> _requestAndDenyMicrophonePermission(
 Future<void> _requestAndDenyLocationPermission(
   PatrolIntegrationTester $,
 ) async {
-  if (!await Permission.contacts.isGranted) {
+  if (!await Permission.location.isGranted) {
     expect($(#location).$(#statusText).text, 'Not granted');
-    await $('Request contacts permission').tap();
+    await $('Request location permission').tap();
     if (await $.native.isPermissionDialogVisible(timeout: _timeout)) {
       await $.native.denyPermission();
       await $.pump();

--- a/dev/e2e_app/integration_test/permissions/permissions_many_test.dart
+++ b/dev/e2e_app/integration_test/permissions/permissions_many_test.dart
@@ -12,7 +12,7 @@ void main() {
 
     await _requestAndGrantCameraPermission($);
     await _requestAndGrantMicrophonePermission($);
-    await _requestAndDenyContactsPermission($);
+    await _requestAndDenyLocationPermission($);
   });
 }
 
@@ -44,11 +44,11 @@ Future<void> _requestAndGrantMicrophonePermission(
   expect($(#microphone).$(#statusText).text, 'Granted');
 }
 
-Future<void> _requestAndDenyContactsPermission(
+Future<void> _requestAndDenyLocationPermission(
   PatrolIntegrationTester $,
 ) async {
-  if (!await Permission.contacts.isGranted) {
-    expect($(#contacts).$(#statusText).text, 'Not granted');
+  if (!await Permission.location.isGranted) {
+    expect($(#location).$(#statusText).text, 'Not granted');
     await $('Request contacts permission').tap();
     if (await $.native.isPermissionDialogVisible(timeout: _timeout)) {
       await $.native.denyPermission();
@@ -56,5 +56,5 @@ Future<void> _requestAndDenyContactsPermission(
     }
   }
 
-  expect($(#contacts).$(#statusText).text, 'Not granted');
+  expect($(#location).$(#statusText).text, 'Not granted');
 }

--- a/dev/e2e_app/integration_test/permissions/permissions_many_test.dart
+++ b/dev/e2e_app/integration_test/permissions/permissions_many_test.dart
@@ -49,7 +49,7 @@ Future<void> _requestAndDenyLocationPermission(
 ) async {
   if (!await Permission.location.isGranted) {
     expect($(#location).$(#statusText).text, 'Not granted');
-    await $('Request contacts permission').tap();
+    await $('Request location permission').tap();
     if (await $.native.isPermissionDialogVisible(timeout: _timeout)) {
       await $.native.denyPermission();
       await $.pump();

--- a/dev/e2e_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/dev/e2e_app/ios/Runner.xcodeproj/project.pbxproj
@@ -8,15 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		3A16A7A891650C176C30778F /* Pods_Runner_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B18DDD7DB44311F55B8FBAC /* Pods_Runner_RunnerUITests.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		51FAB981AF21A7BA28EAA01D /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE9611E92EB9F9C3E24E4795 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		983964DC2978A956007EB76F /* RunnerUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 983964DB2978A956007EB76F /* RunnerUITests.m */; };
 		9862560529F9A72100B267FA /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9862560429F9A72100B267FA /* RunnerTests.swift */; };
+		9EB122AD19AB87EF9A455AE0 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BC3560B4830BA000C071318 /* Pods_Runner.framework */; };
+		B0857128DF1F6A49AC8F8B45 /* Pods_Runner_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54E01A95706666750AB61B42 /* Pods_Runner_RunnerUITests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,15 +52,16 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		1CAFA55991482D2827868BBC /* Pods-Runner-RunnerUITests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.profile.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.profile.xcconfig"; sourceTree = "<group>"; };
+		21A84891CCDF0395C677C1FA /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		3E657AC8E202D4BE9F236453 /* Pods-Runner-RunnerUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.debug.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.debug.xcconfig"; sourceTree = "<group>"; };
-		5B18DDD7DB44311F55B8FBAC /* Pods_Runner_RunnerUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner_RunnerUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		437B59E3AFD5588395844415 /* Pods-Runner-RunnerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.release.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.release.xcconfig"; sourceTree = "<group>"; };
+		54E01A95706666750AB61B42 /* Pods_Runner_RunnerUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner_RunnerUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		61EF0D45B2EFB3231A29904D /* Pods-Runner-RunnerUITests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.profile.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.profile.xcconfig"; sourceTree = "<group>"; };
+		6BC3560B4830BA000C071318 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		75273ABBA75A9DB827CA72CB /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
-		8B49F10ED0F3AEA47F9419A9 /* Pods-Runner-RunnerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.release.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.release.xcconfig"; sourceTree = "<group>"; };
-		8CEE83C435018ACEAB31DA94 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -73,9 +74,8 @@
 		98575F2E29FA960A00AF8421 /* RunnerTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RunnerTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		9862560229F9A72100B267FA /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9862560429F9A72100B267FA /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
-		B4D1855B6A1A2B813F77F7AC /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		DCA20AF227EE6F4FD0EDFF29 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
-		DE9611E92EB9F9C3E24E4795 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C936D69C8587B6EF0FDCEC12 /* Pods-Runner-RunnerUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.debug.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		D4B72E459E8D5DA38685313A /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,7 +83,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				51FAB981AF21A7BA28EAA01D /* Pods_Runner.framework in Frameworks */,
+				9EB122AD19AB87EF9A455AE0 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -91,7 +91,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3A16A7A891650C176C30778F /* Pods_Runner_RunnerUITests.framework in Frameworks */,
+				B0857128DF1F6A49AC8F8B45 /* Pods_Runner_RunnerUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -105,24 +105,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1BA48497B0822771ADDC9C20 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				DE9611E92EB9F9C3E24E4795 /* Pods_Runner.framework */,
-				5B18DDD7DB44311F55B8FBAC /* Pods_Runner_RunnerUITests.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		71514460146D120DA8711EC5 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				B4D1855B6A1A2B813F77F7AC /* Pods-Runner.debug.xcconfig */,
-				DCA20AF227EE6F4FD0EDFF29 /* Pods-Runner.release.xcconfig */,
-				8CEE83C435018ACEAB31DA94 /* Pods-Runner.profile.xcconfig */,
-				3E657AC8E202D4BE9F236453 /* Pods-Runner-RunnerUITests.debug.xcconfig */,
-				8B49F10ED0F3AEA47F9419A9 /* Pods-Runner-RunnerUITests.release.xcconfig */,
-				1CAFA55991482D2827868BBC /* Pods-Runner-RunnerUITests.profile.xcconfig */,
+				21A84891CCDF0395C677C1FA /* Pods-Runner.debug.xcconfig */,
+				D4B72E459E8D5DA38685313A /* Pods-Runner.release.xcconfig */,
+				75273ABBA75A9DB827CA72CB /* Pods-Runner.profile.xcconfig */,
+				C936D69C8587B6EF0FDCEC12 /* Pods-Runner-RunnerUITests.debug.xcconfig */,
+				437B59E3AFD5588395844415 /* Pods-Runner-RunnerUITests.release.xcconfig */,
+				61EF0D45B2EFB3231A29904D /* Pods-Runner-RunnerUITests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -147,7 +138,7 @@
 				9862560329F9A72100B267FA /* RunnerTests */,
 				97C146EF1CF9000F007C117D /* Products */,
 				71514460146D120DA8711EC5 /* Pods */,
-				1BA48497B0822771ADDC9C20 /* Frameworks */,
+				A9EDE3A914EB8EA7657CFA4E /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -193,6 +184,15 @@
 			path = RunnerTests;
 			sourceTree = "<group>";
 		};
+		A9EDE3A914EB8EA7657CFA4E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				6BC3560B4830BA000C071318 /* Pods_Runner.framework */,
+				54E01A95706666750AB61B42 /* Pods_Runner_RunnerUITests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -200,14 +200,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				885D0EFA88B11BF5E5AC1B8E /* [CP] Check Pods Manifest.lock */,
+				5C9D315B699EF318EC999391 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* xcode_backend build */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* xcode_backend embed_and_thin */,
-				A8D5E21E8BC98A494C1E46CD /* [CP] Embed Pods Frameworks */,
+				99630BC56F6B45CF3ED3670B /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,13 +222,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 983964E12978A956007EB76F /* Build configuration list for PBXNativeTarget "RunnerUITests" */;
 			buildPhases = (
-				38F0C60ADAC89D16CDC28C92 /* [CP] Check Pods Manifest.lock */,
+				48CC73F6B1992D6DD8140860 /* [CP] Check Pods Manifest.lock */,
 				983964E62978A9F4007EB76F /* xcode_backend build */,
 				983964D52978A956007EB76F /* Sources */,
 				983964D62978A956007EB76F /* Frameworks */,
 				983964D72978A956007EB76F /* Resources */,
 				983964E52978A9D4007EB76F /* xcode_backend embed_and_thin */,
-				B82A5CCEBEC7517DCC30622A /* [CP] Embed Pods Frameworks */,
+				43FE5AEE72206FD010751A9E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -332,7 +332,38 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		38F0C60ADAC89D16CDC28C92 /* [CP] Check Pods Manifest.lock */ = {
+		3B06AD1E1E4923F5004D2608 /* xcode_backend embed_and_thin */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "xcode_backend embed_and_thin";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"Runner xcode_backend embed_and_thin\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
+		};
+		43FE5AEE72206FD010751A9E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		48CC73F6B1992D6DD8140860 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -354,21 +385,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3B06AD1E1E4923F5004D2608 /* xcode_backend embed_and_thin */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "xcode_backend embed_and_thin";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo \"Runner xcode_backend embed_and_thin\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
-		};
-		885D0EFA88B11BF5E5AC1B8E /* [CP] Check Pods Manifest.lock */ = {
+		5C9D315B699EF318EC999391 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -440,7 +457,7 @@
 			shellPath = /bin/sh;
 			shellScript = "echo \"RunnerUITests xcode_backend build\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
 		};
-		A8D5E21E8BC98A494C1E46CD /* [CP] Embed Pods Frameworks */ = {
+		99630BC56F6B45CF3ED3670B /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -455,23 +472,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B82A5CCEBEC7517DCC30622A /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -578,7 +578,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -656,7 +656,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -705,7 +705,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/dev/e2e_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/dev/e2e_app/ios/Runner.xcodeproj/project.pbxproj
@@ -8,15 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		162296CB6507E7D2B29D6854 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDD038C99EEC86DB1BE3B28B /* Pods_Runner.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		735C0DEADB7AD63E83BA5F87 /* Pods_Runner_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 70AA43B9B4C80C1C97015E37 /* Pods_Runner_RunnerUITests.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		983964DC2978A956007EB76F /* RunnerUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 983964DB2978A956007EB76F /* RunnerUITests.m */; };
 		9862560529F9A72100B267FA /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9862560429F9A72100B267FA /* RunnerTests.swift */; };
-		9EB122AD19AB87EF9A455AE0 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BC3560B4830BA000C071318 /* Pods_Runner.framework */; };
-		B0857128DF1F6A49AC8F8B45 /* Pods_Runner_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54E01A95706666750AB61B42 /* Pods_Runner_RunnerUITests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,16 +52,16 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		21A84891CCDF0395C677C1FA /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		17DC028A3CF64A70DB51B652 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		437B59E3AFD5588395844415 /* Pods-Runner-RunnerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.release.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.release.xcconfig"; sourceTree = "<group>"; };
-		54E01A95706666750AB61B42 /* Pods_Runner_RunnerUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner_RunnerUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		61EF0D45B2EFB3231A29904D /* Pods-Runner-RunnerUITests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.profile.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.profile.xcconfig"; sourceTree = "<group>"; };
-		6BC3560B4830BA000C071318 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		578A1CD38833007246EDDCC8 /* Pods-Runner-RunnerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.release.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.release.xcconfig"; sourceTree = "<group>"; };
+		6C9F904E13C17E9E13E86FE0 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		70AA43B9B4C80C1C97015E37 /* Pods_Runner_RunnerUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner_RunnerUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		75273ABBA75A9DB827CA72CB /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		79FE376A55F9C7A8275AA39F /* Pods-Runner-RunnerUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.debug.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		8EC67D1D3AB2F72F65370373 /* Pods-Runner-RunnerUITests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.profile.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -74,8 +74,8 @@
 		98575F2E29FA960A00AF8421 /* RunnerTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RunnerTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		9862560229F9A72100B267FA /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9862560429F9A72100B267FA /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
-		C936D69C8587B6EF0FDCEC12 /* Pods-Runner-RunnerUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.debug.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.debug.xcconfig"; sourceTree = "<group>"; };
-		D4B72E459E8D5DA38685313A /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		EDD038C99EEC86DB1BE3B28B /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F7164CC8571D465E673C3626 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,7 +83,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9EB122AD19AB87EF9A455AE0 /* Pods_Runner.framework in Frameworks */,
+				162296CB6507E7D2B29D6854 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -91,7 +91,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B0857128DF1F6A49AC8F8B45 /* Pods_Runner_RunnerUITests.framework in Frameworks */,
+				735C0DEADB7AD63E83BA5F87 /* Pods_Runner_RunnerUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -108,12 +108,12 @@
 		71514460146D120DA8711EC5 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				21A84891CCDF0395C677C1FA /* Pods-Runner.debug.xcconfig */,
-				D4B72E459E8D5DA38685313A /* Pods-Runner.release.xcconfig */,
-				75273ABBA75A9DB827CA72CB /* Pods-Runner.profile.xcconfig */,
-				C936D69C8587B6EF0FDCEC12 /* Pods-Runner-RunnerUITests.debug.xcconfig */,
-				437B59E3AFD5588395844415 /* Pods-Runner-RunnerUITests.release.xcconfig */,
-				61EF0D45B2EFB3231A29904D /* Pods-Runner-RunnerUITests.profile.xcconfig */,
+				F7164CC8571D465E673C3626 /* Pods-Runner.debug.xcconfig */,
+				17DC028A3CF64A70DB51B652 /* Pods-Runner.release.xcconfig */,
+				6C9F904E13C17E9E13E86FE0 /* Pods-Runner.profile.xcconfig */,
+				79FE376A55F9C7A8275AA39F /* Pods-Runner-RunnerUITests.debug.xcconfig */,
+				578A1CD38833007246EDDCC8 /* Pods-Runner-RunnerUITests.release.xcconfig */,
+				8EC67D1D3AB2F72F65370373 /* Pods-Runner-RunnerUITests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -138,7 +138,7 @@
 				9862560329F9A72100B267FA /* RunnerTests */,
 				97C146EF1CF9000F007C117D /* Products */,
 				71514460146D120DA8711EC5 /* Pods */,
-				A9EDE3A914EB8EA7657CFA4E /* Frameworks */,
+				DC5B5B2AC4D12BB8678F076E /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -184,11 +184,11 @@
 			path = RunnerTests;
 			sourceTree = "<group>";
 		};
-		A9EDE3A914EB8EA7657CFA4E /* Frameworks */ = {
+		DC5B5B2AC4D12BB8678F076E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				6BC3560B4830BA000C071318 /* Pods_Runner.framework */,
-				54E01A95706666750AB61B42 /* Pods_Runner_RunnerUITests.framework */,
+				EDD038C99EEC86DB1BE3B28B /* Pods_Runner.framework */,
+				70AA43B9B4C80C1C97015E37 /* Pods_Runner_RunnerUITests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -200,14 +200,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				5C9D315B699EF318EC999391 /* [CP] Check Pods Manifest.lock */,
+				91316CBA1E46E86DE7A4FB9D /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* xcode_backend build */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* xcode_backend embed_and_thin */,
-				99630BC56F6B45CF3ED3670B /* [CP] Embed Pods Frameworks */,
+				4BAB6BE95CF298CED1206D94 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,13 +222,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 983964E12978A956007EB76F /* Build configuration list for PBXNativeTarget "RunnerUITests" */;
 			buildPhases = (
-				48CC73F6B1992D6DD8140860 /* [CP] Check Pods Manifest.lock */,
+				57A729EC2F3211B458286925 /* [CP] Check Pods Manifest.lock */,
 				983964E62978A9F4007EB76F /* xcode_backend build */,
 				983964D52978A956007EB76F /* Sources */,
 				983964D62978A956007EB76F /* Frameworks */,
 				983964D72978A956007EB76F /* Resources */,
 				983964E52978A9D4007EB76F /* xcode_backend embed_and_thin */,
-				43FE5AEE72206FD010751A9E /* [CP] Embed Pods Frameworks */,
+				B778A6D350303A188769B23C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -346,24 +346,24 @@
 			shellPath = /bin/sh;
 			shellScript = "echo \"Runner xcode_backend embed_and_thin\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
 		};
-		43FE5AEE72206FD010751A9E /* [CP] Embed Pods Frameworks */ = {
+		4BAB6BE95CF298CED1206D94 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		48CC73F6B1992D6DD8140860 /* [CP] Check Pods Manifest.lock */ = {
+		57A729EC2F3211B458286925 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -385,7 +385,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5C9D315B699EF318EC999391 /* [CP] Check Pods Manifest.lock */ = {
+		91316CBA1E46E86DE7A4FB9D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -457,21 +457,21 @@
 			shellPath = /bin/sh;
 			shellScript = "echo \"RunnerUITests xcode_backend build\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
 		};
-		99630BC56F6B45CF3ED3670B /* [CP] Embed Pods Frameworks */ = {
+		B778A6D350303A188769B23C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -578,7 +578,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -656,7 +656,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -705,7 +705,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/dev/e2e_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/dev/e2e_app/ios/Runner.xcodeproj/project.pbxproj
@@ -8,15 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		3A16A7A891650C176C30778F /* Pods_Runner_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B18DDD7DB44311F55B8FBAC /* Pods_Runner_RunnerUITests.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		6090F033F64EF2E6EC73E939 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B67A70BD9498C1A200C5D078 /* Pods_Runner.framework */; };
+		51FAB981AF21A7BA28EAA01D /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE9611E92EB9F9C3E24E4795 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		983964DC2978A956007EB76F /* RunnerUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 983964DB2978A956007EB76F /* RunnerUITests.m */; };
 		9862560529F9A72100B267FA /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9862560429F9A72100B267FA /* RunnerTests.swift */; };
-		FA27315210C24EEDF8E3A8C2 /* Pods_Runner_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E89E9CC733F51B93EF71E1 /* Pods_Runner_RunnerUITests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,18 +50,17 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		039FF0702EF7414DA773B859 /* Pods-Runner-RunnerUITests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.profile.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.profile.xcconfig"; sourceTree = "<group>"; };
-		0CD8ADEABA35D9D53F0DF923 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		2F26359F19FF5877E6D9BB4A /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		1CAFA55991482D2827868BBC /* Pods-Runner-RunnerUITests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.profile.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.profile.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		6AD63AC0BB42D464CC8ABFC5 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		714A2CF42B7519C44AFD56B9 /* Pods-Runner-RunnerUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.debug.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		3E657AC8E202D4BE9F236453 /* Pods-Runner-RunnerUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.debug.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		5B18DDD7DB44311F55B8FBAC /* Pods_Runner_RunnerUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner_RunnerUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
-		93E89E9CC733F51B93EF71E1 /* Pods_Runner_RunnerUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner_RunnerUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8B49F10ED0F3AEA47F9419A9 /* Pods-Runner-RunnerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.release.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.release.xcconfig"; sourceTree = "<group>"; };
+		8CEE83C435018ACEAB31DA94 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -74,8 +73,9 @@
 		98575F2E29FA960A00AF8421 /* RunnerTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RunnerTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		9862560229F9A72100B267FA /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9862560429F9A72100B267FA /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
-		B447E7B3C41089DE3953018D /* Pods-Runner-RunnerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.release.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.release.xcconfig"; sourceTree = "<group>"; };
-		B67A70BD9498C1A200C5D078 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B4D1855B6A1A2B813F77F7AC /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		DCA20AF227EE6F4FD0EDFF29 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		DE9611E92EB9F9C3E24E4795 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,7 +83,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6090F033F64EF2E6EC73E939 /* Pods_Runner.framework in Frameworks */,
+				51FAB981AF21A7BA28EAA01D /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -91,7 +91,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA27315210C24EEDF8E3A8C2 /* Pods_Runner_RunnerUITests.framework in Frameworks */,
+				3A16A7A891650C176C30778F /* Pods_Runner_RunnerUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -105,15 +105,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1BA48497B0822771ADDC9C20 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				DE9611E92EB9F9C3E24E4795 /* Pods_Runner.framework */,
+				5B18DDD7DB44311F55B8FBAC /* Pods_Runner_RunnerUITests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		71514460146D120DA8711EC5 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				6AD63AC0BB42D464CC8ABFC5 /* Pods-Runner.debug.xcconfig */,
-				0CD8ADEABA35D9D53F0DF923 /* Pods-Runner.release.xcconfig */,
-				2F26359F19FF5877E6D9BB4A /* Pods-Runner.profile.xcconfig */,
-				714A2CF42B7519C44AFD56B9 /* Pods-Runner-RunnerUITests.debug.xcconfig */,
-				B447E7B3C41089DE3953018D /* Pods-Runner-RunnerUITests.release.xcconfig */,
-				039FF0702EF7414DA773B859 /* Pods-Runner-RunnerUITests.profile.xcconfig */,
+				B4D1855B6A1A2B813F77F7AC /* Pods-Runner.debug.xcconfig */,
+				DCA20AF227EE6F4FD0EDFF29 /* Pods-Runner.release.xcconfig */,
+				8CEE83C435018ACEAB31DA94 /* Pods-Runner.profile.xcconfig */,
+				3E657AC8E202D4BE9F236453 /* Pods-Runner-RunnerUITests.debug.xcconfig */,
+				8B49F10ED0F3AEA47F9419A9 /* Pods-Runner-RunnerUITests.release.xcconfig */,
+				1CAFA55991482D2827868BBC /* Pods-Runner-RunnerUITests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -138,7 +147,7 @@
 				9862560329F9A72100B267FA /* RunnerTests */,
 				97C146EF1CF9000F007C117D /* Products */,
 				71514460146D120DA8711EC5 /* Pods */,
-				E54C552FCC7A91D75B1E4F09 /* Frameworks */,
+				1BA48497B0822771ADDC9C20 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -184,15 +193,6 @@
 			path = RunnerTests;
 			sourceTree = "<group>";
 		};
-		E54C552FCC7A91D75B1E4F09 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				B67A70BD9498C1A200C5D078 /* Pods_Runner.framework */,
-				93E89E9CC733F51B93EF71E1 /* Pods_Runner_RunnerUITests.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -200,14 +200,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				01FBF9092C877C4910CAC196 /* [CP] Check Pods Manifest.lock */,
+				885D0EFA88B11BF5E5AC1B8E /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* xcode_backend build */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* xcode_backend embed_and_thin */,
-				E621EC4C03882F1FC407353C /* [CP] Embed Pods Frameworks */,
+				A8D5E21E8BC98A494C1E46CD /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,13 +222,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 983964E12978A956007EB76F /* Build configuration list for PBXNativeTarget "RunnerUITests" */;
 			buildPhases = (
-				CCBA4E2120CD0A4549A78A05 /* [CP] Check Pods Manifest.lock */,
+				38F0C60ADAC89D16CDC28C92 /* [CP] Check Pods Manifest.lock */,
 				983964E62978A9F4007EB76F /* xcode_backend build */,
 				983964D52978A956007EB76F /* Sources */,
 				983964D62978A956007EB76F /* Frameworks */,
 				983964D72978A956007EB76F /* Resources */,
 				983964E52978A9D4007EB76F /* xcode_backend embed_and_thin */,
-				FB0F1ED3C61A5044791AC712 /* [CP] Embed Pods Frameworks */,
+				B82A5CCEBEC7517DCC30622A /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -332,7 +332,43 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		01FBF9092C877C4910CAC196 /* [CP] Check Pods Manifest.lock */ = {
+		38F0C60ADAC89D16CDC28C92 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-RunnerUITests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3B06AD1E1E4923F5004D2608 /* xcode_backend embed_and_thin */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "xcode_backend embed_and_thin";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"Runner xcode_backend embed_and_thin\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
+		};
+		885D0EFA88B11BF5E5AC1B8E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -353,20 +389,6 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
-		};
-		3B06AD1E1E4923F5004D2608 /* xcode_backend embed_and_thin */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "xcode_backend embed_and_thin";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo \"Runner xcode_backend embed_and_thin\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
 		};
 		9740EEB61CF901F6004384FC /* xcode_backend build */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -418,29 +440,7 @@
 			shellPath = /bin/sh;
 			shellScript = "echo \"RunnerUITests xcode_backend build\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
 		};
-		CCBA4E2120CD0A4549A78A05 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Runner-RunnerUITests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E621EC4C03882F1FC407353C /* [CP] Embed Pods Frameworks */ = {
+		A8D5E21E8BC98A494C1E46CD /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -457,7 +457,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		FB0F1ED3C61A5044791AC712 /* [CP] Embed Pods Frameworks */ = {
+		B82A5CCEBEC7517DCC30622A /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -578,7 +578,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -656,7 +656,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -705,7 +705,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/dev/e2e_app/ios/Runner/AppDelegate.swift
+++ b/dev/e2e_app/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Flutter
 import UIKit
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/dev/e2e_app/lib/permissions_screen.dart
+++ b/dev/e2e_app/lib/permissions_screen.dart
@@ -13,7 +13,7 @@ class PermissionsScreen extends StatefulWidget {
 class _PermissionsScreenState extends State<PermissionsScreen> {
   bool _cameraPermissionGranted = false;
   bool _microphonePermissionGranted = false;
-  bool _contactsPermissionGranted = false;
+  bool _locationPermissionGranted = false;
 
   Future<void> _requestCameraPermission() async {
     await Future<void>.delayed(Duration(seconds: 1));
@@ -31,10 +31,10 @@ class _PermissionsScreenState extends State<PermissionsScreen> {
     });
   }
 
-  Future<void> _requestContactsPermission() async {
-    final status = await Permission.contacts.request();
+  Future<void> _requestLocationPermission() async {
+    final status = await Permission.location.request();
     setState(() {
-      _contactsPermissionGranted = status == PermissionStatus.granted;
+      _locationPermissionGranted = status == PermissionStatus.granted;
     });
   }
 
@@ -57,6 +57,15 @@ class _PermissionsScreenState extends State<PermissionsScreen> {
         (value) {
           setState(() {
             _microphonePermissionGranted = value == PermissionStatus.granted;
+          });
+        },
+      ),
+    );
+    unawaited(
+      Permission.location.status.then(
+        (value) {
+          setState(() {
+            _locationPermissionGranted = value == PermissionStatus.granted;
           });
         },
       ),
@@ -85,10 +94,10 @@ class _PermissionsScreenState extends State<PermissionsScreen> {
               onTap: _requestMicrophonePermission,
             ),
             _PermissionTile(
-              name: 'Contacts',
-              icon: Icons.people,
-              granted: _contactsPermissionGranted,
-              onTap: _requestContactsPermission,
+              name: 'Location',
+              icon: Icons.pin_drop,
+              granted: _locationPermissionGranted,
+              onTap: _requestLocationPermission,
             ),
           ],
         ),

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add `clear-permissions` flag on ios commands. (#2367)
+
 ## 3.11.2
 
 - Bump min Flutter SDK to 3.24.0 and Dart SDK to 3.5.0 (#2371)

--- a/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
+++ b/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
@@ -9,6 +9,7 @@
 
 // For every Flutter dart test, dynamically generate an Objective-C method mirroring the test results
 // so it is reported as a native XCTest run result.
+#ifdef CLEAR_PERMISSIONS
 #define PATROL_INTEGRATION_TEST_IOS_RUNNER(__test_class)                                                        \
   @interface __test_class : XCTestCase                                                                          \
   @property(class, strong, nonatomic) NSDictionary *selectedTest;                                               \
@@ -40,6 +41,7 @@
   }                                                                                                             \
                                                                                                                 \
   +(void)resetPermissions {                                                                                     \
+    NSLog(@"Clearing permissions");                                                                             \
     XCUIApplication *app = [[XCUIApplication alloc] init];                                                      \
     if (@available(iOS 13.4, *)) {                                                                              \
       [app resetAuthorizationStatusForResource:XCUIProtectedResourceLocation];                                  \
@@ -67,6 +69,7 @@
   }                                                                                                             \
                                                                                                                 \
   +(NSArray<NSInvocation *> *)testInvocations {                                                                 \
+    NSLog(@"Running tests with clearing permissions");                                                          \
     /* Start native automation server */                                                                        \
     PatrolServer *server = [[PatrolServer alloc] init];                                                         \
                                                                                                                 \
@@ -176,4 +179,148 @@
     return invocations;                                                                                         \
   }                                                                                                             \
                                                                                                                 \
-  @end\
+@end
+#else
+#define PATROL_INTEGRATION_TEST_IOS_RUNNER(__test_class)                                                        \
+  @interface __test_class : XCTestCase                                                                          \
+  @property(class, strong, nonatomic) NSDictionary *selectedTest;                                               \
+  @end                                                                                                          \
+                                                                                                                \
+  @implementation __test_class                                                                                  \
+                                                                                                                \
+  static NSDictionary *_selectedTest = nil;                                                                     \
+                                                                                                                \
+  +(NSDictionary *)selectedTest {                                                                               \
+    return _selectedTest;                                                                                       \
+  }                                                                                                             \
+                                                                                                                \
+  +(void)setSelectedTest : (NSDictionary *)newSelectedTest {                                                    \
+    if (newSelectedTest != _selectedTest) {                                                                     \
+      _selectedTest = [newSelectedTest copy];                                                                   \
+    }                                                                                                           \
+  }                                                                                                             \
+                                                                                                                \
+  +(BOOL)instancesRespondToSelector : (SEL)aSelector {                                                          \
+    NSString *name = NSStringFromSelector(aSelector);                                                           \
+    BOOL skip = NO;                                                                                             \
+    NSDictionary *testInfo = @{@"name" : name, @"skip" : @(skip)};                                              \
+    [self setSelectedTest:testInfo];                                                                            \
+                                                                                                                \
+    [self defaultTestSuite]; /* calls testInvocations */                                                        \
+    BOOL result = [super instancesRespondToSelector:aSelector];                                                 \
+    return true;                                                                                                \
+  }                                                                                                             \
+                                                                                                                \
+                                                                                                                \
+  +(NSArray<NSInvocation *> *)testInvocations {                                                                 \
+    NSLog(@"Running tests without clearing permissions");                                                       \
+    /* Start native automation server */                                                                        \
+    PatrolServer *server = [[PatrolServer alloc] init];                                                         \
+                                                                                                                \
+    NSError *_Nullable __autoreleasing *_Nullable err = NULL;                                                   \
+    [server startAndReturnError:err];                                                                           \
+    if (err != NULL) {                                                                                          \
+      NSLog(@"patrolServer.start(): failed, err: %@", err);                                                     \
+    }                                                                                                           \
+                                                                                                                \
+    /* Create a client for PatrolAppService, which lets us list and run Dart tests */                           \
+    __block ObjCPatrolAppServiceClient *appServiceClient = [[ObjCPatrolAppServiceClient alloc] init];           \
+                                                                                                                \
+    /* Allow the Local Network permission required by Dart Observatory */                                       \
+    XCUIApplication *springboard = [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"]; \
+    XCUIElementQuery *systemAlerts = springboard.alerts;                                                        \
+    if (systemAlerts.buttons[@"Allow"].exists) {                                                                \
+      [systemAlerts.buttons[@"Allow"] tap];                                                                     \
+    }                                                                                                           \
+                                                                                                                \
+    __block NSArray<NSDictionary *> *dartTests = NULL;                                                          \
+    if ([self selectedTest] != nil) {                                                                           \
+      NSLog(@"selectedTest: %@", [self selectedTest]);                                                          \
+      dartTests = [NSArray arrayWithObject:[self selectedTest]];                                                \
+    } else {                                                                                                    \
+      /* Run the app for the first time to gather Dart tests */                                                 \
+      [[[XCUIApplication alloc] init] launch];                                                                  \
+      /* Spin the runloop waiting until the app reports that it is ready to report Dart tests */                \
+      while (!server.appReady) {                                                                                \
+        [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];                      \
+      }                                                                                                         \
+      [appServiceClient                                                                                         \
+          listDartTestsWithCompletion:^(NSArray<NSDictionary *> *_Nullable tests, NSError *_Nullable err) {     \
+            if (err != NULL) {                                                                                  \
+              NSLog(@"listDartTests(): failed, err: %@", err);                                                  \
+            }                                                                                                   \
+                                                                                                                \
+            dartTests = tests;                                                                                  \
+          }];                                                                                                   \
+                                                                                                                \
+      /* Spin the runloop waiting until the app reports the Dart tests it contains */                           \
+      while (!dartTests) {                                                                                      \
+        [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];                      \
+      }                                                                                                         \
+                                                                                                                \
+      NSLog(@"Got %lu Dart tests: %@", dartTests.count, dartTests);                                             \
+    }                                                                                                           \
+                                                                                                                \
+    NSMutableArray<NSInvocation *> *invocations = [[NSMutableArray alloc] init];                                \
+                                                                                                                \
+    /**                                                                                                         \
+     * Once Dart tests are available, we:                                                                       \
+     *                                                                                                          \
+     *  Step 1. Dynamically add test case methods that request execution of an individual Dart test file.       \
+     *                                                                                                          \
+     *  Step 2. Create invocations to the generated methods and return them                                     \
+     */                                                                                                         \
+                                                                                                                \
+    for (NSDictionary * dartTest in dartTests) {                                                                \
+      /* Step 1 - dynamically create test cases */                                                              \
+      NSString *dartTestName = dartTest[@"name"];                                                               \
+      BOOL skip = [dartTest[@"skip"] boolValue];                                                                \
+                                                                                                                \
+      IMP implementation = imp_implementationWithBlock(^(id _self) {                                            \
+        [[[XCUIApplication alloc] init] launch];                                                                \
+        if (skip) {                                                                                             \
+          XCTSkip(@"Skip that test \"%@\"", dartTestName);                                                      \
+        }                                                                                                       \
+                                                                                                                \
+        __block ObjCRunDartTestResponse *response = NULL;                                                       \
+        __block NSError *error;                                                                                 \
+        [appServiceClient                                                                                       \
+            runDartTestWithName:dartTestName                                                                    \
+                     completion:^(ObjCRunDartTestResponse *_Nullable r, NSError *_Nullable err) {               \
+                       NSString *status;                                                                        \
+                       if (err != NULL) {                                                                       \
+                         error = err;                                                                           \
+                         status = @"CRASHED";                                                                   \
+                       } else {                                                                                 \
+                         response = r;                                                                          \
+                         status = response.passed ? @"PASSED" : @"FAILED";                                      \
+                       }                                                                                        \
+                       NSLog(@"runDartTest(\"%@\"): call finished, test result: %@", dartTestName, status);     \
+                     }];                                                                                        \
+                                                                                                                \
+        /* Wait until Dart test finishes (either fails or passes) or crashes */                                 \
+        while (!response && !error) {                                                                           \
+          [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];                    \
+        }                                                                                                       \
+        BOOL passed = response ? response.passed : NO;                                                          \
+        NSString *details = response ? response.details : @"(no details - app likely crashed)";                 \
+        XCTAssertTrue(passed, @"%@", details);                                                                  \
+      });                                                                                                       \
+      SEL selector = NSSelectorFromString(dartTestName);                                                        \
+      class_addMethod(self, selector, implementation, "v@:");                                                   \
+                                                                                                                \
+      /* Step 2 – create invocations to the dynamically created methods */                                      \
+      NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];                        \
+      NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];                        \
+      invocation.selector = selector;                                                                           \
+                                                                                                                \
+      NSLog(@"RunnerUITests.testInvocations(): selectorName = %@, signature: %@", dartTestName, signature);     \
+                                                                                                                \
+      [invocations addObject:invocation];                                                                       \
+    }                                                                                                           \
+                                                                                                                \
+    return invocations;                                                                                         \
+  }                                                                                                             \
+                                                                                                                \
+@end
+#endif

--- a/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
+++ b/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
@@ -40,7 +40,6 @@
   }                                                                                                             \
                                                                                                                 \
   +(void)resetPermissions {                                                                                     \
-    XCUIApplication *app = [[XCUIApplication alloc] init];                                                      \
     if (@available(iOS 13.4, *)) {                                                                              \
       [app resetAuthorizationStatusForResource:XCUIProtectedResourceLocation];                                  \
       [app resetAuthorizationStatusForResource:XCUIProtectedResourceContacts];                                  \

--- a/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
+++ b/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
@@ -40,6 +40,7 @@
   }                                                                                                             \
                                                                                                                 \
   +(void)resetPermissions {                                                                                     \
+    XCUIApplication *app = [[XCUIApplication alloc] init];                                                      \
     if (@available(iOS 13.4, *)) {                                                                              \
       [app resetAuthorizationStatusForResource:XCUIProtectedResourceLocation];                                  \
       [app resetAuthorizationStatusForResource:XCUIProtectedResourceContacts];                                  \

--- a/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
+++ b/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
@@ -103,7 +103,9 @@
       BOOL skip = [dartTest[@"skip"] boolValue];                                                                \
                                                                                                                 \
       IMP implementation = imp_implementationWithBlock(^(id _self) {                                            \
-        [[[XCUIApplication alloc] init] launch];                                                                \
+        XCUIApplication *app = [[XCUIApplication alloc] init];                                                  \
+        [app resetAuthorizationStatusForResource:XCUIProtectedResourceCamera];                                  \
+        [app launch];                                                                                           \
         if (skip) {                                                                                             \
           XCTSkip(@"Skip that test \"%@\"", dartTestName);                                                      \
         }                                                                                                       \

--- a/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
+++ b/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
@@ -53,6 +53,19 @@
       [app resetAuthorizationStatusForResource:XCUIProtectedResourceMediaLibrary];                              \
       [app resetAuthorizationStatusForResource:XCUIProtectedResourceKeyboardNetwork];                           \
     }                                                                                                           \
+    if (@available(iOS 14.0, *)) {                                                                              \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceHealth];                                    \
+    }                                                                                                           \
+    if (@available(iOS 15.0, *)) {                                                                              \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceUserTracking];                              \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceFocus];                                     \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceRemovableVolumes];                          \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceNetworkVolumes];                            \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceAppleEvents];                               \
+    }                                                                                                           \
+    if (@available(iOS 15.4, *)) {                                                                              \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceLocalNetwork];                              \
+    }                                                                                                           \
   }                                                                                                             \
                                                                                                                 \
   +(NSArray<NSInvocation *> *)testInvocations {                                                                 \

--- a/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
+++ b/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
@@ -166,7 +166,7 @@
       SEL selector = NSSelectorFromString(dartTestName);                                                        \
       class_addMethod(self, selector, implementation, "v@:");                                                   \
                                                                                                                 \
-      /* Step 2 – create invocations to the dynamically created methods */                                    \
+      /* Step 2 – create invocations to the dynamically created methods */                                      \
       NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];                        \
       NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];                        \
       invocation.selector = selector;                                                                           \
@@ -308,7 +308,7 @@
       SEL selector = NSSelectorFromString(dartTestName);                                                        \
       class_addMethod(self, selector, implementation, "v@:");                                                   \
                                                                                                                 \
-      /* Step 2 – create invocations to the dynamically created methods */                                    \
+      /* Step 2 – create invocations to the dynamically created methods */                                      \
       NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];                        \
       NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];                        \
       invocation.selector = selector;                                                                           \

--- a/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
+++ b/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
@@ -60,9 +60,6 @@
     if (@available(iOS 15.0, *)) {                                                                              \
       [app resetAuthorizationStatusForResource:XCUIProtectedResourceUserTracking];                              \
       [app resetAuthorizationStatusForResource:XCUIProtectedResourceFocus];                                     \
-      [app resetAuthorizationStatusForResource:XCUIProtectedResourceRemovableVolumes];                          \
-      [app resetAuthorizationStatusForResource:XCUIProtectedResourceNetworkVolumes];                            \
-      [app resetAuthorizationStatusForResource:XCUIProtectedResourceAppleEvents];                               \
     }                                                                                                           \
     if (@available(iOS 15.4, *)) {                                                                              \
       [app resetAuthorizationStatusForResource:XCUIProtectedResourceLocalNetwork];                              \

--- a/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
+++ b/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
@@ -39,6 +39,23 @@
     return true;                                                                                                \
   }                                                                                                             \
                                                                                                                 \
+  +(void)resetPermissions {                                                                                     \
+    XCUIApplication *app = [[XCUIApplication alloc] init];                                                      \
+    if (@available(iOS 13.4, *)) {                                                                              \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceLocation];                                  \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceContacts];                                  \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceCalendar];                                  \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceReminders];                                 \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourcePhotos];                                    \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceBluetooth];                                 \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceMicrophone];                                \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceCamera];                                    \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceHomeKit];                                   \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceMediaLibrary];                              \
+      [app resetAuthorizationStatusForResource:XCUIProtectedResourceKeyboardNetwork];                           \
+    }                                                                                                           \
+  }                                                                                                             \
+                                                                                                                \
   +(NSArray<NSInvocation *> *)testInvocations {                                                                 \
     /* Start native automation server */                                                                        \
     PatrolServer *server = [[PatrolServer alloc] init];                                                         \
@@ -103,9 +120,8 @@
       BOOL skip = [dartTest[@"skip"] boolValue];                                                                \
                                                                                                                 \
       IMP implementation = imp_implementationWithBlock(^(id _self) {                                            \
-        XCUIApplication *app = [[XCUIApplication alloc] init];                                                  \
-        [app resetAuthorizationStatusForResource:XCUIProtectedResourceCamera];                                  \
-        [app launch];                                                                                           \
+        [self resetPermissions];                                                                                \
+        [[[XCUIApplication alloc] init] launch];                                                                \
         if (skip) {                                                                                             \
           XCTSkip(@"Skip that test \"%@\"", dartTestName);                                                      \
         }                                                                                                       \

--- a/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
+++ b/packages/patrol/darwin/Classes/PatrolIntegrationTestIosRunner.h
@@ -166,7 +166,7 @@
       SEL selector = NSSelectorFromString(dartTestName);                                                        \
       class_addMethod(self, selector, implementation, "v@:");                                                   \
                                                                                                                 \
-      /* Step 2 – create invocations to the dynamically created methods */                                      \
+      /* Step 2 – create invocations to the dynamically created methods */                                    \
       NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];                        \
       NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];                        \
       invocation.selector = selector;                                                                           \
@@ -179,7 +179,7 @@
     return invocations;                                                                                         \
   }                                                                                                             \
                                                                                                                 \
-@end
+  @end
 #else
 #define PATROL_INTEGRATION_TEST_IOS_RUNNER(__test_class)                                                        \
   @interface __test_class : XCTestCase                                                                          \
@@ -210,7 +210,6 @@
     BOOL result = [super instancesRespondToSelector:aSelector];                                                 \
     return true;                                                                                                \
   }                                                                                                             \
-                                                                                                                \
                                                                                                                 \
   +(NSArray<NSInvocation *> *)testInvocations {                                                                 \
     NSLog(@"Running tests without clearing permissions");                                                       \
@@ -309,7 +308,7 @@
       SEL selector = NSSelectorFromString(dartTestName);                                                        \
       class_addMethod(self, selector, implementation, "v@:");                                                   \
                                                                                                                 \
-      /* Step 2 – create invocations to the dynamically created methods */                                      \
+      /* Step 2 – create invocations to the dynamically created methods */                                    \
       NSMethodSignature *signature = [self instanceMethodSignatureForSelector:selector];                        \
       NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];                        \
       invocation.selector = selector;                                                                           \
@@ -322,5 +321,5 @@
     return invocations;                                                                                         \
   }                                                                                                             \
                                                                                                                 \
-@end
+  @end
 #endif

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add `clear-permissions` flag on ios commands. (#2367)
+
 ## 3.2.1
 
 - Allow running Patrol tests from any subfolder of the project (#2351)

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -157,6 +157,7 @@ class BuildIOSCommand extends PatrolCommand {
       simulator: boolArg('simulator'),
       appServerPort: super.appServerPort,
       testServerPort: super.testServerPort,
+      clearPermissions: boolArg('clear-permissions'),
     );
 
     try {

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -233,6 +233,7 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
       simulator: !device.real,
       appServerPort: super.appServerPort,
       testServerPort: super.testServerPort,
+      clearPermissions: boolArg('clear-permissions'),
     );
 
     final macosOpts = MacOSAppOptions(

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -148,6 +148,7 @@ class IOSAppOptions {
     required this.simulator,
     required this.appServerPort,
     required this.testServerPort,
+    this.clearPermissions = false,
   });
 
   final FlutterAppOptions flutter;
@@ -157,6 +158,7 @@ class IOSAppOptions {
   final bool simulator;
   final int appServerPort;
   final int testServerPort;
+  final bool clearPermissions;
 
   String get description {
     final platform = simulator ? 'simulator' : 'device';
@@ -208,6 +210,8 @@ class IOSAppOptions {
       '-quiet',
       ...['-derivedDataPath', '../build/ios_integ'],
       r'OTHER_SWIFT_FLAGS=$(inherited) -D PATROL_ENABLED',
+      if (clearPermissions)
+        r'GCC_PREPROCESSOR_DEFINITIONS=$(inherited) CLEAR_PERMISSIONS=1',
     ];
 
     return cmd;

--- a/packages/patrol_cli/lib/src/runner/patrol_command.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command.dart
@@ -165,7 +165,7 @@ abstract class PatrolCommand extends Command<int> {
       ..addFlag(
         'clear-permissions',
         help:
-            '*Experimental* Clear permissions available through XCUIProtectedResource API before running each test.',
+            'Clear permissions available through XCUIProtectedResource API before running each test.',
         negatable: false,
       );
   }

--- a/packages/patrol_cli/lib/src/runner/patrol_command.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command.dart
@@ -156,11 +156,18 @@ abstract class PatrolCommand extends Command<int> {
   }
 
   void usesIOSOptions() {
-    argParser.addOption(
-      'bundle-id',
-      help: 'Bundle identifier of the iOS app under test.',
-      valueHelp: 'pl.leancode.AwesomeApp',
-    );
+    argParser
+      ..addOption(
+        'bundle-id',
+        help: 'Bundle identifier of the iOS app under test.',
+        valueHelp: 'pl.leancode.AwesomeApp',
+      )
+      ..addFlag(
+        'clear-permissions',
+        help:
+            '*Experimental* Clear permissions available through XCUIProtectedResource API before running each test.',
+        negatable: false,
+      );
   }
 
   void usesMacOSOptions() {


### PR DESCRIPTION
Issue: #2366 

Resetting permissions on iOS is available from iOS 13.4, but some permissions require a higher version (check #2366).

Permissions with error `use of undeclared identifier`:
```
XCUIProtectedResourceAppleEvents
XCUIProtectedResourceRemovableVolumes
XCUIProtectedResourceNetworkVolumes
XCUIProtectedResourceUserDownloadsDirectory
XCUIProtectedResourceUserDocumentsDirectory
XCUIProtectedResourceUserDesktopDirectory
XCUIProtectedResourceSystemRootDirectory
```

These should be investigated further.

The `clear_permissions_test.dart` has only few permissions tested, because there is an issue with getting `PermissionStatus.permanentlyDenied` status for them.

I've reverted ios target to 11.0 and the test passed 👀 


TODO:
- Changes should also include a parameter that would turn clearing permissions on.


https://github.com/user-attachments/assets/59088842-26c9-45bc-8a9a-951757caff18

