### PR TITLE
Revert "feat: Implement patrol_log for develop mode on web"

### DIFF
--- a/packages/patrol_cli/lib/src/web/web_test_backend.dart
+++ b/packages/patrol_cli/lib/src/web/web_test_backend.dart
@@ -132,13 +132,10 @@ class WebTestBackend {
     if (io.stdin.hasTerminal) {
       previousStdinModes = flutterTool.enableInteractiveMode();
     }
-    final completer = Completer<String>();
-
-    _startPatrolLogReader(flutterProcess, completer);
 
     try {
       // Wait for server to be ready and get the URL
-      final port = await completer.future;
+      final port = await _waitForWebDebugger(flutterProcess);
 
       _attachForHotRestart(flutterProcess, switch (previousStdinModes) {
         final stdinModes? => () => flutterTool.revertInteractiveMode(
@@ -207,45 +204,6 @@ class WebTestBackend {
     return process;
   }
 
-  void _startPatrolLogReader(
-    Process flutterProcess,
-    Completer<String> completer,
-  ) {
-    PatrolLogReader(
-        scope: _disposeScope,
-        listenStdOut: flutterProcess.listenStdOut,
-        additionalOnData: (line) => _parseDebuggerPort(line, completer),
-        log: _logger.info,
-        reportPath: '',
-        showFlutterLogs: true,
-        hideTestSteps: false,
-        clearTestSteps: true,
-      )
-      ..listen()
-      ..startTimer();
-
-    Timer(const Duration(minutes: 2), () {
-      if (!completer.isCompleted) {
-        completer.completeError('Timeout waiting for web server to start');
-      }
-    });
-  }
-
-  void _parseDebuggerPort(String line, Completer<String> completer) {
-    _logger.detail('Flutter: $line');
-
-    // [CHROME]: DevTools listening on ws://127.0.0.1:38861/devtools/browser/431953d3-ef67-428f-9321-9317256022d0
-    final urlMatch = RegExp(
-      r'DevTools listening on ws://[^/]+:(\d+)',
-    ).firstMatch(line);
-
-    if (urlMatch != null && !completer.isCompleted) {
-      final port = urlMatch.group(1)!;
-      _logger.info('Debugger started at port: $port');
-      completer.complete(port);
-    }
-  }
-
   Future<String> _waitForWebServer(Process flutterProcess) {
     _logger.detail('Waiting for web server to start...');
 
@@ -307,6 +265,62 @@ class WebTestBackend {
               );
             }
           }
+        });
+
+    // Check if process exits unexpectedly
+    flutterProcess.exitCode.then((exitCode) {
+      if (!completer.isCompleted && exitCode != 0) {
+        stdoutSubscription.cancel();
+        stderrSubscription.cancel();
+        completer.completeError(
+          'Flutter process exited unexpectedly with code $exitCode',
+        );
+      }
+    }).ignore();
+
+    // Timeout after 2 minutes
+    Timer(const Duration(minutes: 2), () {
+      if (!completer.isCompleted) {
+        stdoutSubscription.cancel();
+        stderrSubscription.cancel();
+        completer.completeError('Timeout waiting for web server to start');
+      }
+    });
+
+    return completer.future;
+  }
+
+  Future<String> _waitForWebDebugger(Process flutterProcess) {
+    _logger.detail('Waiting for debugger to start...');
+
+    final completer = Completer<String>();
+    late StreamSubscription<String> stdoutSubscription;
+    late StreamSubscription<String> stderrSubscription;
+
+    stdoutSubscription = flutterProcess.stdout
+        .transform(const SystemEncoding().decoder)
+        .transform(const LineSplitter())
+        .listen((line) {
+          _logger.detail('Flutter: $line');
+
+          // [CHROME]: DevTools listening on ws://127.0.0.1:38861/devtools/browser/431953d3-ef67-428f-9321-9317256022d0
+          final urlMatch = RegExp(
+            r'DevTools listening on ws://[^/]+:(\d+)',
+          ).firstMatch(line);
+
+          if (urlMatch != null && !completer.isCompleted) {
+            final port = urlMatch.group(1)!;
+            _logger.info('Debugger started at port: $port');
+            completer.complete(port);
+          }
+        });
+
+    // Listen to stderr for errors
+    stderrSubscription = flutterProcess.stderr
+        .transform(const SystemEncoding().decoder)
+        .transform(const LineSplitter())
+        .listen((line) {
+          _logger.detail('Flutter stderr: $line');
         });
 
     // Check if process exits unexpectedly

--- a/packages/patrol_log/lib/src/patrol_log_reader.dart
+++ b/packages/patrol_log/lib/src/patrol_log_reader.dart
@@ -16,7 +16,6 @@ class PatrolLogReader {
     required this.showFlutterLogs,
     required this.hideTestSteps,
     required this.clearTestSteps,
-    this.additionalOnData,
   }) : _scope = scope;
 
   final void Function(String) log;
@@ -31,12 +30,6 @@ class PatrolLogReader {
     bool? cancelOnError,
   })
   listenStdOut;
-
-  /// Additional on data callback to be called when new data is received.
-  /// This is used to handle additional data that is not part of the patrol log.
-  /// As we can listen to the stdout of the process only once.
-  void Function(String)? additionalOnData;
-
   final DisposeScope _scope;
 
   /// Stopwatch measuring the whole tests duration.
@@ -93,7 +86,6 @@ class PatrolLogReader {
   /// Parse the line from the process output.
   void parse(String line) {
     try {
-      additionalOnData?.call(line);
       if (line.contains('PATROL_LOG')) {
         _parsePatrolLog(line);
       } else if (showFlutterLogs) {
@@ -103,8 +95,6 @@ class PatrolLogReader {
           ),
           _ when line.contains('I flutter :') => _parseFlutterAndroidLog(line),
           _ when line.contains('flutter:') => _parseFlutterIOsReleaseLog(line),
-          _ when RegExp(r'^\[.*?\]\s*(.*)').hasMatch(line) =>
-            _parseFlutterWebLog(line),
           _ when line.contains('Playwright:') => _parsePlaywrightLog(line),
           _ => null,
         };
@@ -157,14 +147,6 @@ class PatrolLogReader {
   void _parseFlutterAndroidLog(String line) {
     final regExp = RegExp('I flutter (.*)');
     final match = regExp.firstMatch(line);
-    if (match?.group(1) case final firstMatch?) {
-      log(firstMatch);
-    }
-  }
-
-  /// Parse the line containing Flutter logs and print them.
-  void _parseFlutterWebLog(String line) {
-    final match = RegExp(r'^\[.*?\]\s*(.*)').firstMatch(line);
     if (match?.group(1) case final firstMatch?) {
       log(firstMatch);
     }
@@ -239,7 +221,7 @@ class PatrolLogReader {
             '${entry.pretty()} ${AnsiCodes.gray}(${executionTime}s)${AnsiCodes.reset}',
           );
         case StepEntry():
-          _singleEntries.lastOrNull?.addEntry(entry);
+          _singleEntries.last.addEntry(entry);
           if (!hideTestSteps) {
             // Clear the previous line it's not the new step, or increment counter
             // for new step


### PR DESCRIPTION
Reverts leancodepl/patrol#2777

Reason for that revert is that in order to make this solution work we would have to release new version of `patrol_log` and go through the whole 'multiple packages release flow'. I think it makes no sense to do it now if we are not going to support develop yet