### PR TITLE
Remove PATROL_WAIT from internal Dart defines in develop and test com…

### DIFF
--- a/packages/patrol_cli/lib/src/commands/develop.dart
+++ b/packages/patrol_cli/lib/src/commands/develop.dart
@@ -165,7 +165,6 @@ class DevelopCommand extends PatrolCommand {
       ..._dartDefinesReader.fromCli(args: stringsArg('dart-define')),
     };
     final internalDartDefines = {
-      'PATROL_WAIT': defaultWait.toString(),
       'PATROL_APP_PACKAGE_NAME': packageName,
       'PATROL_APP_BUNDLE_ID': bundleId,
       'PATROL_MACOS_APP_BUNDLE_ID': config.macos.bundleId,

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -167,7 +167,6 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
     final bundleId = stringArg('bundle-id') ?? config.ios.bundleId;
     final macosBundleId = stringArg('bundle-id') ?? config.macos.bundleId;
 
-    final wait = intArg('wait') ?? defaultWait;
     final displayLabel = boolArg('label');
     final uninstall = boolArg('uninstall');
     final coverageEnabled = boolArg('coverage');
@@ -179,7 +178,6 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
       ..._dartDefinesReader.fromCli(args: stringsArg('dart-define')),
     };
     final internalDartDefines = {
-      'PATROL_WAIT': wait.toString(),
       'PATROL_APP_PACKAGE_NAME': packageName,
       'PATROL_APP_BUNDLE_ID': bundleId,
       'PATROL_MACOS_APP_BUNDLE_ID': macosBundleId,


### PR DESCRIPTION
patrol test throws error because there are some leftovers after removing --wait