### PR TITLE
Fix/darkmode ios 18 simulator

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix `$.native.enableDarkMode()` and `$.native.disableDarkMode()` on iOS 18. (#2705)
+
 ## 3.18.0
 
 - Bump `leancode_lint` to `17.0.0`.

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Fix logging for `$.native.pullToRefresh()` and `$.native.swipeBack()` (#2707) 
 - Fix `$.native.enableDarkMode()` and `$.native.disableDarkMode()` on iOS 18 simulators. (#2705)
+- Add support for de, fr and pl locales for native methods that operates on strings (#2659)
+- Add support for gallery permission dialog on iOS 17 (#2659)
 
 ## 3.18.0
 

--- a/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
@@ -396,6 +396,7 @@
           if let osVersionString = self.getOsVersion().split(separator: ".").first,
             let osVersion = Int(osVersionString)
           {
+            // For iOS 18 and above, we need to swipe to the developer option because it's is moved to the bottom of the list
             if osVersion >= 18 {
               let start = self.preferences.coordinate(
                 withNormalizedOffset: CGVector(dx: 0.5, dy: 0.9))

--- a/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
@@ -390,6 +390,9 @@
     func enableDarkMode(_ bundleId: String) throws {
       try runSettingsAction("enabling dark mode", bundleId) {
         #if targetEnvironment(simulator)
+          let start = self.preferences.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.9))
+          let end = self.preferences.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.3))
+          start.press(forDuration: 0.1, thenDragTo: end)
           self.preferences.descendants(matching: .any)["Developer"].firstMatch.tap()
 
           let value =
@@ -408,6 +411,9 @@
     func disableDarkMode(_ bundleId: String) throws {
       try runSettingsAction("disabling dark mode", bundleId) {
         #if targetEnvironment(simulator)
+          let start = self.preferences.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.9))
+          let end = self.preferences.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.3))
+          start.press(forDuration: 0.1, thenDragTo: end)
           self.preferences.descendants(matching: .any)["Developer"].firstMatch.tap()
 
           let value =

--- a/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/Automator/IOSAutomator.swift
@@ -390,9 +390,17 @@
     func enableDarkMode(_ bundleId: String) throws {
       try runSettingsAction("enabling dark mode", bundleId) {
         #if targetEnvironment(simulator)
-          let start = self.preferences.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.9))
-          let end = self.preferences.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.3))
-          start.press(forDuration: 0.1, thenDragTo: end)
+          if let osVersionString = self.getOsVersion().split(separator: ".").first,
+            let osVersion = Int(osVersionString)
+          {
+            if osVersion >= 18 {
+              let start = self.preferences.coordinate(
+                withNormalizedOffset: CGVector(dx: 0.5, dy: 0.9))
+              let end = self.preferences.coordinate(
+                withNormalizedOffset: CGVector(dx: 0.5, dy: 0.3))
+              start.press(forDuration: 0.1, thenDragTo: end)
+            }
+          }
           self.preferences.descendants(matching: .any)["Developer"].firstMatch.tap()
 
           let value =
@@ -411,9 +419,17 @@
     func disableDarkMode(_ bundleId: String) throws {
       try runSettingsAction("disabling dark mode", bundleId) {
         #if targetEnvironment(simulator)
-          let start = self.preferences.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.9))
-          let end = self.preferences.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.3))
-          start.press(forDuration: 0.1, thenDragTo: end)
+          if let osVersionString = self.getOsVersion().split(separator: ".").first,
+            let osVersion = Int(osVersionString)
+          {
+            if osVersion >= 18 {
+              let start = self.preferences.coordinate(
+                withNormalizedOffset: CGVector(dx: 0.5, dy: 0.9))
+              let end = self.preferences.coordinate(
+                withNormalizedOffset: CGVector(dx: 0.5, dy: 0.3))
+              start.press(forDuration: 0.1, thenDragTo: end)
+            }
+          }
           self.preferences.descendants(matching: .any)["Developer"].firstMatch.tap()
 
           let value =

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## Unreleased 
 
-- Add support for de, fr and pl locales for native methods that operates on strings (#2659)
-- Add support for gallery permission dialog on iOS 17 (#2659)
 - Add printing paths to the APKs after `patrol build` command. (#2685)
 
 ## 3.9.0


### PR DESCRIPTION
Fix for [#2393](https://github.com/leancodepl/patrol/issues/2393)
Add scroll on simulator iOS 18 devices to be able to click Developer options and change theme.