### PR TITLE
Wyjątek klienta automatora android

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Improve setup error reporting for Patrol Web failures. (#2928)
 - Fix `tapOnNotificationByIndex` and `getNotifications` on iOS 18+ to use consistent indexing with other systems. (#2899)
+- Fix Android native automator error logs to use `AndroidAutomatorClientException` instead of `IosAutomatorClientException`.
 
 # 4.1.1
 

--- a/packages/patrol/lib/src/platform/android/android_automator_native.dart
+++ b/packages/patrol/lib/src/platform/android/android_automator_native.dart
@@ -130,7 +130,7 @@ class AndroidAutomator extends NativeMobileAutomator
 
       _config.logger('$name() failed');
       final log =
-          'IosAutomatorClientException: '
+          'AndroidAutomatorClientException: '
           '$name() failed with $err';
 
       if (enablePatrolLog) {


### PR DESCRIPTION
Fix incorrect exception label in Android native automator error handling.

When Android native requests failed, the wrapped error message incorrectly reported an iOS exception type, which was misleading during debugging.

---
<p><a href="https://cursor.com/agents/bc-ade271d8-0f24-4e3a-9e02-815a790e7488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ade271d8-0f24-4e3a-9e02-815a790e7488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

