### PR TITLE
Introduce native swipe back mimic

### DIFF
--- a/dev/e2e_app/emulatorwtf.yaml
+++ b/dev/e2e_app/emulatorwtf.yaml
@@ -29,13 +29,13 @@ all_devices:
 ci_devices:
   device:
     - model: Pixel7
-      version: 31
+      version: 33
       gpu: auto
     - model: NexusLowRes
-      version: 31
+      version: 33
       gpu: auto
     - model: Tablet10
-      version: 31
+      version: 33
       gpu: auto
     # Unstable, see https://github.com/leancodepl/patrol/issues/1445
     # - model: Pixel2

--- a/dev/e2e_app/integration_test/swipe_back_test.dart
+++ b/dev/e2e_app/integration_test/swipe_back_test.dart
@@ -1,0 +1,18 @@
+import 'common.dart';
+
+void main() {
+  patrol(
+    'performs swipe back gesture ',
+    ($) async {
+      await createApp($);
+
+      final openLoadingScreenButton = $(find.text('Open loading screen'));
+
+      await openLoadingScreenButton.scrollTo().tap();
+
+      await $.native.swipeBack(dy: 0.6);
+
+      await openLoadingScreenButton.waitUntilExists();
+    },
+  );
+}

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add `$.native.swipeBack()` method (#2608)
+
 ## 3.16.0
 
 - Make activity aliases work in PatrolJUnitRunner

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -827,7 +827,7 @@ class NativeAutomator {
   ///
   /// Example usage:
   /// ```dart
-  /// await tester.swipeBack(height: 0.2); // Swipe back at 1/5 height of the screen
+  /// await tester.swipeBack(dy: 0.8); // Swipe back at 1/5 height of the screen
   /// await tester.swipeBack(); // Swipe back at the center of the screen
   /// ```
   Future<void> swipeBack({double dy = 0.5, String? appId}) {

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -810,6 +810,31 @@ class NativeAutomator {
     );
   }
 
+  /// Mimics the swipe back (left to right) gesture.
+  ///
+  /// [dy] determines the vertical offset of the swipe. It must be in the inclusive 0-1 range.
+  ///
+  /// [appId] optionally specifies the application ID to target.
+  ///
+  /// This is equivalent to:
+  /// $.native.swipe(
+  ///    from: Offset(0, dy),
+  ///    to: Offset(1, dy),
+  ///    appId: appId,
+  ///  );
+  ///
+  /// On Android, navigation with gestures might have to be turned on in devices settings.
+  ///
+  /// Example usage:
+  /// ```dart
+  /// await tester.swipeBack(height: 0.2); // Swipe back at 1/5 height of the screen
+  /// await tester.swipeBack(); // Swipe back at the center of the screen
+  /// ```
+  Future<void> swipeBack({double dy = 0.5, String? appId}) {
+    assert(dy >= 0.0 && dy <= 1.0, 'dy must be between 0.0 and 1.0');
+    return swipe(from: Offset(0, dy), to: Offset(1, dy), appId: appId);
+  }
+
   /// Waits until the native view specified by [selector] becomes visible.
   /// It waits for the view to become visible for [timeout] duration. If
   /// [timeout] is not specified, it utilizes the

--- a/packages/patrol/lib/src/native/native_automator2.dart
+++ b/packages/patrol/lib/src/native/native_automator2.dart
@@ -684,6 +684,31 @@ class NativeAutomator2 {
     );
   }
 
+  /// Mimics the swipe back (left to right) gesture.
+  ///
+  /// [dy] determines the vertical offset of the swipe. It must be in the inclusive 0-1 range.
+  ///
+  /// [appId] optionally specifies the application ID to target.
+  ///
+  /// This is equivalent to:
+  /// $.native.swipe(
+  ///    from: Offset(0, dy),
+  ///    to: Offset(1, dy),
+  ///    appId: appId,
+  ///  );
+  ///
+  /// On Android, navigation with gestures might have to be turned on in devices settings.
+  ///
+  /// Example usage:
+  /// ```dart
+  /// await tester.swipeBack(height: 0.2); // Swipe back at 1/5 height of the screen
+  /// await tester.swipeBack(); // Swipe back at the center of the screen
+  /// ```
+  Future<void> swipeBack({double dy = 0.5, String? appId}) {
+    assert(dy >= 0.0 && dy <= 1.0, 'dy must be between 0.0 and 1.0');
+    return swipe(from: Offset(0, dy), to: Offset(1, dy), appId: appId);
+  }
+
   /// Waits until the native view specified by [selector] becomes visible.
   /// It waits for the view to become visible for [timeout] duration. If
   /// [timeout] is not specified, it utilizes the

--- a/packages/patrol/lib/src/native/native_automator2.dart
+++ b/packages/patrol/lib/src/native/native_automator2.dart
@@ -701,7 +701,7 @@ class NativeAutomator2 {
   ///
   /// Example usage:
   /// ```dart
-  /// await tester.swipeBack(height: 0.2); // Swipe back at 1/5 height of the screen
+  /// await tester.swipeBack(dy: 0.8); // Swipe back at 1/5 height of the screen
   /// await tester.swipeBack(); // Swipe back at the center of the screen
   /// ```
   Future<void> swipeBack({double dy = 0.5, String? appId}) {


### PR DESCRIPTION
Adds `$.native.swipeBack()` for easy to use testing of navigation with gestures. 

Motivation:
I've stumbled upon necessity to do swipe back gesture in patrol tests in my current project. Necessity arose for iOS because on Android we can always do `pressBack()` but there is no corresponding method for iOS which is somewhat limiting patrol use-cases because requires introduction of back arrow, which although conventional might not be sth the decision maker wants in their app. Even with back button available it might still be handy to be able to verify if navigation with gestures work as intended.

Introduced method is supported for all current patrol compatible platforms (android, iOS, macOS).  

Please let me know if using already defined  `swipe()` is ok or I should introduce a separate `swipeBack` request to Automator Servers. 

Current status: Bumping API version on emulator.wtf caused one of the tests `mock_location_test.dart` to fail. Looking into it now...