### PR TITLE
[patrol_cli]: Add throwToolExit to build commands when packages are incompatible

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Improve patrol test error messaging when compatibility check fails, added same compatibility check and error messaging to patrol build command (#2597)
 - Improve patrol update messaging by showing incompatibility warning when applicable, sharing compatibility table (#2579)
 - Add ability to quit the `patrol develop` process by pressing q on the keyboard (#2577)
 - Add `--ios` flag to `patrol test` that specifies the iOS version to use. (#2540)

--- a/packages/patrol_cli/lib/src/commands/build.dart
+++ b/packages/patrol_cli/lib/src/commands/build.dart
@@ -4,6 +4,7 @@ import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/commands/build_android.dart';
 import 'package:patrol_cli/src/commands/build_ios.dart';
 import 'package:patrol_cli/src/commands/build_macos.dart';
+import 'package:patrol_cli/src/compatibility_checker/compatibility_checker.dart';
 import 'package:patrol_cli/src/dart_defines_reader.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
 import 'package:patrol_cli/src/macos/macos_test_backend.dart';
@@ -22,6 +23,7 @@ class BuildCommand extends PatrolCommand {
     required IOSTestBackend iosTestBackend,
     required MacOSTestBackend macosTestBackend,
     required Analytics analytics,
+    required CompatibilityChecker compatibilityChecker,
     required Logger logger,
   }) {
     addSubcommand(
@@ -31,6 +33,7 @@ class BuildCommand extends PatrolCommand {
         dartDefinesReader: dartDefinesReader,
         pubspecReader: pubspecReader,
         androidTestBackend: androidTestBackend,
+        compatibilityChecker: compatibilityChecker,
         analytics: analytics,
         logger: logger,
       ),
@@ -42,6 +45,7 @@ class BuildCommand extends PatrolCommand {
         dartDefinesReader: dartDefinesReader,
         pubspecReader: pubspecReader,
         iosTestBackend: iosTestBackend,
+        compatibilityChecker: compatibilityChecker,
         analytics: analytics,
         logger: logger,
       ),
@@ -53,6 +57,7 @@ class BuildCommand extends PatrolCommand {
         dartDefinesReader: dartDefinesReader,
         pubspecReader: pubspecReader,
         macosTestBackend: macosTestBackend,
+        compatibilityChecker: compatibilityChecker,
         analytics: analytics,
         logger: logger,
       ),

--- a/packages/patrol_cli/lib/src/commands/build_android.dart
+++ b/packages/patrol_cli/lib/src/commands/build_android.dart
@@ -5,6 +5,7 @@ import 'package:patrol_cli/src/android/android_test_backend.dart';
 import 'package:patrol_cli/src/base/extensions/core.dart';
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/commands/dart_define_utils.dart';
+import 'package:patrol_cli/src/compatibility_checker/compatibility_checker.dart';
 import 'package:patrol_cli/src/crossplatform/app_options.dart';
 import 'package:patrol_cli/src/dart_defines_reader.dart';
 import 'package:patrol_cli/src/pubspec_reader.dart';
@@ -21,13 +22,15 @@ class BuildAndroidCommand extends PatrolCommand {
     required AndroidTestBackend androidTestBackend,
     required Analytics analytics,
     required Logger logger,
+    required CompatibilityChecker compatibilityChecker,
   })  : _testFinder = testFinder,
         _testBundler = testBundler,
         _dartDefinesReader = dartDefinesReader,
         _pubspecReader = pubspecReader,
         _androidTestBackend = androidTestBackend,
         _analytics = analytics,
-        _logger = logger {
+        _logger = logger,
+        _compatibilityChecker = compatibilityChecker {
     usesTargetOption();
     usesBuildModeOption();
     usesFlavorOption();
@@ -49,6 +52,7 @@ class BuildAndroidCommand extends PatrolCommand {
   final DartDefinesReader _dartDefinesReader;
   final PubspecReader _pubspecReader;
   final AndroidTestBackend _androidTestBackend;
+  final CompatibilityChecker _compatibilityChecker;
 
   final Analytics _analytics;
   final Logger _logger;
@@ -73,6 +77,12 @@ class BuildAndroidCommand extends PatrolCommand {
 
     final config = _pubspecReader.read();
     final testFileSuffix = config.testFileSuffix;
+
+    // Check compatibility between CLI and package versions
+    final patrolVersion = _pubspecReader.getPatrolVersion();
+    await _compatibilityChecker.checkVersionsCompatibilityWithWarning(
+      patrolVersion: patrolVersion,
+    );
 
     final target = stringsArg('target');
     final targets = target.isNotEmpty

--- a/packages/patrol_cli/lib/src/commands/build_android.dart
+++ b/packages/patrol_cli/lib/src/commands/build_android.dart
@@ -80,7 +80,7 @@ class BuildAndroidCommand extends PatrolCommand {
 
     // Check compatibility between CLI and package versions
     final patrolVersion = _pubspecReader.getPatrolVersion();
-    await _compatibilityChecker.checkVersionsCompatibilityWithWarning(
+    await _compatibilityChecker.checkVersionsCompatibilityForBuild(
       patrolVersion: patrolVersion,
     );
 

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -82,7 +82,7 @@ class BuildIOSCommand extends PatrolCommand {
 
     // Check compatibility between CLI and package versions
     final patrolVersion = _pubspecReader.getPatrolVersion();
-    await _compatibilityChecker.checkVersionsCompatibilityWithWarning(
+    await _compatibilityChecker.checkVersionsCompatibilityForBuild(
       patrolVersion: patrolVersion,
     );
 

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -4,6 +4,7 @@ import 'package:path/path.dart' show join;
 import 'package:patrol_cli/src/analytics/analytics.dart';
 import 'package:patrol_cli/src/base/extensions/core.dart';
 import 'package:patrol_cli/src/base/logger.dart';
+import 'package:patrol_cli/src/compatibility_checker/compatibility_checker.dart';
 import 'package:patrol_cli/src/crossplatform/app_options.dart';
 import 'package:patrol_cli/src/dart_defines_reader.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
@@ -21,13 +22,15 @@ class BuildIOSCommand extends PatrolCommand {
     required IOSTestBackend iosTestBackend,
     required Analytics analytics,
     required Logger logger,
+    required CompatibilityChecker compatibilityChecker,
   })  : _testFinder = testFinder,
         _testBundler = testBundler,
         _dartDefinesReader = dartDefinesReader,
         _pubspecReader = pubspecReader,
         _iosTestBackend = iosTestBackend,
         _analytics = analytics,
-        _logger = logger {
+        _logger = logger,
+        _compatibilityChecker = compatibilityChecker {
     usesTargetOption();
     usesBuildModeOption();
     usesFlavorOption();
@@ -51,6 +54,7 @@ class BuildIOSCommand extends PatrolCommand {
   final DartDefinesReader _dartDefinesReader;
   final PubspecReader _pubspecReader;
   final IOSTestBackend _iosTestBackend;
+  final CompatibilityChecker _compatibilityChecker;
 
   final Analytics _analytics;
   final Logger _logger;
@@ -75,6 +79,12 @@ class BuildIOSCommand extends PatrolCommand {
 
     final config = _pubspecReader.read();
     final testFileSuffix = config.testFileSuffix;
+
+    // Check compatibility between CLI and package versions
+    final patrolVersion = _pubspecReader.getPatrolVersion();
+    await _compatibilityChecker.checkVersionsCompatibilityWithWarning(
+      patrolVersion: patrolVersion,
+    );
 
     final target = stringsArg('target');
     final targets = target.isNotEmpty

--- a/packages/patrol_cli/lib/src/commands/build_macos.dart
+++ b/packages/patrol_cli/lib/src/commands/build_macos.dart
@@ -78,7 +78,7 @@ class BuildMacOSCommand extends PatrolCommand {
 
     // Check compatibility between CLI and package versions
     final patrolVersion = _pubspecReader.getPatrolVersion();
-    await _compatibilityChecker.checkVersionsCompatibilityWithWarning(
+    await _compatibilityChecker.checkVersionsCompatibilityForBuild(
       patrolVersion: patrolVersion,
     );
 

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -177,6 +177,11 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
         androidTestBackend: androidTestBackend,
         iosTestBackend: iosTestBackend,
         macosTestBackend: macosTestBackend,
+        compatibilityChecker: CompatibilityChecker(
+          projectRoot: rootDirectory,
+          processManager: _processManager,
+          logger: _logger,
+        ),
         analytics: _analytics,
         logger: _logger,
       ),


### PR DESCRIPTION
This PR adds an improved error system during the build and test processes that alerts users when they are using incompatible versions of patrol and patrol_cli. It enhances the error message shown during these commands when the compatibility check fails, providing clearer guidance on how to resolve version compatibility issues.

Addresses #2566.

-----------------

**Changes**

- Added version compatibility checks in all build commands (Android, iOS, macOS)
- Created a new helper method in CompatibilityChecker to show warnings without failing the build process
- Enhanced compatibility  error messages to include:
  - Clear explanation of the incompatibility issue
  - The maximum compatible CLI version for the project's patrol version
  - Specific command to downgrade to the compatible version
  - Option to upgrade both dependencies
  - Link to the compatibility table for reference
- Fixed a bug in build_macos.dart where it was incorrectly using iOS flavor configuration instead of macOS

-----------------

Given the scenario from #2566, a user will see the following when running patrol build or patrol test now when the compatibility check fails:

<img width="1006" alt="Screenshot 2025-04-14 at 10 49 13 PM" src="https://github.com/user-attachments/assets/6d9d9fb2-f2cd-496f-8d0e-e045ae0b61e2" />
