### PR TITLE
Support inline and full-line comments in .patrol.env files

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Added support for comments in .patrol.env files. Lines starting with #, as well as any content following a # on the same line as a variable, are now ignored. This allows for both full-line and inline comments to improve file readability and documentation.
+
 ## 3.6.0-dev.1
 
 - Improve patrol test error messaging when compatibility check fails, added same compatibility check and error messaging to patrol build command (#2597)

--- a/packages/patrol_cli/lib/src/dart_defines_reader.dart
+++ b/packages/patrol_cli/lib/src/dart_defines_reader.dart
@@ -22,7 +22,10 @@ class DartDefinesReader {
     }
 
     final lines = file.readAsLinesSync()
-      ..removeWhere((line) => line.trim().isEmpty);
+      .map((line) => line.split('#').first.trim()) // Remove any characters in a line that are after # symbol.
+      .where((line) => line.isNotEmpty)
+      .toList();
+
     return _parse(lines);
   }
 

--- a/packages/patrol_cli/test/general/dart_defines_reader_test.dart
+++ b/packages/patrol_cli/test/general/dart_defines_reader_test.dart
@@ -81,6 +81,22 @@ void _test(Platform platform) {
           equals({'EMAIL': 'email@example.com', 'PASSWORD': 'ny4ncat'}),
         );
       });
+      test('reads correct simple input with comment on own line', () {
+        file.writeAsString('EMAIL=email@example.com\n#The password for the API\nPASSWORD=ny4ncat\n');
+
+        expect(
+          reader.fromFile(),
+          equals({'EMAIL': 'email@example.com', 'PASSWORD': 'ny4ncat'}),
+        );
+      });
+      test('reads correct simple input with comment on same line as variable', () {
+        file.writeAsString(' EMAIL=email@example.com  \nPASSWORD=ny4ncat # The password for the API\n');
+
+        expect(
+          reader.fromFile(),
+          equals({'EMAIL': 'email@example.com', 'PASSWORD': 'ny4ncat'}),
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
## Add support for comments in `.patrol.env` files

### Problem

Currently, `.patrol.env` files do not support comments. This makes it difficult to document the purpose of environment variables, provide context, or temporarily disable lines without deleting them.

### Solution

This PR adds support for both full-line and inline comments:

- Lines starting with `#` are now ignored completely.
- Inline comments are supported — any text following a `#` on the same line as a variable is stripped out.

### Example

```env
# This is the API key used in staging
API_KEY=abc123 # Replace with actual key

# This one is disabled for now
# DEBUG_MODE=true
```

### Benefits
- Improves readability and maintainability of .patrol.env files.
- Makes it easier for team members to understand or modify test configs.
- Compatible with existing .env file conventions.