### PR TITLE
fix: Catch TestFailure and exceptions in testBody to prevent test hang

### DIFF
--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -247,9 +247,26 @@ class PatrolBinding extends LiveTestWidgetsFlutterBinding {
       }
     };
 
-    await testBody();
+    try {
+      await testBody();
+    } catch (err, st) {
+      // Catch TestFailure and other exceptions thrown in testBody
+      if (_currentDartTest case final testName?) {
+        final previousDetails = switch (_testResults[testName]) {
+          Failure(:final details?) => details,
+          _ => null,
+        };
+        final detailsAsString = '$err\n$st';
 
-    FlutterError.onError = previousOnError;
+        _testResults[testName] = Failure(
+          testName,
+          '$detailsAsString${previousDetails != null ? '\n$previousDetails' : ''}',
+        );
+      }
+      rethrow;
+    } finally {
+      FlutterError.onError = previousOnError;
+    }
   }
 
   @override


### PR DESCRIPTION
## Problem

When `fail()` or an exception is thrown inside `patrolTest`, the test hangs indefinitely instead of failing properly.

## Cause

In `_wrapTestBodyWithExceptionGatherer`, only `FlutterError` was caught via `FlutterError.onError`. Regular exceptions and `TestFailure` (thrown by `fail()`) were not caught and therefore not recorded in `_testResults`. This prevented `tearDown` from properly reporting the test result to the native side.

## Solution

Wrap `testBody()` in a `try-catch-finally` block to:
1. Catch all exceptions, including `TestFailure`
2. Record them in `_testResults` for proper reporting
3. Rethrow to let the Flutter test framework handle the failure
4. Ensure `FlutterError.onError` is restored in `finally`