### PR TITLE
Restore build phases in setup

### DIFF
--- a/dev/e2e_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/dev/e2e_app/ios/Runner.xcodeproj/project.pbxproj
@@ -223,10 +223,12 @@
 			buildConfigurationList = 983964E12978A956007EB76F /* Build configuration list for PBXNativeTarget "RunnerUITests" */;
 			buildPhases = (
 				57A729EC2F3211B458286925 /* [CP] Check Pods Manifest.lock */,
+				AB6016A22D565AEA0041A30D /* xcode_backend build */,
 				983964D52978A956007EB76F /* Sources */,
 				983964D62978A956007EB76F /* Frameworks */,
 				983964D72978A956007EB76F /* Resources */,
 				B778A6D350303A188769B23C /* [CP] Embed Pods Frameworks */,
+				AB6016A32D565AEC0041A30D /* xcode_backend embed_and_thin */,
 			);
 			buildRules = (
 			);
@@ -418,6 +420,42 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "echo \"Runner xcode_backend build\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
+		};
+		AB6016A22D565AEA0041A30D /* xcode_backend build */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "xcode_backend build";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
+		};
+		AB6016A32D565AEC0041A30D /* xcode_backend embed_and_thin */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "xcode_backend embed_and_thin";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
 		};
 		B778A6D350303A188769B23C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/docs/documentation/index.mdx
+++ b/docs/documentation/index.mdx
@@ -293,6 +293,35 @@ Check out our video version of this tutorial on YouTube!
         </Step>
 
         <Step>
+          Go to **RunnerUITests** -> **Build Phases** and add 2 new "Run Script Phase" Build Phases.
+            Name them `xcode_backend build` and `xcode_backend embed_and_thin`.
+
+          ![Xcode config setup](/assets/ios_runner_build_phases_create.png)
+        </Step>
+
+        <Step>
+          Arrange the newly created Build Phases in the order shown in the screenshot below.
+
+          ![Xcode config setup](/assets/ios_runner_build_phases.png)
+        </Step>
+
+        <Step>
+          Paste this code into the `xcode_backend build` Build Phase:
+
+          ```
+          /bin/sh "$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh" build
+          ```
+        </Step>
+
+        <Step>
+          Paste this code into the `xcode_backend embed_and_thin` Build Phase:
+
+          ```
+          /bin/sh "$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh" embed_and_thin
+          ```
+        </Step>
+
+        <Step>
           Xcode by default also enables a "parallel execution" setting, which
             breaks Patrol. Disable it **for all schemes** (if you have more than one):
 
@@ -382,6 +411,36 @@ Check out our video version of this tutorial on YouTube!
 
           ```
           $ pod install --repo-update
+          ```
+        </Step>
+
+        <Step>
+          Go to **RunnerUITests** -> **Build Phases** and add 2 new "Run Script Phase" Build Phases.
+            Rename them to `xcode_backend build` and `xcode_backend embed_and_thin` by double clicking
+            on their names.
+
+          ![Xcode config setup](/assets/macos_runner_build_phases_create.png)
+        </Step>
+
+        <Step>
+          Arrange the newly created Build Phases in the order shown in the screenshot below.
+
+          ![Xcode config setup](/assets/macos_runner_build_phases.png)
+        </Step>
+
+        <Step>
+          Paste this code into the first `macos_assemble build` Build Phase:
+
+          ```
+          /bin/sh "$FLUTTER_ROOT/packages/flutter_tools/bin/macos_assemble.sh" build
+          ```
+        </Step>
+
+        <Step>
+          Paste this code into the second `macos_assemble embed` Build Phase:
+
+          ```
+          /bin/sh "$FLUTTER_ROOT/packages/flutter_tools/bin/macos_assemble.sh" embed
           ```
         </Step>
 

--- a/packages/patrol/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/patrol/example/ios/Runner.xcodeproj/project.pbxproj
@@ -224,11 +224,13 @@
 			buildConfigurationList = 9835C3C52AEBE2B200AD4576 /* Build configuration list for PBXNativeTarget "RunnerUITests" */;
 			buildPhases = (
 				6DD48773736CF13259607197 /* [CP] Check Pods Manifest.lock */,
+				AB6016A42D565B920041A30D /* xcode_backend build */,
 				9835C3B32AEBE2B200AD4576 /* Sources */,
 				9835C3B42AEBE2B200AD4576 /* Frameworks */,
 				9835C3B52AEBE2B200AD4576 /* Resources */,
 				FFE213DE21216A1B3F16BFE9 /* [CP] Embed Pods Frameworks */,
 				E638E53E9CC2B1B19E82D614 /* [CP] Copy Pods Resources */,
+				AB6016A52D565B940041A30D /* xcode_backend embed_and_thin */,
 			);
 			buildRules = (
 			);
@@ -409,6 +411,42 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
+		};
+		AB6016A42D565B920041A30D /* xcode_backend build */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "xcode_backend build";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
+		};
+		AB6016A52D565B940041A30D /* xcode_backend embed_and_thin */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "xcode_backend embed_and_thin";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
 		};
 		E638E53E9CC2B1B19E82D614 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Contrary to what we claimed in #2510, build_phases are still needed to run on physical iOS devices. So we are restoring the information in the configuration documentation and will continue to think about simplifying iOS configuration 