### PR TITLE
Added Flutter compatibility information to the compatibility-table.mdx 

### DIFF
--- a/docs/compatibility-table.mdx
+++ b/docs/compatibility-table.mdx
@@ -13,7 +13,7 @@ the table below to assess which version you should use.
 
 | patrol_cli            | patrol            | Flutter Version |
 |-----------------------|-------------------|-----------------|
-| 3.2.0+                | 3.11.0+           | 3.16+           |
+| 3.2.0+                | 3.11.0+           | 3.22+           |
 | 3.1.0 - 3.1.1         | 3.10.0            | 3.10 – 3.15     |
 | 2.6.5 - 3.0.1         | 3.6.0 - 3.10.0    | 3.0 – 3.9       |
 | 2.6.0 - 2.6.4         | 3.4.0 - 3.5.2     | 2.10 – 2.17     |
@@ -23,6 +23,4 @@ the table below to assess which version you should use.
 | 2.0.0                 | 2.0.0             | 2.0             |
 | 1.1.4 - 1.1.11        | 1.0.9 - 1.1.11    | 1.x             |
 
-->Why Flutter 3.16+? : `Patrol v3` requires `Flutter 3.16` or newer due to changes in the flutter_test package, impacting its compatibility​
 
-->Backwards Compatibility : Older `Patrol versions` are mapped against Flutter versions to ensure users can easily pick compatible versions.

--- a/docs/compatibility-table.mdx
+++ b/docs/compatibility-table.mdx
@@ -4,23 +4,22 @@ title: Compatibility table
 
 # Compatibility table
 
-The following table describes which versions of `patrol`
-and `patrol_cli` are compatible with each other.
+The following table describes which versions of `patrol` , `patrol_cli` and `flutter` are compatible with each other and 
 The simplest way to ensure that both packages are compatible
 is by always using the latest version. However,
 if for some reason that isn't possible, you can refer to 
 the table below to assess which version you should use.
 
-| patrol_cli            | patrol            | Flutter Version |
-|-----------------------|-------------------|-----------------|
-| 3.2.0+                | 3.11.0+           | 3.22+           |
-| 3.1.0 - 3.1.1         | 3.10.0            | 3.10 – 3.15     |
-| 2.6.5 - 3.0.1         | 3.6.0 - 3.10.0    | 3.0 – 3.9       |
-| 2.6.0 - 2.6.4         | 3.4.0 - 3.5.2     | 2.10 – 2.17     |
-| 2.3.0 - 2.5.0         | 3.0.0 - 3.3.0     | 2.5 – 2.9       |
-| 2.2.0 - 2.2.2         | 2.3.0 - 2.3.2     | 2.0 – 2.4       |
-| 2.0.1 - 2.1.5         | 2.0.1 - 2.2.5     | 2.0 – 2.2       |
-| 2.0.0                 | 2.0.0             | 2.0             |
-| 1.1.4 - 1.1.11        | 1.0.9 - 1.1.11    | 1.x             |
+| patrol_cli            | patrol            | min flutter version |
+|-----------------------|-------------------|---------------------|
+| 3.2.0+                | 3.11.0+           | 3.22+               |
+| 3.1.0 - 3.1.1         | 3.10.0            | 3.10                |
+| 2.6.5 - 3.0.1         | 3.6.0 - 3.10.0    | 3.0                 |
+| 2.6.0 - 2.6.4         | 3.4.0 - 3.5.2     | 2.10                |
+| 2.3.0 - 2.5.0         | 3.0.0 - 3.3.0     | 2.5                 |
+| 2.2.0 - 2.2.2         | 2.3.0 - 2.3.2     | 2.0                 |
+| 2.0.1 - 2.1.5         | 2.0.1 - 2.2.5     | 2.0                 |
+| 2.0.0                 | 2.0.0             | 2.0                 |
+| 1.1.4 - 1.1.11        | 1.0.9 - 1.1.11    | 1.x                 |
 
 

--- a/docs/compatibility-table.mdx
+++ b/docs/compatibility-table.mdx
@@ -11,14 +11,18 @@ is by always using the latest version. However,
 if for some reason that isn't possible, you can refer to 
 the table below to assess which version you should use.
 
-|   patrol_cli   |     patrol     |
-| -------------- | -------------- |
-| 3.2.0 -        | 3.11.0 -       |
-| 3.1.0 - 3.1.1  |     3.10.0     |
-| 2.6.5 - 3.0.1  | 3.6.0 - 3.10.0 |
-| 2.6.0 - 2.6.4  | 3.4.0 - 3.5.2  |
-| 2.3.0 - 2.5.0  | 3.0.0 - 3.3.0  |
-| 2.2.0 - 2.2.2  | 2.3.0 - 2.3.2  |
-| 2.0.1 - 2.1.5  | 2.0.1 - 2.2.5  |
-| 2.0.0          | 2.0.0          |
-| 1.1.4 - 1.1.11 | 1.0.9 - 1.1.11 |
+| patrol_cli            | patrol            | Flutter Version |
+|-----------------------|-------------------|-----------------|
+| 3.2.0+                | 3.11.0+           | 3.16+           |
+| 3.1.0 - 3.1.1         | 3.10.0            | 3.10 – 3.15     |
+| 2.6.5 - 3.0.1         | 3.6.0 - 3.10.0    | 3.0 – 3.9       |
+| 2.6.0 - 2.6.4         | 3.4.0 - 3.5.2     | 2.10 – 2.17     |
+| 2.3.0 - 2.5.0         | 3.0.0 - 3.3.0     | 2.5 – 2.9       |
+| 2.2.0 - 2.2.2         | 2.3.0 - 2.3.2     | 2.0 – 2.4       |
+| 2.0.1 - 2.1.5         | 2.0.1 - 2.2.5     | 2.0 – 2.2       |
+| 2.0.0                 | 2.0.0             | 2.0             |
+| 1.1.4 - 1.1.11        | 1.0.9 - 1.1.11    | 1.x             |
+
+->Why Flutter 3.16+? : `Patrol v3` requires `Flutter 3.16` or newer due to changes in the flutter_test package, impacting its compatibility​
+
+->Backwards Compatibility : Older `Patrol versions` are mapped against Flutter versions to ensure users can easily pick compatible versions.


### PR DESCRIPTION
This **_PR updates the compatibility table_** in the Patrol documentation to include Flutter version compatibility details. The changes ensure that users can easily determine which **Patrol** and **patrol_cli** versions align with their Flutter version, facilitating better dependency management.

### ** Changes Made:**

- Updated the compatibility table to reflect:
- Minimum Flutter version required for Patrol v3.2.0+ as Flutter 3.16+.
- Detailed mappings of Patrol and patrol_cli versions with compatible Flutter versions.
- Ensured consistent formatting of the table.

### **### Reason for Changes:**

- Patrol v3 introduces changes that depend on Flutter 3.16+ due to updates in the flutter_test package.
- Providing this information helps developers choose the correct versions if they cannot upgrade to the latest Flutter or Patrol version.

### Linked Issue:
**Resolves [Issue #2365](https://github.com/leancodepl/patrol/issues/2365).**

This PR ensures users have accurate versioning information and improves documentation usability. Let me know if you need further modifications