### PR TITLE
fix: disable Chrome throttling options in Playwright configuration

### DIFF
--- a/packages/patrol/web_runner/playwright.config.ts
+++ b/packages/patrol/web_runner/playwright.config.ts
@@ -45,6 +45,13 @@ export default defineConfig({
     permissions,
     userAgent,
     viewport,
+    launchOptions: {
+      args: [
+        "--disable-background-timer-throttling",
+        "--disable-backgrounding-occluded-windows",
+        "--disable-renderer-backgrounding",
+      ],
+    },
   },
   globalSetup: require.resolve("./tests/setup"),
   outputDir,

--- a/packages/patrol/web_runner/tests/setup.ts
+++ b/packages/patrol/web_runner/tests/setup.ts
@@ -4,7 +4,13 @@ import { DartTestEntry, PatrolTestEntry } from "./types"
 
 async function setup(config: FullConfig) {
   const { baseURL } = config.projects[0].use
-  const browser = await chromium.launch()
+  const browser = await chromium.launch({
+    args: [
+      "--disable-background-timer-throttling",
+      "--disable-backgrounding-occluded-windows",
+      "--disable-renderer-backgrounding",
+    ],
+  })
   const page = await browser.newPage()
 
   if (!baseURL) {


### PR DESCRIPTION
chrome places some restrictions on background tabs, and this can hurt testing performance and loading time a lot, especially with large apps

https://developer.chrome.com/blog/background_tabs