### PR TITLE
fix: Support values with # in .patrol.env

### DIFF
--- a/packages/patrol_cli/lib/src/dart_defines_reader.dart
+++ b/packages/patrol_cli/lib/src/dart_defines_reader.dart
@@ -21,16 +21,21 @@ class DartDefinesReader {
       return {};
     }
 
-    final lines = file
-        .readAsLinesSync()
-        .map((line) => line
-            .split('#')
-            .first
-            .trim()) // Remove any characters in a line that are after # symbol.
+    final configRaw = file.readAsStringSync();
+    final lines = configRaw
+        .split('\n')
+        .map((line) => line.trim())
         .where((line) => line.isNotEmpty)
+        .where((line) => !line.startsWith('#')) // Remove comment lines.
         .toList();
 
-    return _parse(lines);
+    final propertyMap = <String, String>{};
+    for (final line in lines) {
+      final property = _parseProperty(line);
+      propertyMap[property.key] = property.value;
+    }
+
+    return propertyMap;
   }
 
   Map<String, String> _parse(List<String> args) {

--- a/packages/patrol_cli/test/general/dart_defines_reader_test.dart
+++ b/packages/patrol_cli/test/general/dart_defines_reader_test.dart
@@ -83,7 +83,8 @@ void _test(Platform platform) {
       });
       test('reads correct simple input with comment on own line', () {
         file.writeAsString(
-            'EMAIL=email@example.com\n#The password for the API\nPASSWORD=ny4ncat\n');
+          'EMAIL=email@example.com\n#The password for the API\nPASSWORD=ny4ncat\n',
+        );
 
         expect(
           reader.fromFile(),
@@ -93,7 +94,8 @@ void _test(Platform platform) {
       test('reads correct simple input with comment on same line as variable',
           () {
         file.writeAsString(
-            ' EMAIL=email@example.com  \nPASSWORD=ny4ncat # The password for the API\n');
+          ' EMAIL=email@example.com  \nPASSWORD=ny4ncat # The password for the API\n',
+        );
 
         expect(
           reader.fromFile(),
@@ -102,11 +104,40 @@ void _test(Platform platform) {
       });
       test('reads correct simple input with commented out variable', () {
         file.writeAsString(
-            ' EMAIL=email@example.com  \n#PASSWORD=ny4ncat # The password for the API\n');
+          ' EMAIL=email@example.com  \n#PASSWORD=ny4ncat # The password for the API\n',
+        );
 
         expect(
           reader.fromFile(),
           equals({'EMAIL': 'email@example.com'}),
+        );
+      });
+
+      test('reads correct input containing # characters in values', () {
+        file.writeAsString(
+          'URL="https://example.com/#section"\nFRAGMENT="value#with#hashes"\n',
+        );
+
+        expect(
+          reader.fromFile(),
+          equals({
+            'URL': 'https://example.com/#section',
+            'FRAGMENT': 'value#with#hashes',
+          }),
+        );
+      });
+
+      test('treats # as comment delimiter in unquoted values', () {
+        file.writeAsString(
+          'URL=https://example.com/ # This is a comment\nFRAGMENT=value # Another comment\n',
+        );
+
+        expect(
+          reader.fromFile(),
+          equals({
+            'URL': 'https://example.com/',
+            'FRAGMENT': 'value',
+          }),
         );
       });
     });


### PR DESCRIPTION
Change introduced in #2653 disallowed having `#` in key-value pairs inside `.patrol.env` as everything after this character would be (sometimes incorrectly) treated as a comment.