### PR TITLE
Add ability to quit the `patrol develop` process by pressing q on the keyboard

### DIFF
--- a/dev/cli_tests/patrol_develop_test.dart
+++ b/dev/cli_tests/patrol_develop_test.dart
@@ -84,7 +84,7 @@ void main(List<String> args) async {
 
     final isReadyToRestart = isFirstTestPassed &&
         isReloaded == false &&
-        stringOutput.contains('press "r" to restart');
+        stringOutput.contains('r Hot restart.');
 
     if (isReadyToRestart) {
       exampleTestFile.writeAsStringSync(exampleTestWithFailingContents);

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add proper cleanup of app and develop process when quitting with 'q'. (#2575)
 - Add `--ios` flag to `patrol test` that specifies the iOS version to use. (#2540)
 - Bump `custom_lint` to `0.7.0` and `leancode_lint` to `14.3.0`. (#2574)
 

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## Unreleased
 
 - Add ability to quit the `patrol develop` process by pressing q on the keyboard (#2577)
-- Add proper cleanup of app and develop process when quitting with 'q'. (#2575)
 - Add `--ios` flag to `patrol test` that specifies the iOS version to use. (#2540)
 - Bump `custom_lint` to `0.7.0` and `leancode_lint` to `14.3.0`. (#2574)
 

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add ability to quit the `patrol develop` process by pressing q on the keyboard (#2577)
 - Add proper cleanup of app and develop process when quitting with 'q'. (#2575)
 - Add `--ios` flag to `patrol test` that specifies the iOS version to use. (#2540)
 - Bump `custom_lint` to `0.7.0` and `leancode_lint` to `14.3.0`. (#2574)

--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -384,6 +384,7 @@ class DevelopCommand extends PatrolCommand {
         dartDefines: flutterOpts.dartDefines,
         openDevtools: openDevtools,
         attachUsingUrl: device.targetPlatform == TargetPlatform.macOS,
+        onQuit: finalizer,
       );
 
       await future;

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' as io;
+import 'dart:io' show exit;
 
 import 'package:dispose_scope/dispose_scope.dart';
 import 'package:meta/meta.dart';
@@ -17,6 +18,7 @@ class FlutterTool {
     required Platform platform,
     required DisposeScope parentDisposeScope,
     required Logger logger,
+    this.onQuit,
   })  : _stdin = stdin,
         _processManager = processManager,
         _platform = platform,
@@ -30,6 +32,7 @@ class FlutterTool {
   final Platform _platform;
   final DisposeScope _disposeScope;
   final Logger _logger;
+  final Future<void> Function()? onQuit;
 
   bool _hotRestartActive = false;
   bool _logsActive = false;
@@ -43,6 +46,7 @@ class FlutterTool {
     required Map<String, String> dartDefines,
     required bool openDevtools,
     bool attachUsingUrl = false,
+    Future<void> Function()? onQuit,
   }) async {
     if (io.stdin.hasTerminal) {
       _enableInteractiveMode();
@@ -64,6 +68,7 @@ class FlutterTool {
         debugUrl: url,
         dartDefines: dartDefines,
         openBrowser: openDevtools,
+        onQuit: onQuit,
       );
     } else {
       await Future.wait<void>([
@@ -75,6 +80,7 @@ class FlutterTool {
           appId: appId,
           dartDefines: dartDefines,
           openBrowser: openDevtools,
+          onQuit: onQuit,
         ),
       ]);
     }
@@ -95,6 +101,7 @@ class FlutterTool {
     required String? appId,
     required Map<String, String> dartDefines,
     required bool openBrowser,
+    Future<void> Function()? onQuit,
   }) async {
     await _disposeScope.run((scope) async {
       final process = await _processManager.start(
@@ -116,7 +123,15 @@ class FlutterTool {
       )
         ..disposedBy(scope);
 
-      _stdin.listen((event) {
+      final completer = Completer<void>();
+      scope.addDispose(() async {
+        if (!completer.isCompleted) {
+          _logger.detail('Killed before attached to the app');
+          completer.complete();
+        }
+      });
+
+      _stdin.listen((event) async {
         final char = String.fromCharCode(event.first);
         if (char == 'r' || char == 'R') {
           if (!_hotRestartActive) {
@@ -126,16 +141,25 @@ class FlutterTool {
 
           _logger.success('Hot Restart for entrypoint ${basename(target)}...');
           process.stdin.add('R'.codeUnits);
+        } else if (char == 'q' || char == 'Q') {
+          _logger.success('Quitting process...');
+          process.kill();
+          if (!completer.isCompleted) {
+            completer.complete();
+          }
+
+          // Call the uninstall function if provided
+          if (onQuit != null) {
+            try {
+              await onQuit();
+            } catch (err) {
+              _logger.err('Failed to clean up app: $err');
+            }
+          }
+
+          exit(0);
         }
       }).disposedBy(scope);
-
-      final completer = Completer<void>();
-      scope.addDispose(() async {
-        if (!completer.isCompleted) {
-          _logger.detail('Killed before attached to the app');
-          completer.complete();
-        }
-      });
 
       _logger.detail('Hot Restart: waiting for attach to the app...');
       process.listenStdOut((line) {
@@ -213,7 +237,9 @@ class FlutterTool {
           observationUrlCompleter?.complete(url);
         }
         if (line.startsWith('Showing ') && line.endsWith('logs:')) {
-          _logger.success('Hot Restart: logs connected');
+          _logger
+            ..success('Hot Restart: logs connected')
+            ..info('Press "q" to quit at any time');
           _logsActive = true;
 
           if (!_hotRestartActive) {

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -165,7 +165,10 @@ class FlutterTool {
       process.listenStdOut((line) {
         if (line == 'Flutter run key commands.' && !completer.isCompleted) {
           _logger.success(
-            'Hot Restart: attached to the app (press "r" to restart)',
+            'Hot Restart: attached to the app\n'
+            'Patrol develop key commands:\n'
+            'r Hot restart.\n'
+            'q Quit (terminate the process and application on the device).',
           );
           _hotRestartActive = true;
 
@@ -237,9 +240,7 @@ class FlutterTool {
           observationUrlCompleter?.complete(url);
         }
         if (line.startsWith('Showing ') && line.endsWith('logs:')) {
-          _logger
-            ..success('Hot Restart: logs connected')
-            ..info('Press "q" to quit at any time');
+          _logger.success('Hot Restart: logs connected');
           _logsActive = true;
 
           if (!_hotRestartActive) {


### PR DESCRIPTION
This PR implements the requested functionality described in #2383 

I've added user-facing messaging to the console logs during the patrol develop process to advertise this new feature.

## Changes
- Added `onQuit` callback parameter to `FlutterTool` class to handle cleanup operations
- Modified the quit handler to call the uninstall function before exiting
- Updated `attachForHotRestart` and `attach` methods to accept and pass through the `onQuit` callback
- Modified `develop.dart` to pass the uninstall function as the `onQuit` callback

This change ensures that when users quit the Flutter tool using 'q', all associated processes are properly cleaned up, preventing any lingering processes from running in the background.

## Example
When running the Flutter develop command and pressing 'q':
1. The Flutter attach process is killed
2. The uninstall function is called to clean up the app and test processes
3. The program exits cleanly