### PR TITLE
Fix/platform ios notification fallback

### DIFF
--- a/packages/patrol/darwin/Classes/AutomatorServer/AutomatorServer.swift
+++ b/packages/patrol/darwin/Classes/AutomatorServer/AutomatorServer.swift
@@ -268,7 +268,7 @@
           )
         } else if let selector = request.selector {
           try automator.tapOnNotification(
-            bySubstring: selector.textContains ?? String(),
+            bySubstring: selector.textContains ?? selector.titleContains ?? String(),
             withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) }
           )
         } else {


### PR DESCRIPTION
On master V4 it's
```
        if let index = request.index {
          try automator.tapOnNotification(
            byIndex: index,
            withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) }
          )
        } else if let selector = request.selector {
          try automator.tapOnNotification(
            bySubstring: selector.textContains ?? String(),
            withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) }
          )
        } else if let selector = request.iosSelector {
          try automator.tapOnNotification(
            bySubstring: selector.titleContains ?? String(),
            withTimeout: request.timeoutMillis.map { TimeInterval($0 / 1000) }
          )
        } else {
          throw PatrolError.internal("tapOnNotification(): neither index nor selector are set")
        }
```

and on platform automator branch we're missing `selector.titleContains` fallback - it made one of e2e app tests fail