### PR TITLE
Disable update check if command name is "completion"

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Skip update check when the `patrol_cli` binary is triggered for shell completion only (#2512)
+
 ## 3.7.0
 
 - Bump min Flutter SDK to 3.32.0 (#2649)

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -1,5 +1,6 @@
 import 'dart:io' as p show Platform;
 import 'dart:io' show ProcessSignal, stdin;
+
 import 'package:adb/adb.dart';
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
@@ -467,7 +468,9 @@ To install a specific version of Patrol CLI, run:
       return false;
     }
 
-    if (commandName == 'update' || commandName == 'doctor') {
+    if (commandName == 'update' ||
+        commandName == 'doctor' ||
+        commandName == HandleCompletionRequestCommand.commandName) {
       return false;
     }
 


### PR DESCRIPTION
a stab at fixing #1966

### Problem description

The version check is performed synchronously.

This makes shell completions needlessly slow (in case of slow/unreliable network) and kinda defeats the purpose of using them. My bad.

https://github.com/leancodepl/patrol/blob/e465db026ffcd6b6bc1ab03f045b949cf676fb77/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart#L375-L377

### Resources

- ~~https://stackoverflow.com/a/78657717/7009800~~ AI-generated garbage answer, such API doesn't exist, see https://github.com/dart-lang/http/issues/424

The `pub_updater` package doesn't provide any way to cancel an update check that is in progress. So it seems to me that the only way to do cancel the version check is to run it in a separate isolate. This seems a bit complex as isolates cannot share memory, but `pub_updater.PubUpdater` and `patrol_cli.Logger` must be present in the isolate.

<details><summary>Example 1 (using async, not working as intended)</summary>

```dart
import 'dart:async';

Future<void> main(List<String> args) async {
  unawaited(_backgroundTask());

  // Simulate main work
  print('start: main task');
  await Future<void>.delayed(const Duration(seconds: 1));
  print('end: main task');
}

/// A low-priority background task.
///  * May take longer than the main task
///  * If it lasts longer than main task, it should be preempted (to not block)
///  * It's low priority so it's fine if it's preempted
Future<void> _backgroundTask() async {
  print('start: background task');
  // Simulate some work
  await Future<void>.delayed(const Duration(seconds: 3));
  print('end: background task');
}
```

</details> 

<details><summary>Example 2 (using isolates, working as intended)</summary>

```dart
import 'dart:async';
import 'dart:isolate' as isolate;

Future<void> main(List<String> args) async {
  unawaited(
    isolate.Isolate.spawn<void>((_) => _backgroundTask(), null),
  );

  // Simulate main work
  print('start: main task');
  await Future<void>.delayed(const Duration(seconds: 1));
  print('end: main task');
}

/// A low-priority background task.
///  * May take longer than the main task
///  * If it lasts longer than main task, it should be preempted (to not block)
///  * It's low priority so it's fine if it's preempted
Future<void> _backgroundTask() async {
  print('start: background task');
  // Simulate some work
  await Future<void>.delayed(const Duration(seconds: 3));
  print('end: background task');
}
```

</details> 