### PR TITLE
[patrol_cli]: Add instructions to deactivate, install specific version to --help message

### DIFF
--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -311,7 +311,14 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
   String? get usageFooter => '''
 Read documentation at https://patrol.leancode.pl
 Report bugs, request features at https://github.com/leancodepl/patrol/issues
-Ask questions, get support at https://github.com/leancodepl/patrol/discussions''';
+Ask questions, get support at https://github.com/leancodepl/patrol/discussions
+
+To deactivate Patrol CLI, run:
+  dart pub global deactivate patrol_cli
+
+To install a specific version of Patrol CLI, run:
+  dart pub global activate patrol_cli <version>
+  Example: dart pub global activate patrol_cli 3.5.0''';
 
   @override
   Future<int?> run(Iterable<String> args) async {


### PR DESCRIPTION
This PR is to resolve issue #2580 

Adds the following to the help message when using the CLI
 
- Instruction on how to deactivate patrol_cli
- Instruction on how to install a specific version of patrol_cli

Since these commands are not apart of the patrol cli, and are apart of dart pub, I chose to not update the "CLI commands" documentation. 