### PR TITLE
fix: Android emulator workflow (location related tests) 

### DIFF
--- a/dev/e2e_app/integration_test/permissions/permissions_location_test.dart
+++ b/dev/e2e_app/integration_test/permissions/permissions_location_test.dart
@@ -69,8 +69,14 @@ void main() {
       await tapOkIfGoogleDialogAppears($);
     }
 
-    expect(await $(RegExp('lat')).waitUntilVisible(), findsOneWidget);
-    expect(await $(RegExp('lng')).waitUntilVisible(), findsOneWidget);
+    expect(
+      await $(RegExp('lat')).waitUntilVisible(timeout: Duration(seconds: 20)),
+      findsOneWidget,
+    );
+    expect(
+      await $(RegExp('lng')).waitUntilVisible(timeout: Duration(seconds: 20)),
+      findsOneWidget,
+    );
   });
 
   patrol('accepts location permission native2', ($) async {

--- a/dev/e2e_app/integration_test/permissions/permissions_location_test.dart
+++ b/dev/e2e_app/integration_test/permissions/permissions_location_test.dart
@@ -70,10 +70,14 @@ void main() {
     }
 
     expect(
+      // timeout duration is increased here as the location service on CI
+      // needs more time to start up
       await $(RegExp('lat')).waitUntilVisible(timeout: Duration(seconds: 20)),
       findsOneWidget,
     );
     expect(
+      // timeout duration is increased here as the location service on CI
+      // needs more time to start up
       await $(RegExp('lng')).waitUntilVisible(timeout: Duration(seconds: 20)),
       findsOneWidget,
     );
@@ -98,10 +102,14 @@ void main() {
     }
 
     expect(
+      // timeout duration is increased here as the location service on CI
+      // needs more time to start up
       await $(RegExp('lat')).waitUntilVisible(timeout: Duration(seconds: 30)),
       findsOneWidget,
     );
     expect(
+      // timeout duration is increased here as the location service on CI
+      // needs more time to start up
       await $(RegExp('lng')).waitUntilVisible(timeout: Duration(seconds: 30)),
       findsOneWidget,
     );

--- a/dev/e2e_app/integration_test/permissions/permissions_location_test.dart
+++ b/dev/e2e_app/integration_test/permissions/permissions_location_test.dart
@@ -97,7 +97,13 @@ void main() {
       await tapOkIfGoogleDialogAppearsV2($);
     }
 
-    expect(await $(RegExp('lat')).waitUntilVisible(), findsOneWidget);
-    expect(await $(RegExp('lng')).waitUntilVisible(), findsOneWidget);
+    expect(
+      await $(RegExp('lat')).waitUntilVisible(timeout: Duration(seconds: 30)),
+      findsOneWidget,
+    );
+    expect(
+      await $(RegExp('lng')).waitUntilVisible(timeout: Duration(seconds: 30)),
+      findsOneWidget,
+    );
   });
 }


### PR DESCRIPTION
For a reason which is unclear to me, after merging #2547 "accepts location permission native2" test in `permission_location_test.dart` started to fail on CI. I increased timeout and it now seems to work fine