### PR TITLE
Gracefully handle analytics failing to send (patrol_cli)

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Gracefully handle when analytics fail to send (#2460)
+
 ## 3.5.0
 
 - Add `PATROL_ANALYTICS_ENABLED` environment variable to disable analytics. (#2483)

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -57,6 +57,7 @@ Future<int> patrolCommandRunner(List<String> args) async {
       platform: platform,
       isCI: isCI,
       envAnalyticsEnabled: analyticsEnabled,
+      logger: logger,
     ),
     processManager: processManager,
     isCI: isCI,


### PR DESCRIPTION
Handle exceptions raised when analytics fail to be sent.

This is related to https://github.com/leancodepl/patrol/issues/2460 where I ran into the same due to a DNS block on the domain - which I'd expect to be common in CI environments where egress is tightly controlled. As analytics aren't an essential part of the CLI, my rationale is that if the call fails it should not halt execution