### PR TITLE
fix: Update import for current_platform in binding.dart to use current.dart

### DIFF
--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
 import 'package:patrol/src/devtools_service_extensions/devtools_service_extensions.dart';
 import 'package:patrol/src/global_state.dart' as global_state;
-import 'package:patrol/src/platform/current_io.dart' as current_platform;
+import 'package:patrol/src/platform/current.dart' as current_platform;
 
 import 'constants.dart' as constants;
 


### PR DESCRIPTION
This pull request makes a minor update to the import path for the platform module in the `packages/patrol/lib/src/binding.dart` file. The change ensures the code references the correct platform abstraction.

* Updated the import statement to use `patrol/src/platform/current.dart` instead of `patrol/src/platform/current_io.dart` for platform-specific functionality.