### PR TITLE
fix: recover macos functionality

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix macos functionality. (#2408)
+
 ## 3.13.0-dev.2
 
 - Bump `patrol_log` version.

--- a/packages/patrol/darwin/Classes/AutomatorServer/Automator/MacOSAutomator.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Automator/MacOSAutomator.swift
@@ -127,7 +127,9 @@
       on selector: Selector,
       inApp bundleId: String,
       dismissKeyboard: Bool,
-      withTimeout timeout: TimeInterval?
+      withTimeout timeout: TimeInterval?,
+      dx: CGFloat,
+      dy: CGFloat
     ) throws {
       try runAction("enterText") {
         throw PatrolError.methodNotImplemented("enterText")
@@ -139,7 +141,9 @@
       on selector: IOSSelector,
       inApp bundleId: String,
       dismissKeyboard: Bool,
-      withTimeout timeout: TimeInterval?
+      withTimeout timeout: TimeInterval?,
+      dx: CGFloat,
+      dy: CGFloat
     ) throws {
       try runAction("enterText") {
         throw PatrolError.methodNotImplemented("enterText")
@@ -151,7 +155,9 @@
       byIndex index: Int,
       inApp bundleId: String,
       dismissKeyboard: Bool,
-      withTimeout timeout: TimeInterval?
+      withTimeout timeout: TimeInterval?,
+      dx: CGFloat,
+      dy: CGFloat
     ) throws {
       try runAction("enterText") {
         throw PatrolError.methodNotImplemented("enterText")


### PR DESCRIPTION
👋 

This PR recovers macOS testing functionality, which I last saw working in 3.10.0. Since then it appears to fail with:

```
.pub-cache/hosted/pub.dev/patrol-3.12.0/darwin/Classes/AutomatorServer/Automator/MacOSAutomator.swift:6:9: error: type 'MacOSAutomator' does not conform to protocol 'Automator'
	  class MacOSAutomator: Automator {
	        ^
```

this still seems an issue at commit:  6a1df028d0a4e525451b43eaf160634d6161c988

Testing:
works on my machine. I didn't quickly find a test suite to run / update locally, though at a guess there is some coverage missing for this functionality / platform. Let me know if there are other things I can do to help with this submission.