### PR TITLE
Fix Android automator exception label in error logs

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Improve setup error reporting for Patrol Web failures. (#2928)
 - Fix `tapOnNotificationByIndex` and `getNotifications` on iOS 18+ to use consistent indexing with other systems. (#2899)
+- Fix Android native automator error logs to use `AndroidAutomatorClientException` instead of `IosAutomatorClientException`.
 
 # 4.1.1
 

--- a/packages/patrol/lib/src/platform/android/android_automator_native.dart
+++ b/packages/patrol/lib/src/platform/android/android_automator_native.dart
@@ -130,7 +130,7 @@ class AndroidAutomator extends NativeMobileAutomator
 
       _config.logger('$name() failed');
       final log =
-          'IosAutomatorClientException: '
+          'AndroidAutomatorClientException: '
           '$name() failed with $err';
 
       if (enablePatrolLog) {


### PR DESCRIPTION
## Summary
- Fix incorrect exception label in Android native automator error handling.
- Replace `IosAutomatorClientException` with `AndroidAutomatorClientException` in `AndroidAutomator.wrapRequest()`.
- Update `packages/patrol/CHANGELOG.md` under `Unreleased`.
 
## Why
When Android native requests fail, the wrapped error message incorrectly reports an iOS exception type, which is misleading during debugging.
