### PR TITLE
Use new notification tile identifier for iOS 18

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix tapping on notification on iOS 18. (#2394)
+
 ## 3.12.0
 
 - Add `clear-permissions` flag on ios commands. (#2367)

--- a/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
@@ -628,6 +628,14 @@
 
     // MARK: Notifications
 
+    private let notificationCellIdentifier: String = {
+      if #available(iOS 18, *) {
+        return "ListCell"
+      } else {
+        return "NotificationCell"
+      }
+    }()
+
     func openNotifications() throws {
       // TODO: Check if works on iPhones without notch
 
@@ -667,7 +675,7 @@
     func getNotifications() throws -> [Notification] {
       var notifications = [Notification]()
       runAction("getting notifications") {
-        let cells = self.springboard.buttons.matching(identifier: "NotificationCell")
+        let cells = self.springboard.buttons.matching(identifier: self.notificationCellIdentifier)
           .allElementsBoundByIndex
         for (i, cell) in cells.enumerated() {
           Logger.shared.i("found notification at index \(i) with label \(format: cell.label)")
@@ -681,7 +689,8 @@
 
     func tapOnNotification(byIndex index: Int, withTimeout timeout: TimeInterval?) throws {
       try runAction("tapping on notification at index \(index)") {
-        let cellsQuery = self.springboard.buttons.matching(identifier: "NotificationCell")
+        let cellsQuery = self.springboard.buttons.matching(
+          identifier: self.notificationCellIdentifier)
         guard
           let cell = self.waitFor(query: cellsQuery, index: index, timeout: timeout ?? self.timeout)
         else {
@@ -703,7 +712,8 @@
       try runAction("tapping on notification containing text \(format: substring)") {
         let cellsQuery = self.springboard.buttons.matching(
           NSPredicate(
-            format: "identifier == %@ AND label CONTAINS %@", "NotificationCell", substring)
+            format: "identifier == %@ AND label CONTAINS %@", self.notificationCellIdentifier,
+            substring)
         )
 
         guard let cell = self.waitFor(query: cellsQuery, index: 0, timeout: timeout ?? self.timeout)


### PR DESCRIPTION
Fixes tapping on notification in iOS 18. 
Looks like `identifier` changed in the latest iOS version:
iOS 17:
![image](https://github.com/user-attachments/assets/0de5d5ae-d396-420c-bcc2-8b1eed143012)
iOS 18:
![image](https://github.com/user-attachments/assets/a5415957-f125-4961-a4f8-1c0b01d04d23)
 