### PR TITLE
Fix running ios tests in example project with dev flavor

### DIFF
--- a/packages/patrol/example/ios/Podfile.lock
+++ b/packages/patrol/example/ios/Podfile.lock
@@ -202,9 +202,9 @@ SPEC CHECKSUMS:
   FirebaseMessaging: e1aca1fcc23e8b9eddb0e33f375ff90944623021
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
-  flutter_native_splash: f71420956eb811e6d310720fee915f1d42852e7a
+  flutter_native_splash: edf599c81f74d093a4daf8e17bd7a018854bc778
   geocoding_ios: a389ea40f6f548de6e63006a2e31bf66ff80769a
-  geolocator_apple: 9bcea1918ff7f0062d98345d238ae12718acfbc1
+  geolocator_apple: 6cbaf322953988e009e5ecb481f07efece75c450
   google_sign_in_ios: 07375bfbf2620bc93a602c0e27160d6afc6ead38
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db

--- a/packages/patrol/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/dev.xcscheme
+++ b/packages/patrol/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/dev.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug-dev"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <TestPlans>
          <TestPlanReference
             reference = "container:TestPlan.xctestplan"

--- a/packages/patrol/example/pubspec.yaml
+++ b/packages/patrol/example/pubspec.yaml
@@ -11,9 +11,9 @@ dependencies:
   animations: ^2.0.8
   confetti: ^0.7.0
   dispose_scope: ^2.1.0
-  firebase_auth: ^5.2.0
-  firebase_core: ^3.0.0
-  firebase_messaging: ^15.0.0
+  firebase_auth: ^5.4.1
+  firebase_core: ^3.10.1
+  firebase_messaging: ^15.2.1
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.3


### PR DESCRIPTION
This PR fix running iOS tests in example app using `dev` flavor. 
Before the fix, process was failing with `xcodebuild: error: Failed to build workspace Runner with scheme dev.: There are no test bundles available to test.` error which was caused by multiple `.xctest` files generated for `dev` scheme upon building the tests.
To fix that, `shouldAutocreateTestPlan = "YES"` line was removed from `dev.xcscheme` file.
PR also contains other changes which were required in order to make project compatible with Flutter 3.27.0, but those changes were also introduced in #2510.