### PR TITLE
Fix patrol tags page; add warning about not number tags

### DIFF
--- a/docs/documentation/patrol-tags.mdx
+++ b/docs/documentation/patrol-tags.mdx
@@ -107,7 +107,6 @@ patrol test --tags='((login || payment) && (smoke || regression))'
 
 You can combine tag filtering with other Patrol CLI options:
 
-# Run specific test file with tag filtering
 ```
 patrol test --target integration_test/login_test.dart --tags smoke
 ```

--- a/docs/documentation/patrol-tags.mdx
+++ b/docs/documentation/patrol-tags.mdx
@@ -81,7 +81,7 @@ Patrol supports complex tag expressions using logical operators:
 - `&&` - AND operator (run tests with both tags)
 - `!` - NOT operator (exclude tests with this tag)
 
-<Warning>Tag can't be a number without any other sign</Warning>
+<Warning>Tag can't start or be just a number</Warning>
 For more information about tag rules, see: https://pub.dev/packages/test#tagging-tests
 
 ### Examples

--- a/docs/documentation/patrol-tags.mdx
+++ b/docs/documentation/patrol-tags.mdx
@@ -81,6 +81,7 @@ Patrol supports complex tag expressions using logical operators:
 - `&&` - AND operator (run tests with both tags)
 - `!` - NOT operator (exclude tests with this tag)
 
+<Warning>Tag can't be a number without any other sign</Warning>
 For more information about tag rules, see: https://pub.dev/packages/test#tagging-tests
 
 ### Examples
@@ -107,5 +108,6 @@ patrol test --tags='((login || payment) && (smoke || regression))'
 You can combine tag filtering with other Patrol CLI options:
 
 # Run specific test file with tag filtering
+```
 patrol test --target integration_test/login_test.dart --tags smoke
 ```

--- a/docs/documentation/patrol-tags.mdx
+++ b/docs/documentation/patrol-tags.mdx
@@ -81,7 +81,7 @@ Patrol supports complex tag expressions using logical operators:
 - `&&` - AND operator (run tests with both tags)
 - `!` - NOT operator (exclude tests with this tag)
 
-<Warning>Tag can't start or be just a number</Warning>
+<Warning>Note that tags must be valid Dart identifiers, although they may also contain hyphens.</Warning>
 For more information about tag rules, see: https://pub.dev/packages/test#tagging-tests
 
 ### Examples


### PR DESCRIPTION
Resolving https://github.com/leancodepl/patrol/issues/2609, not sure if we want to handle just numbered tags.