### PR TITLE
fix tapOnNotificationByIndex on Android

### DIFF
--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -570,15 +570,18 @@ class Automator private constructor() {
         Logger.d("tapOnNotificationV2($index)")
 
         try {
-            val query = AndroidSelector(
-                resourceName = "android:id/status_bar_latest_event_content",
-                instance = index.toLong()
+            val queryForBySelector = AndroidSelector(
+                resourceName = "android:id/status_bar_latest_event_content"
             )
-            val selector = query.toBySelector()
+            val selector = queryForBySelector.toBySelector()
             if (waitForView(selector, index, timeout) == null) {
                 throw UiObjectNotFoundException("$selector")
             }
-            val obj = uiDevice.findObject(query.toUiSelector())
+            val queryForUiSelector = AndroidSelector(
+                resourceName = "android:id/status_bar_latest_event_content",
+                instance = index.toLong()
+            )
+            val obj = uiDevice.findObject(queryForUiSelector.toUiSelector())
             obj.click()
         } catch (err: UiObjectNotFoundException) {
             throw UiObjectNotFoundException("notification at index $index")


### PR DESCRIPTION
tapOnNotification function was creating an AndroidSelector with instance = index.toLong(), then converting it to BySelector. BySelector doesn't support instance(), causing the error:

```
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
The following PatrolActionException was thrown running a test:
Patrol action failed: IosAutomatorClientException:
tapOnNotificationByIndex() failed with Invalid response: 500
java.lang.IllegalArgumentException: instance() argument is not
supported for BySelector
```