### PR TITLE
Bump Gradle in example apps so it's possible to build them on the latest JDK

### DIFF
--- a/dev/e2e_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/e2e_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Bump Gradle version in the example app so it's possible to build them on the
+  latest JDK 23 (#2503)
+
 ## 3.14.0
 
 - Remove `exception` from `StepEntry`. When it was too long, it caused crash because of badly formed JSON. (#2481)

--- a/packages/patrol/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/patrol/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/patrol/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/patrol/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip

--- a/packages/patrol_finders/CHANGELOG.md
+++ b/packages/patrol_finders/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Bump Gradle version in the example app so it's possible to build them on the
+  latest JDK 23 (#2503)
+
 ## 2.7.0
 
 - Add `alignment` parameter to `waitUntilVisible` in order to improve visibility check on Row and Column widgets. (#2464)

--- a/packages/patrol_finders/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/patrol_finders/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip


### PR DESCRIPTION
Gradle 8.9 doesn't support the latest stable Java 23. ([see Gradle-Java compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html))

Java 23 is the default when using `brew install openjdk` (which is arguably a very popular way to install JDK on macOS). I use it.

### Repro

```
$ brew install openjdk
```

```
$ echo $JAVA_HOME
/Library/Java/JavaVirtualMachines/openjdk.jdk/Contents/Home
```

```
$ cd packages/patrol/example
```


```
$ flutter build apk --config-only
```

```
cd android && ./gradlew :app:assembleDebug
```

Results in:

```
FAILURE: Build failed with an exception.

* What went wrong:
BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_' Unsupported class file major version 67
> Unsupported class file major version 67

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 26s
Running Gradle task 'assembleDebug'...                             27.5s
```

> [!NOTE]
>
>Using `flutter build apk --debug` works because by default, it ignores `$JAVA_HOME` and defaults to the Java bundled in IntelliJ IDEA/Android Studio. Still, when the developer calls `flutter config --jdk-dir "$JAVA_HOME` (and JDK 23 is in `$JAVA_HOME`), the same problem occurs.