### PR TITLE
fix: extend native enterText with AutoCompleteTextView.

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Extend `$.native.enterText()` on Android to support `AutoCompleteTextView`. (#1162)
+
 ## 3.17.0
 
 - Add `takeCameraPhoto` method. (#2660)

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -14,6 +14,7 @@ import android.os.SystemClock
 import android.provider.Settings
 import android.view.KeyEvent.KEYCODE_VOLUME_DOWN
 import android.view.KeyEvent.KEYCODE_VOLUME_UP
+import android.widget.AutoCompleteTextView
 import android.widget.EditText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
@@ -413,11 +414,28 @@ class Automator private constructor() {
         }
 
         var uiObject = uiDevice.findObject(uiSelector)
+        val uiObjectClassName = uiObject.getClassName()
 
-        val uiObjectClassname = uiObject.getClassName()
+        val supportedClassNames = setOf(
+            EditText::class.java.name,
+            AutoCompleteTextView::class.java.name
+        )
 
-        if (uiObjectClassname != EditText::class.java.name) {
-            uiObject = uiObject.getChild(UiSelector().className(EditText::class.java))
+        if (uiObjectClassName !in supportedClassNames) {
+            var hasSupportedChild = false
+            for (supportedClassName in supportedClassNames) {
+                try {
+                    uiObject = uiObject.getChild(UiSelector().className(supportedClassName))
+                    hasSupportedChild = true
+                    break
+                } catch (e: UiObjectNotFoundException) {
+                    // skip and try next
+                }
+            }
+
+            if (!hasSupportedChild) {
+                throw UiObjectNotFoundException("Could not find any supported child for $uiSelector")
+            }
         }
 
         if (keyboardBehavior == KeyboardBehavior.showAndDismiss) {

--- a/packages/patrol/lib/src/native/native_automator.dart
+++ b/packages/patrol/lib/src/native/native_automator.dart
@@ -702,7 +702,7 @@ class NativeAutomator {
   /// [NativeAutomatorConfig.findTimeout] duration from the configuration.
   ///
   /// The native view specified by [selector] must be:
-  ///  * EditText on Android
+  ///  * EditText or AutoCompleteTextView on Android
   ///  * TextField or SecureTextField on iOS
   ///
   /// See also:

--- a/packages/patrol/lib/src/native/native_automator2.dart
+++ b/packages/patrol/lib/src/native/native_automator2.dart
@@ -581,7 +581,7 @@ class NativeAutomator2 {
   /// [NativeAutomatorConfig.findTimeout] duration from the configuration.
   ///
   /// The native view specified by [selector] must be:
-  ///  * EditText on Android
+  ///  * EditText or AutoCompleteTextView on Android
   ///  * TextField or SecureTextField on iOS
   ///
   /// See also:


### PR DESCRIPTION
Resolved #1162

The search bar in Android inherits from `EditText` and could not be used before. This should fix this problem and also match `AutoCompleteTextView` for user input. The first commit addresses `$.native.enterText()` by selector and not with an additional index.

Two things:
- Searching for children of the expected widget when the selector was not found initially seems weird for me, but as it was there before I expanded it to work with the new type.
- I am not completely sure if and how to refactor enterText by index as we would need to add an await multiple selectors method.