### PR TITLE
Display a friendly device name

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add ability to quit the `patrol develop` process by pressing q on the keyboard (#2577)
 - Add `--ios` flag to `patrol test` that specifies the iOS version to use. (#2540)
 - Bump `custom_lint` to `0.7.0` and `leancode_lint` to `14.3.0`. (#2574)
+- Display the name of the default device instead of its ID. (#2581)
 
 ## 3.5.1
 

--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -144,7 +144,7 @@ class DevelopCommand extends PatrolCommand {
       throwToolExit('macOS is not supported with develop');
     }
 
-    _logger.detail('Received device: ${device.resolvedName}');
+    _logger.detail('Received device: ${device.name} (${device.id})');
 
     final packageName = stringArg('package-name') ?? config.android.packageName;
     final bundleId = stringArg('bundle-id') ?? config.ios.bundleId;

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -143,7 +143,7 @@ class TestCommand extends PatrolCommand {
     );
     _logger.detail('Received ${devices.length} device(s) to run on');
     for (final device in devices) {
-      _logger.detail('Received device: ${device.resolvedName}');
+      _logger.detail('Received device: ${device.name} (${device.id})');
     }
 
     if (devices.length > 1) {

--- a/packages/patrol_cli/lib/src/devices.dart
+++ b/packages/patrol_cli/lib/src/devices.dart
@@ -95,7 +95,7 @@ class DeviceFinder {
     if (wantDevices.isEmpty) {
       final firstDevice = attachedDevices.first;
       _logger.info(
-        'No device specified, using the first one (${firstDevice.resolvedName})',
+        'No device specified, using the first one (${firstDevice.name})',
       );
       return [firstDevice];
     }
@@ -174,23 +174,6 @@ class Device {
   final String id;
   final TargetPlatform targetPlatform;
   final bool real;
-
-  /// Returns the name that Patrol is usually interested with.
-  ///
-  /// On Android, this is the ID of the device, e.g "emulator-5554".
-  ///
-  /// On iOS, this is the name of the device, e.g "iPhone 13" or
-  /// "Barteks-iPhone".
-  String get resolvedName {
-    switch (targetPlatform) {
-      case TargetPlatform.android:
-        return id;
-      case TargetPlatform.iOS:
-        return name;
-      case TargetPlatform.macOS:
-        return name;
-    }
-  }
 
   String get description {
     switch (targetPlatform) {


### PR DESCRIPTION
Removes `resolvedName` and replaces it with `device.name` and/or `device.id`.

- Closes #2561