### PR TITLE
Correct the description of the `patrol build` command

### DIFF
--- a/docs/cli-commands/build.mdx
+++ b/docs/cli-commands/build.mdx
@@ -21,7 +21,7 @@ To see all available options and flags, run `patrol build android --help` or
 ### Description
 
 `patrol build` is useful if you want to run test on CI, for example on Firebase
-Test Lab. It works the same as `patrol test`, except that it does run tests.
+Test Lab. It works the same as `patrol test`, except that it does not run tests.
 
 `patrol build` builds apps in debug mode by default.
 


### PR DESCRIPTION
"It" refers to `patrol build` in this sentence.