### PR TITLE
Link correct docs in Lambda integration docs

### DIFF
--- a/docs/documentation/integrations/lambdatest.mdx
+++ b/docs/documentation/integrations/lambdatest.mdx
@@ -56,7 +56,7 @@ Uploaded testsuite, "app_id": "lt://APP1016047291733312896265135",
 }
 ```
 
-[LT_app_docs]: https://www.lambdatest.com/support/docs/getting-started-with-flutter-dart-android-automation/#step-2-upload-your-application
-[LT_test_docs]: https://www.lambdatest.com/support/docs/getting-started-with-flutter-dart-android-automation/#step-3-uploading-test-suite
-[LT_execute_docs]: https://www.lambdatest.com/support/docs/getting-started-with-flutter-dart-android-automation/#step-4-executing-the-test
+[LT_app_docs]: https://www.lambdatest.com/support/docs/getting-started-with-espresso-testing/#running-your-first-test-a-step-by-step-guide
+[LT_test_docs]: https://www.lambdatest.com/support/docs/getting-started-with-espresso-testing/#step-2-upload-your-test-suite
+[LT_execute_docs]: https://www.lambdatest.com/support/docs/getting-started-with-espresso-testing/#step-3-executing-the-test
 [LambdaTest App Test Automation]: https://www.lambdatest.com/app-test-automation


### PR DESCRIPTION
patrol uses Espresso endpoints not Flutter's ones