### PR TITLE
Update misleading error logging for Android automator

### DIFF
--- a/packages/patrol/lib/src/platform/android/android_automator_native.dart
+++ b/packages/patrol/lib/src/platform/android/android_automator_native.dart
@@ -130,7 +130,7 @@ class AndroidAutomator extends NativeMobileAutomator
 
       _config.logger('$name() failed');
       final log =
-          'IosAutomatorClientException: '
+          'AndroidAutomatorClientException: '
           '$name() failed with $err';
 
       if (enablePatrolLog) {


### PR DESCRIPTION
The PR just fixes a misleading error log label in the Android native automator wrapper so that thrown/logged exceptions correctly reference Android rather than iOS.