### PR TITLE
Update shown example to include a device that exists on browser stack

### DIFF
--- a/docs/integrations/browserstack.mdx
+++ b/docs/integrations/browserstack.mdx
@@ -58,7 +58,7 @@ Now reload your shell (e.g. `exec zsh`) and run `bs_android`:
 
 ```
 $ export BS_PROJECT=AwesomeApp # optional
-$ export BS_ANDROID_DEVICES="[\"Google Pixel 4-10.0\"]" # optional
+$ export BS_ANDROID_DEVICES="[\"Google Pixel 5-11.0\"]" # optional
 $ bs_android
 • Building apk with entrypoint test_bundle.dart...
 ✓ Completed building apk with entrypoint test_bundle.dart (11.0s)


### PR DESCRIPTION
\"Google Pixel 4-10.0\" is an invalid device identifier. Was probably removed at some point on browser stack side.

See list of supported devices here:
https://www.browserstack.com/list-of-browsers-and-platforms/app_automate