### PR TITLE
Add assertions for to coordinates in swipe method

### DIFF
--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -792,6 +792,8 @@ class NativeAutomator {
   }) async {
     assert(from.dx >= 0 && from.dx <= 1);
     assert(from.dy >= 0 && from.dy <= 1);
+    assert(to.dx >= 0 && to.dx <= 1);
+    assert(to.dy >= 0 && to.dy <= 1);
 
     await _wrapRequest(
       'swipe',

--- a/packages/patrol/lib/src/native/native_automator2.dart
+++ b/packages/patrol/lib/src/native/native_automator2.dart
@@ -666,6 +666,8 @@ class NativeAutomator2 {
   }) async {
     assert(from.dx >= 0 && from.dx <= 1);
     assert(from.dy >= 0 && from.dy <= 1);
+    assert(to.dx >= 0 && to.dx <= 1);
+    assert(to.dy >= 0 && to.dy <= 1);
 
     await _wrapRequest(
       'swipe',


### PR DESCRIPTION
Ensured `to.dx` and `to.dy` are within the inclusive `0-1` range.
This aligns with the existing assertions for from and prevents out-of-bounds errors.