### PR TITLE
feat(web): add multi-tab browser support for web tests

### DIFF
--- a/dev/e2e_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/dev/e2e_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -4,6 +4,7 @@
 
 import FlutterMacOS
 import Foundation
+
 import app_links
 import file_picker
 import file_saver
@@ -21,8 +22,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSaverPlugin.register(with: registry.registrar(forPlugin: "FileSaverPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
-  FlutterLocalNotificationsPlugin.register(
-    with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/dev/e2e_app/patrol_test/web/web_example_app.dart
+++ b/dev/e2e_app/patrol_test/web/web_example_app.dart
@@ -103,6 +103,13 @@ class _HomePage extends StatelessWidget {
                 label: const Text('Go to Page 1'),
               ),
               ElevatedButton.icon(
+                key: const Key('open_popup_button'),
+                onPressed: () =>
+                    web.window.open('about:blank', '_blank'),
+                icon: const Icon(Icons.open_in_new),
+                label: const Text('Open Popup Window'),
+              ),
+              ElevatedButton.icon(
                 onPressed: () => context.go('/iframe'),
                 icon: const Icon(Icons.web),
                 label: const Text('Go to Iframe Test'),

--- a/dev/e2e_app/patrol_test/web/web_example_multi_tab_navigation_test.dart
+++ b/dev/e2e_app/patrol_test/web/web_example_multi_tab_navigation_test.dart
@@ -1,0 +1,53 @@
+import '../common.dart';
+
+import 'web_example_app.dart';
+
+void main() {
+  patrol('interact with form in new tab while navigating Flutter app',
+      ($) async {
+    await $.pumpWidgetAndSettle(const WebExampleApp());
+
+    final formUrl = '${Uri.base.origin}/assets/assets/iframe_content.html';
+    final newTabId = await $.platform.web.openNewTab(url: formUrl);
+    await $.pumpAndSettle();
+    await Future<void>.delayed(const Duration(seconds: 2));
+
+    final tabsResult = await $.platform.web.getTabs();
+    final tabs = tabsResult['tabs'] as List<Object?>;
+    expect(tabs.length, 2);
+
+    // Fill form in the new tab
+    await $.platform.web.switchToTab(tabId: newTabId);
+    await $.pumpAndSettle();
+    await Future<void>.delayed(const Duration(seconds: 1));
+
+    await $.platform.web.enterText(
+      WebSelector(cssOrXpath: '#test-input'),
+      text: 'Patrol multi-tab test',
+    );
+    await $.platform.web.tap(WebSelector(cssOrXpath: '#submit-button'));
+    await Future<void>.delayed(const Duration(seconds: 1));
+
+    // Switch back and navigate the Flutter app
+    await $.platform.web.switchToTab(tabId: 'tab_0');
+    await $.pumpAndSettle();
+
+    await $('Go to Page 1').scrollTo().tap();
+    await $.pumpAndSettle();
+    await Future<void>.delayed(const Duration(seconds: 2));
+
+    expect($('This is Page 1'), findsOneWidget);
+
+    await $.platform.web.goBack();
+    await $.pumpAndSettle();
+    await Future<void>.delayed(const Duration(seconds: 2));
+
+    expect($('This is the home page'), findsOneWidget);
+
+    await $.platform.web.closeTab(tabId: newTabId);
+
+    final finalTabs = await $.platform.web.getTabs();
+    final remaining = finalTabs['tabs'] as List<Object?>;
+    expect(remaining.length, 1);
+  });
+}

--- a/dev/e2e_app/patrol_test/web/web_example_multi_tab_test.dart
+++ b/dev/e2e_app/patrol_test/web/web_example_multi_tab_test.dart
@@ -1,0 +1,101 @@
+import 'dart:collection';
+
+import '../common.dart';
+
+import 'web_example_app.dart';
+
+void main() {
+  patrol('open external page, fill form, and return to Flutter app', ($) async {
+    await $.pumpWidgetAndSettle(const WebExampleApp());
+
+    final formUrl = '${Uri.base.origin}/assets/assets/iframe_content.html';
+    final newTabId = await $.platform.web.openNewTab(url: formUrl);
+    await $.pumpAndSettle();
+    await Future<void>.delayed(const Duration(seconds: 2));
+
+    await $.platform.web.switchToTab(tabId: newTabId);
+    await $.pumpAndSettle();
+    await Future<void>.delayed(const Duration(seconds: 1));
+
+    final currentTab = await $.platform.web.getCurrentTab();
+    expect(currentTab, newTabId);
+
+    await $.platform.web.enterText(
+      WebSelector(cssOrXpath: '#test-input'),
+      text: 'Hello from new tab',
+    );
+    await $.platform.web.tap(WebSelector(cssOrXpath: '#submit-button'));
+    await Future<void>.delayed(const Duration(seconds: 1));
+
+    await $.platform.web.switchToTab(tabId: 'tab_0');
+    await $.pumpAndSettle();
+
+    expect(await $.platform.web.getCurrentTab(), 'tab_0');
+    expect($('This is the home page'), findsOneWidget);
+
+    await $.platform.web.closeTab(tabId: newTabId);
+  });
+
+  patrol('open leancode.co, accept cookies, and close tab', ($) async {
+    await $.pumpWidgetAndSettle(const WebExampleApp());
+
+    final newTabId = await $.platform.web.openNewTab(
+      url: 'https://leancode.co/',
+    );
+    await $.pumpAndSettle();
+    await Future<void>.delayed(const Duration(seconds: 3));
+
+    await $.platform.web.switchToTab(tabId: newTabId);
+    await $.pumpAndSettle();
+    await Future<void>.delayed(const Duration(seconds: 2));
+
+    await $.platform.web.tap(WebSelector(text: 'Accept All'));
+    await Future<void>.delayed(const Duration(seconds: 1));
+
+    await $.platform.web.switchToTab(tabId: 'tab_0');
+    await $.pumpAndSettle();
+
+    expect($('This is the home page'), findsOneWidget);
+
+    await $.platform.web.closeTab(tabId: newTabId);
+  });
+
+  patrol('cross-tab cookies persist across browser context', ($) async {
+    await $.pumpWidgetAndSettle(const WebExampleApp());
+
+    await $.platform.web.addCookie(
+      name: 'session',
+      value: 'abc123',
+      url: Uri.base.origin,
+    );
+
+    var cookies = await $.platform.web.getCookies();
+    var sessionCookie = cookies.firstWhere(
+      (c) => c['name'] == 'session',
+      orElse: LinkedHashMap<Object?, Object?>.new,
+    );
+    expect(sessionCookie['value'], 'abc123');
+
+    final formUrl = '${Uri.base.origin}/assets/assets/iframe_content.html';
+    final newTabId = await $.platform.web.openNewTab(url: formUrl);
+    await $.pumpAndSettle();
+    await Future<void>.delayed(const Duration(seconds: 2));
+
+    await $.platform.web.switchToTab(tabId: newTabId);
+    await $.pumpAndSettle();
+    await Future<void>.delayed(const Duration(seconds: 1));
+
+    cookies = await $.platform.web.getCookies();
+    sessionCookie = cookies.firstWhere(
+      (c) => c['name'] == 'session',
+      orElse: LinkedHashMap<Object?, Object?>.new,
+    );
+    expect(sessionCookie['value'], 'abc123');
+
+    await $.platform.web.switchToTab(tabId: 'tab_0');
+    await $.pumpAndSettle();
+
+    await $.platform.web.clearCookies();
+    await $.platform.web.closeTab(tabId: newTabId);
+  });
+}

--- a/dev/e2e_app/pubspec.lock
+++ b/dev/e2e_app/pubspec.lock
@@ -838,30 +838,30 @@ packages:
       path: "../../packages/patrol"
       relative: true
     source: path
-    version: "4.1.0"
+    version: "4.3.0"
   patrol_cli:
     dependency: "direct dev"
     description:
       path: "../../packages/patrol_cli"
       relative: true
     source: path
-    version: "4.0.2"
+    version: "4.2.0"
   patrol_finders:
     dependency: transitive
     description:
       name: patrol_finders
-      sha256: "2b46426a89498414ee5c24d2fbf34ba1796cc9dff4e49ce4322544bace03be6b"
+      sha256: ac0bfaf3eaaa6cc3d49c8a365329cc7f4361a5f486f1adb45edc96dbfc854da9
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.0"
   patrol_log:
     dependency: transitive
     description:
       name: patrol_log
-      sha256: "017fe7ea3ab662e78673a8acbbb7c96b71f38def59b70d44d0169887620e9fbf"
+      sha256: b3bd2862c15bd6b163763d7d2a80ae07c24af6da07d62d202798ceea327045d7
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.1"
   permission_handler:
     dependency: "direct main"
     description:

--- a/docs/documentation/web.mdx
+++ b/docs/documentation/web.mdx
@@ -94,4 +94,14 @@ await $.platform.web.enterTextWeb(selector: inputSelector, text: 'Hello from Pat
 await $.platform.web.tapWeb(selector: buttonSelector, iframeSelector: iframeSelector);
 // Window operations
 await $.platform.web.resizeWindow(size: Size(800, 600));
+// Multi-tab management
+final tabId = await $.platform.web.openNewTab(url: 'https://example.com');
+await $.platform.web.switchToTab(tabId: tabId);
+final currentTab = await $.platform.web.getCurrentTab();
+final tabs = await $.platform.web.getTabs();
+await $.platform.web.closeTab(tabId: tabId);
+final popupTabId = await $.platform.web.waitForPopup(
+  triggerAction: 'tap',
+  triggerParams: {'selector': buttonSelector},
+);
 ```

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add multi-tab browser support for web tests: `openNewTab`, `closeTab`, `switchToTab`, `getTabs`, `getCurrentTab`, `waitForPopup`. (#2871)
+
 ## 4.3.0
 
 - Fix WASM compatibility by migrating conditional imports from `dart.library.html` to `dart.library.js_interop`. (#2960)

--- a/packages/patrol/lib/src/platform/web/web_automator.dart
+++ b/packages/patrol/lib/src/platform/web/web_automator.dart
@@ -88,4 +88,28 @@ abstract interface class WebAutomator {
 
   /// Returns a list of all files downloaded during the single test.
   Future<List<String>> verifyFileDownloads();
+
+  /// Opens a new browser tab navigating to [url].
+  /// Returns the stable tab ID of the new tab.
+  Future<String> openNewTab({required String url});
+
+  /// Closes the tab with the given [tabId].
+  Future<void> closeTab({required String tabId});
+
+  /// Switches the active tab to [tabId].
+  /// All subsequent actions will target this tab until switched again.
+  Future<void> switchToTab({required String tabId});
+
+  /// Returns information about all open tabs.
+  Future<LinkedHashMap<Object?, Object?>> getTabs();
+
+  /// Returns the ID of the currently active tab.
+  Future<String> getCurrentTab();
+
+  /// Executes [triggerAction] and waits for a popup/new tab to open.
+  /// Returns the tab ID of the newly opened tab.
+  Future<String> waitForPopup({
+    required String triggerAction,
+    required Map<String, dynamic> triggerParams,
+  });
 }

--- a/packages/patrol/lib/src/platform/web/web_automator_native.dart
+++ b/packages/patrol/lib/src/platform/web/web_automator_native.dart
@@ -283,4 +283,71 @@ class WebAutomator implements web_automator.WebAutomator {
     );
     return (result as List<dynamic>).cast<String>();
   }
+
+  @override
+  Future<String> openNewTab({required String url}) async {
+    final result = await callPlaywright(
+      'openNewTab',
+      {'url': url},
+      logger: _config.logger,
+      patrolLog: _patrolLog,
+    );
+    return result as String;
+  }
+
+  @override
+  Future<void> closeTab({required String tabId}) async {
+    await callPlaywright(
+      'closeTab',
+      {'tabId': tabId},
+      logger: _config.logger,
+      patrolLog: _patrolLog,
+    );
+  }
+
+  @override
+  Future<void> switchToTab({required String tabId}) async {
+    await callPlaywright(
+      'switchToTab',
+      {'tabId': tabId},
+      logger: _config.logger,
+      patrolLog: _patrolLog,
+    );
+  }
+
+  @override
+  Future<LinkedHashMap<Object?, Object?>> getTabs() async {
+    final result = await callPlaywright(
+      'getTabs',
+      {},
+      logger: _config.logger,
+      patrolLog: _patrolLog,
+    );
+    return result as LinkedHashMap<Object?, Object?>;
+  }
+
+  @override
+  Future<String> getCurrentTab() async {
+    final result = await callPlaywright(
+      'getCurrentTab',
+      {},
+      logger: _config.logger,
+      patrolLog: _patrolLog,
+    );
+    return result as String;
+  }
+
+  @override
+  Future<String> waitForPopup({
+    required String triggerAction,
+    required Map<String, dynamic> triggerParams,
+  }) async {
+    final result = await callPlaywright(
+      'waitForPopup',
+      {'triggerAction': triggerAction, 'triggerParams': triggerParams},
+      logger: _config.logger,
+      patrolLog: _patrolLog,
+    );
+    return result as String;
+  }
 }

--- a/packages/patrol/web_runner/playwright.integration.config.ts
+++ b/packages/patrol/web_runner/playwright.integration.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./tests/__tests__",
+  testMatch: "**/*.integration.test.ts",
+  reporter: "list",
+  timeout: 30_000,
+  workers: 1,
+  use: {
+    headless: true,
+  },
+})

--- a/packages/patrol/web_runner/playwright.unit.config.ts
+++ b/packages/patrol/web_runner/playwright.unit.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./tests/__tests__",
+  testMatch: /^(?!.*\.integration\.).*\.test\.ts$/,
+  reporter: "list",
+  timeout: 10_000,
+  workers: 1,
+})

--- a/packages/patrol/web_runner/tests/__tests__/assumptions.integration.test.ts
+++ b/packages/patrol/web_runner/tests/__tests__/assumptions.integration.test.ts
@@ -1,0 +1,211 @@
+import { test, expect } from "@playwright/test"
+import { PageManager } from "../pageManager"
+import { startTest, downloadedFiles } from "../actions/startTest"
+
+// ---------------------------------------------------------------------------
+// Teardown tests
+// ---------------------------------------------------------------------------
+
+test("teardown closes secondary pages without errors", async ({ browser }) => {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  new PageManager(context, page)
+
+  // Open 3 additional pages
+  const second = await context.newPage()
+  const third = await context.newPage()
+  const fourth = await context.newPage()
+
+  expect(context.pages()).toHaveLength(4)
+
+  // Close one manually before teardown to simulate a page that was closed
+  // during the test itself
+  await third.close()
+  expect(context.pages()).toHaveLength(3)
+
+  // Run the exact teardown logic from test.spec.ts
+  for (const p of context.pages()) {
+    if (p !== page && !p.isClosed()) {
+      await p.close().catch(() => {})
+    }
+  }
+
+  // Only the initial page should remain
+  expect(context.pages()).toHaveLength(1)
+  expect(context.pages()[0]).toBe(page)
+
+  // The pages we closed should all report as closed
+  expect(second.isClosed()).toBe(true)
+  expect(third.isClosed()).toBe(true)
+  expect(fourth.isClosed()).toBe(true)
+
+  await context.close()
+})
+
+test("teardown handles page that was already closed", async ({ browser }) => {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+
+  // Open a secondary page and immediately close it
+  const secondary = await context.newPage()
+  await secondary.close()
+  expect(secondary.isClosed()).toBe(true)
+
+  // Run teardown — should NOT throw even though secondary is already closed.
+  // The isClosed() guard should skip it entirely.
+  await expect(
+    (async () => {
+      for (const p of context.pages()) {
+        if (p !== page && !p.isClosed()) {
+          await p.close().catch(() => {})
+        }
+      }
+    })(),
+  ).resolves.toBeUndefined()
+
+  // Only the initial page remains
+  expect(context.pages()).toHaveLength(1)
+  expect(context.pages()[0]).toBe(page)
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// Download tracking tests
+// ---------------------------------------------------------------------------
+
+test("download in a secondary tab is captured by verifyFileDownloads", async ({ browser }) => {
+  const context = await browser.newContext({ acceptDownloads: true })
+  const page = await context.newPage()
+  new PageManager(context, page)
+
+  // Set up download tracking via startTest
+  await startTest(page)
+
+  // Open a secondary page — startTest's context.on('page') listener should
+  // register a download listener on it automatically
+  const secondPage = await context.newPage()
+
+  // Trigger a download on the secondary page
+  await secondPage.setContent(`
+    <a href="data:text/plain,hello" download="test-file.txt">Download</a>
+  `)
+
+  const [download] = await Promise.all([secondPage.waitForEvent("download"), secondPage.click("a")])
+
+  // Wait for the download to finish so the event handler has fired
+  await download.path()
+
+  // Verify that downloadedFiles captured the file from the secondary tab
+  expect(downloadedFiles).toContain("test-file.txt")
+
+  await context.close()
+})
+
+test("download tracking is cleared between tests", async ({ browser }) => {
+  const context = await browser.newContext({ acceptDownloads: true })
+  const page = await context.newPage()
+
+  // First call to startTest should clear downloadedFiles
+  await startTest(page)
+  expect(downloadedFiles).toHaveLength(0)
+
+  // Trigger a download
+  await page.setContent(`
+    <a href="data:text/plain,hello" download="first-file.txt">Download</a>
+  `)
+
+  const [download1] = await Promise.all([page.waitForEvent("download"), page.click("a")])
+  await download1.path()
+
+  expect(downloadedFiles).toHaveLength(1)
+  expect(downloadedFiles[0]).toBe("first-file.txt")
+
+  // Calling startTest again should clear the list (simulates a new test run)
+  await startTest(page)
+  expect(downloadedFiles).toHaveLength(0)
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// Binding timing tests
+// ---------------------------------------------------------------------------
+
+test("context.exposeBinding works on a page that loaded content BEFORE the binding was set up", async ({
+  browser,
+}) => {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+
+  // Navigate to content FIRST — before any binding is registered
+  await page.setContent(`
+    <button id="test-btn">Click me</button>
+  `)
+
+  // THEN set up the binding on the context
+  let bindingCalled = false
+  let receivedArg: unknown = null
+  await context.exposeBinding("testBinding", (_source, arg) => {
+    bindingCalled = true
+    receivedArg = arg
+    return "binding-response"
+  })
+
+  // Call the binding from the already-loaded page
+  const result = await page.evaluate(async () => {
+    return await (window as any).testBinding("hello-from-page")
+  })
+
+  expect(bindingCalled).toBe(true)
+  expect(receivedArg).toBe("hello-from-page")
+  expect(result).toBe("binding-response")
+
+  await context.close()
+})
+
+test("context.exposeBinding works on a NEW page created AFTER the binding was set up", async ({ browser }) => {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+
+  // Set up binding on the context first
+  let bindingCalled = false
+  let receivedArg: unknown = null
+  await context.exposeBinding("testBinding", (_source, arg) => {
+    bindingCalled = true
+    receivedArg = arg
+    return "binding-response-new-page"
+  })
+
+  // Create a NEW page after the binding is in place
+  const newPage = await context.newPage()
+
+  // Set content on the new page
+  await newPage.setContent(`
+    <button id="test-btn">Click me</button>
+  `)
+
+  // Call the binding from the new page
+  const result = await newPage.evaluate(async () => {
+    return await (window as any).testBinding("hello-from-new-page")
+  })
+
+  expect(bindingCalled).toBe(true)
+  expect(receivedArg).toBe("hello-from-new-page")
+  expect(result).toBe("binding-response-new-page")
+
+  // Also verify the binding still works on the original page
+  bindingCalled = false
+  receivedArg = null
+
+  await page.setContent(`<div>original</div>`)
+  const resultOriginal = await page.evaluate(async () => {
+    return await (window as any).testBinding("hello-from-original")
+  })
+
+  expect(bindingCalled).toBe(true)
+  expect(receivedArg).toBe("hello-from-original")
+  expect(resultOriginal).toBe("binding-response-new-page")
+
+  await context.close()
+})

--- a/packages/patrol/web_runner/tests/__tests__/contracts.test.ts
+++ b/packages/patrol/web_runner/tests/__tests__/contracts.test.ts
@@ -1,0 +1,228 @@
+import { test, expect } from "@playwright/test"
+import type {
+  TapRequest,
+  EnterTextRequest,
+  ScrollToRequest,
+  OpenNewTabRequest,
+  CloseTabRequest,
+  SwitchToTabRequest,
+  GetTabsRequest,
+  GetCurrentTabRequest,
+  WaitForPopupRequest,
+  PatrolNativeRequest,
+} from "../contracts"
+
+// ---------------------------------------------------------------------------
+// Type-level helpers -- these are compile-time-only checks.
+// If a type does not satisfy the constraint the file will not compile.
+// ---------------------------------------------------------------------------
+
+// Asserts that type A is assignable to type B.
+type AssertAssignable<A, B extends A> = B
+
+// ---------------------------------------------------------------------------
+// 1. Existing requests still work WITHOUT tabId
+// ---------------------------------------------------------------------------
+
+type _TapWithoutTabId = AssertAssignable<
+  TapRequest,
+  {
+    action: "tap"
+    params: {
+      selector: {
+        role: null; label: null; placeholder: null; text: null
+        altText: null; title: null; testId: null; cssOrXpath: null
+      }
+      iframeSelector: null
+    }
+  }
+>
+
+// ---------------------------------------------------------------------------
+// 2. _routeToTab is optional on all requests (spot-check TapRequest, EnterTextRequest, ScrollToRequest)
+// ---------------------------------------------------------------------------
+
+type _TapWithRouteToTab = AssertAssignable<
+  TapRequest,
+  {
+    action: "tap"
+    params: {
+      selector: {
+        role: null; label: null; placeholder: null; text: null
+        altText: null; title: null; testId: null; cssOrXpath: null
+      }
+      iframeSelector: null
+      _routeToTab: "tab_1"
+    }
+  }
+>
+
+type _EnterTextWithRouteToTab = AssertAssignable<
+  EnterTextRequest,
+  {
+    action: "enterText"
+    params: {
+      selector: {
+        role: null; label: null; placeholder: null; text: null
+        altText: null; title: null; testId: null; cssOrXpath: null
+      }
+      text: "hello"
+      iframeSelector: null
+      _routeToTab: "tab_2"
+    }
+  }
+>
+
+type _ScrollToWithRouteToTab = AssertAssignable<
+  ScrollToRequest,
+  {
+    action: "scrollTo"
+    params: {
+      selector: {
+        role: null; label: null; placeholder: null; text: null
+        altText: null; title: null; testId: null; cssOrXpath: null
+      }
+      iframeSelector: null
+      _routeToTab: "tab_3"
+    }
+  }
+>
+
+// ---------------------------------------------------------------------------
+// 3. New request types exist and have the correct shape
+// ---------------------------------------------------------------------------
+
+type _OpenNewTab = AssertAssignable<
+  OpenNewTabRequest,
+  { action: "openNewTab"; params: { url: string } }
+>
+
+type _CloseTab = AssertAssignable<
+  CloseTabRequest,
+  { action: "closeTab"; params: { tabId: string } }
+>
+
+type _SwitchToTab = AssertAssignable<
+  SwitchToTabRequest,
+  { action: "switchToTab"; params: { tabId: string } }
+>
+
+type _GetTabs = AssertAssignable<
+  GetTabsRequest,
+  { action: "getTabs"; params: Record<string, never> }
+>
+
+type _GetCurrentTab = AssertAssignable<
+  GetCurrentTabRequest,
+  { action: "getCurrentTab"; params: Record<string, never> }
+>
+
+type _WaitForPopup = AssertAssignable<
+  WaitForPopupRequest,
+  {
+    action: "waitForPopup"
+    params: { triggerAction: string; triggerParams: Record<string, unknown> }
+  }
+>
+
+// ---------------------------------------------------------------------------
+// 4. New types are included in the PatrolNativeRequest union
+// ---------------------------------------------------------------------------
+
+type _UnionIncludesOpenNewTab = AssertAssignable<OpenNewTabRequest, Extract<PatrolNativeRequest, { action: "openNewTab" }>>
+type _UnionIncludesCloseTab = AssertAssignable<CloseTabRequest, Extract<PatrolNativeRequest, { action: "closeTab" }>>
+type _UnionIncludesSwitchToTab = AssertAssignable<SwitchToTabRequest, Extract<PatrolNativeRequest, { action: "switchToTab" }>>
+type _UnionIncludesGetTabs = AssertAssignable<GetTabsRequest, Extract<PatrolNativeRequest, { action: "getTabs" }>>
+type _UnionIncludesGetCurrentTab = AssertAssignable<GetCurrentTabRequest, Extract<PatrolNativeRequest, { action: "getCurrentTab" }>>
+type _UnionIncludesWaitForPopup = AssertAssignable<WaitForPopupRequest, Extract<PatrolNativeRequest, { action: "waitForPopup" }>>
+
+// ---------------------------------------------------------------------------
+// Runtime structure tests
+// ---------------------------------------------------------------------------
+
+test.describe("contract types - new multi-tab requests", () => {
+  test("OpenNewTabRequest has correct structure", () => {
+    const req: OpenNewTabRequest = { action: "openNewTab", params: { url: "https://example.com" } }
+    expect(req.action).toBe("openNewTab")
+    expect(req.params).toEqual({ url: "https://example.com" })
+  })
+
+  test("CloseTabRequest has correct structure", () => {
+    const req: CloseTabRequest = { action: "closeTab", params: { tabId: "tab_1" } }
+    expect(req.action).toBe("closeTab")
+    expect(req.params).toEqual({ tabId: "tab_1" })
+  })
+
+  test("SwitchToTabRequest has correct structure", () => {
+    const req: SwitchToTabRequest = { action: "switchToTab", params: { tabId: "tab_2" } }
+    expect(req.action).toBe("switchToTab")
+    expect(req.params).toEqual({ tabId: "tab_2" })
+  })
+
+  test("GetTabsRequest has correct structure", () => {
+    const req: GetTabsRequest = { action: "getTabs", params: {} }
+    expect(req.action).toBe("getTabs")
+    expect(req.params).toEqual({})
+  })
+
+  test("GetCurrentTabRequest has correct structure", () => {
+    const req: GetCurrentTabRequest = { action: "getCurrentTab", params: {} }
+    expect(req.action).toBe("getCurrentTab")
+    expect(req.params).toEqual({})
+  })
+
+  test("WaitForPopupRequest has correct structure", () => {
+    const req: WaitForPopupRequest = {
+      action: "waitForPopup",
+      params: { triggerAction: "tap", triggerParams: { selector: "button" } },
+    }
+    expect(req.action).toBe("waitForPopup")
+    expect(req.params.triggerAction).toBe("tap")
+    expect(req.params.triggerParams).toEqual({ selector: "button" })
+  })
+})
+
+test.describe("contract types - _routeToTab is optional on existing requests", () => {
+  test("TapRequest accepts _routeToTab in params", () => {
+    const req: TapRequest = {
+      action: "tap",
+      params: {
+        selector: {
+          role: null, label: null, placeholder: null, text: null,
+          altText: null, title: null, testId: null, cssOrXpath: null,
+        },
+        iframeSelector: null,
+        _routeToTab: "tab_1",
+      },
+    }
+    expect(req.params._routeToTab).toBe("tab_1")
+  })
+
+  test("TapRequest works without _routeToTab (backward compatible)", () => {
+    const req: TapRequest = {
+      action: "tap",
+      params: {
+        selector: {
+          role: null, label: null, placeholder: null, text: null,
+          altText: null, title: null, testId: null, cssOrXpath: null,
+        },
+        iframeSelector: null,
+      },
+    }
+    expect(req.params).not.toHaveProperty("_routeToTab")
+  })
+})
+
+test.describe("contract types - union includes new request types", () => {
+  test("PatrolNativeRequest union accepts all new tab types", () => {
+    const requests: PatrolNativeRequest[] = [
+      { action: "openNewTab", params: { url: "https://example.com" } },
+      { action: "closeTab", params: { tabId: "tab_1" } },
+      { action: "switchToTab", params: { tabId: "tab_2" } },
+      { action: "getTabs", params: {} },
+      { action: "getCurrentTab", params: {} },
+      { action: "waitForPopup", params: { triggerAction: "tap", triggerParams: {} } },
+    ]
+    expect(requests).toHaveLength(6)
+  })
+})

--- a/packages/patrol/web_runner/tests/__tests__/existingActions.integration.test.ts
+++ b/packages/patrol/web_runner/tests/__tests__/existingActions.integration.test.ts
@@ -1,0 +1,682 @@
+import { test, expect, BrowserContext, Page } from "@playwright/test"
+import { PageManager } from "../pageManager"
+import { handlePatrolPlatformAction } from "../patrolPlatformHandler"
+import { WebSelector } from "../contracts"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a full WebSelector with only the specified fields set; all others null. */
+function selector(overrides: Partial<WebSelector>): WebSelector {
+  return {
+    role: null,
+    label: null,
+    placeholder: null,
+    text: null,
+    altText: null,
+    title: null,
+    testId: null,
+    cssOrXpath: null,
+    ...overrides,
+  }
+}
+
+/** Shorthand: create isolated context + page + PageManager and tear down afterwards. */
+async function setup(browser: import("@playwright/test").Browser) {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  const pageManager = new PageManager(context, page)
+  return { context, page, pageManager }
+}
+
+// ---------------------------------------------------------------------------
+// 1. tap
+// ---------------------------------------------------------------------------
+test("tap - clicks a button through the dispatch layer", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await page.setContent(`
+    <button data-testid="clicker">Click me</button>
+    <span id="result"></span>
+    <script>
+      document.querySelector('[data-testid="clicker"]')
+        .addEventListener('click', () => {
+          document.getElementById('result').textContent = 'clicked';
+        });
+    </script>
+  `)
+
+  await handlePatrolPlatformAction(pageManager, {
+    action: "tap",
+    params: {
+      selector: selector({ testId: "clicker" }),
+      iframeSelector: null,
+    },
+  })
+
+  const resultText = await page.locator("#result").textContent()
+  expect(resultText).toBe("clicked")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 2. enterText
+// ---------------------------------------------------------------------------
+test("enterText - fills an input through the dispatch layer", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await page.setContent(`<input data-testid="name-input" type="text" />`)
+
+  await handlePatrolPlatformAction(pageManager, {
+    action: "enterText",
+    params: {
+      selector: selector({ testId: "name-input" }),
+      text: "Hello Patrol",
+      iframeSelector: null,
+    },
+  })
+
+  const value = await page.locator('[data-testid="name-input"]').inputValue()
+  expect(value).toBe("Hello Patrol")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 3. enableDarkMode
+// ---------------------------------------------------------------------------
+test("enableDarkMode - emulates dark color scheme without crashing", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await page.setContent(`
+    <style>
+      body { background: white; }
+      @media (prefers-color-scheme: dark) { body { background: black; } }
+    </style>
+    <body></body>
+  `)
+
+  await handlePatrolPlatformAction(pageManager, {
+    action: "enableDarkMode",
+    params: {},
+  })
+
+  const bg = await page.evaluate(() => getComputedStyle(document.body).backgroundColor)
+  // "rgb(0, 0, 0)" is black
+  expect(bg).toBe("rgb(0, 0, 0)")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 4. disableDarkMode
+// ---------------------------------------------------------------------------
+test("disableDarkMode - emulates light color scheme without crashing", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  // First enable dark mode, then disable it
+  await page.setContent(`
+    <style>
+      body { background: white; }
+      @media (prefers-color-scheme: dark) { body { background: black; } }
+    </style>
+    <body></body>
+  `)
+
+  await handlePatrolPlatformAction(pageManager, {
+    action: "enableDarkMode",
+    params: {},
+  })
+
+  await handlePatrolPlatformAction(pageManager, {
+    action: "disableDarkMode",
+    params: {},
+  })
+
+  const bg = await page.evaluate(() => getComputedStyle(document.body).backgroundColor)
+  // "rgb(255, 255, 255)" is white
+  expect(bg).toBe("rgb(255, 255, 255)")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 5. goBack / goForward
+// ---------------------------------------------------------------------------
+test("goBack and goForward - navigate browser history", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  // Use route interception to serve two distinct pages without network calls
+  await context.route("**/page-one", route =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<html><body><h1>Page One</h1></body></html>",
+    }),
+  )
+  await context.route("**/page-two", route =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<html><body><h1>Page Two</h1></body></html>",
+    }),
+  )
+
+  await page.goto("http://localhost/page-one")
+  await page.goto("http://localhost/page-two")
+  expect(page.url()).toContain("page-two")
+
+  // Go back
+  await handlePatrolPlatformAction(pageManager, {
+    action: "goBack",
+    params: {},
+  })
+  expect(page.url()).toContain("page-one")
+
+  // Go forward
+  await handlePatrolPlatformAction(pageManager, {
+    action: "goForward",
+    params: {},
+  })
+  expect(page.url()).toContain("page-two")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 6. pressKey
+// ---------------------------------------------------------------------------
+test("pressKey - types a key into a focused input", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await page.setContent(`<input data-testid="key-input" type="text" />`)
+  await page.locator('[data-testid="key-input"]').focus()
+
+  await handlePatrolPlatformAction(pageManager, {
+    action: "pressKey",
+    params: { key: "a" },
+  })
+
+  const value = await page.locator('[data-testid="key-input"]').inputValue()
+  expect(value).toBe("a")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 7. pressKeyCombo
+// ---------------------------------------------------------------------------
+test("pressKeyCombo - sends a key combination", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await page.setContent(`
+    <span id="combo-result"></span>
+    <script>
+      document.addEventListener('keydown', (e) => {
+        if (e.shiftKey && e.key === 'A') {
+          document.getElementById('combo-result').textContent = 'Shift+A pressed';
+        }
+      });
+    </script>
+  `)
+
+  // Send Shift+A key combo through the dispatch layer
+  await handlePatrolPlatformAction(pageManager, {
+    action: "pressKeyCombo",
+    params: { keys: ["Shift", "A"] },
+  })
+
+  const resultText = await page.locator("#combo-result").textContent()
+  expect(resultText).toBe("Shift+A pressed")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 8. acceptNextDialog
+// ---------------------------------------------------------------------------
+test("acceptNextDialog - accepts an alert and returns its message", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await page.setContent(`<button data-testid="alert-btn">Alert</button>`)
+
+  // Register the dialog handler BEFORE triggering the dialog
+  const dialogPromise = handlePatrolPlatformAction(pageManager, {
+    action: "acceptNextDialog",
+    params: {},
+  })
+
+  // Trigger the alert
+  await page.evaluate(() => alert("Hello from alert"))
+
+  const message = await dialogPromise
+  expect(message).toBe("Hello from alert")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 9. dismissNextDialog
+// ---------------------------------------------------------------------------
+test("dismissNextDialog - dismisses a confirm and returns its message", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await page.setContent(`<div id="result"></div>`)
+
+  // Register the dialog handler BEFORE triggering the dialog
+  const dialogPromise = handlePatrolPlatformAction(pageManager, {
+    action: "dismissNextDialog",
+    params: {},
+  })
+
+  // Trigger a confirm dialog (dismiss returns false for confirm)
+  await page.evaluate(() => {
+    const result = confirm("Shall we proceed?")
+    document.getElementById("result")!.textContent = result ? "yes" : "no"
+  })
+
+  const message = await dialogPromise
+  expect(message).toBe("Shall we proceed?")
+
+  // Confirm was dismissed, so result should be "no"
+  const resultText = await page.locator("#result").textContent()
+  expect(resultText).toBe("no")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 10. addCookie / getCookies / clearCookies
+// ---------------------------------------------------------------------------
+test("addCookie, getCookies, clearCookies - full cookie lifecycle", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  // Cookies need a real origin; use a routed page
+  await context.route("**/cookie-page", route =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<html><body>Cookie Page</body></html>",
+    }),
+  )
+  await page.goto("http://localhost/cookie-page")
+
+  // Add a cookie
+  await handlePatrolPlatformAction(pageManager, {
+    action: "addCookie",
+    params: {
+      name: "patrol_test",
+      value: "abc123",
+      domain: "localhost",
+      path: "/",
+      url: null,
+      expires: null,
+      httpOnly: null,
+      secure: null,
+      sameSite: null,
+    },
+  })
+
+  // Get cookies and verify
+  const cookies = (await handlePatrolPlatformAction(pageManager, {
+    action: "getCookies",
+    params: {},
+  })) as any[]
+
+  expect(cookies).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ name: "patrol_test", value: "abc123" }),
+    ]),
+  )
+
+  // Clear cookies
+  await handlePatrolPlatformAction(pageManager, {
+    action: "clearCookies",
+    params: {},
+  })
+
+  // Verify cookies are gone
+  const cookiesAfterClear = (await handlePatrolPlatformAction(pageManager, {
+    action: "getCookies",
+    params: {},
+  })) as any[]
+
+  expect(cookiesAfterClear).toHaveLength(0)
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 11. grantPermissions / clearPermissions
+// ---------------------------------------------------------------------------
+test("grantPermissions and clearPermissions - execute without error", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  // Navigate to a routed page so we have a valid origin
+  await context.route("**/perm-page", route =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<html><body>Permissions Page</body></html>",
+    }),
+  )
+  await page.goto("http://localhost/perm-page")
+
+  // Grant permissions (geolocation is commonly supported)
+  await handlePatrolPlatformAction(pageManager, {
+    action: "grantPermissions",
+    params: {
+      permissions: ["geolocation"],
+      origin: "http://localhost",
+    },
+  })
+
+  // Clear permissions
+  await handlePatrolPlatformAction(pageManager, {
+    action: "clearPermissions",
+    params: {},
+  })
+
+  // If we got here without throwing, the actions work through the dispatch layer
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 12. resizeWindow
+// ---------------------------------------------------------------------------
+test("resizeWindow - changes the viewport size", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await page.setContent("<html><body>Resize test</body></html>")
+
+  await handlePatrolPlatformAction(pageManager, {
+    action: "resizeWindow",
+    params: { width: 800, height: 600 },
+  })
+
+  const viewportSize = page.viewportSize()
+  expect(viewportSize).toEqual({ width: 800, height: 600 })
+
+  // Resize again to a different size to prove it actually changes
+  await handlePatrolPlatformAction(pageManager, {
+    action: "resizeWindow",
+    params: { width: 1024, height: 768 },
+  })
+
+  const newViewportSize = page.viewportSize()
+  expect(newViewportSize).toEqual({ width: 1024, height: 768 })
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 13. setClipboard / getClipboard
+// ---------------------------------------------------------------------------
+test("setClipboard and getClipboard - round-trip clipboard text", async ({ browser }) => {
+  // Grant clipboard permissions via context options
+  const context = await browser.newContext({
+    permissions: ["clipboard-read", "clipboard-write"],
+  })
+  const page = await context.newPage()
+  const pageManager = new PageManager(context, page)
+
+  // Need a page with an origin for clipboard API to work
+  await context.route("**/clipboard-page", route =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<html><body>Clipboard test</body></html>",
+    }),
+  )
+  await page.goto("http://localhost/clipboard-page")
+
+  // Set clipboard
+  await handlePatrolPlatformAction(pageManager, {
+    action: "setClipboard",
+    params: { text: "patrol clipboard test" },
+  })
+
+  // Get clipboard
+  const clipboardText = await handlePatrolPlatformAction(pageManager, {
+    action: "getClipboard",
+    params: {},
+  })
+
+  expect(clipboardText).toBe("patrol clipboard test")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 14. scrollTo
+// ---------------------------------------------------------------------------
+test("scrollTo - scrolls an element into view", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await page.setContent(`
+    <div style="height: 3000px;">
+      <div style="height: 2500px;">Spacer</div>
+      <div data-testid="scroll-target">Target element</div>
+    </div>
+  `)
+
+  // Verify the element is NOT in the viewport initially
+  const initiallyVisible = await page.locator('[data-testid="scroll-target"]').isVisible()
+  // The element exists in the DOM but is far below the fold
+  expect(initiallyVisible).toBe(true) // visible in DOM, but not in viewport
+
+  const scrollYBefore = await page.evaluate(() => window.scrollY)
+  expect(scrollYBefore).toBe(0)
+
+  await handlePatrolPlatformAction(pageManager, {
+    action: "scrollTo",
+    params: {
+      selector: selector({ testId: "scroll-target" }),
+      iframeSelector: null,
+    },
+  })
+
+  // After scrollTo, the page should have scrolled down
+  const scrollYAfter = await page.evaluate(() => window.scrollY)
+  expect(scrollYAfter).toBeGreaterThan(0)
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 15. tap with cssOrXpath selector
+// ---------------------------------------------------------------------------
+test("tap - works with cssOrXpath selector variant", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await page.setContent(`
+    <button class="my-btn">CSS Button</button>
+    <span id="result"></span>
+    <script>
+      document.querySelector('.my-btn')
+        .addEventListener('click', () => {
+          document.getElementById('result').textContent = 'css-clicked';
+        });
+    </script>
+  `)
+
+  await handlePatrolPlatformAction(pageManager, {
+    action: "tap",
+    params: {
+      selector: selector({ cssOrXpath: ".my-btn" }),
+      iframeSelector: null,
+    },
+  })
+
+  const resultText = await page.locator("#result").textContent()
+  expect(resultText).toBe("css-clicked")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 16. tap with text selector
+// ---------------------------------------------------------------------------
+test("tap - works with text selector variant", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await page.setContent(`
+    <button>Unique Text Button</button>
+    <span id="result"></span>
+    <script>
+      document.querySelector('button')
+        .addEventListener('click', () => {
+          document.getElementById('result').textContent = 'text-clicked';
+        });
+    </script>
+  `)
+
+  await handlePatrolPlatformAction(pageManager, {
+    action: "tap",
+    params: {
+      selector: selector({ text: "Unique Text Button" }),
+      iframeSelector: null,
+    },
+  })
+
+  const resultText = await page.locator("#result").textContent()
+  expect(resultText).toBe("text-clicked")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 17. enterText with placeholder selector
+// ---------------------------------------------------------------------------
+test("enterText - works with placeholder selector", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await page.setContent(`<input placeholder="Enter your email" type="text" />`)
+
+  await handlePatrolPlatformAction(pageManager, {
+    action: "enterText",
+    params: {
+      selector: selector({ placeholder: "Enter your email" }),
+      text: "test@example.com",
+      iframeSelector: null,
+    },
+  })
+
+  const value = await page.locator('[placeholder="Enter your email"]').inputValue()
+  expect(value).toBe("test@example.com")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 18. startTest - initializes download listener
+// ---------------------------------------------------------------------------
+test("startTest - executes without error through dispatch layer", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await page.setContent("<html><body>Start test page</body></html>")
+
+  // startTest should not throw
+  await handlePatrolPlatformAction(pageManager, {
+    action: "startTest",
+    params: {},
+  })
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 19. dispatch of unknown action throws
+// ---------------------------------------------------------------------------
+test("dispatch of unknown action throws an error", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await expect(
+    handlePatrolPlatformAction(pageManager, {
+      action: "unknown-placeholder-nonexistent" as any,
+      params: {},
+    }),
+  ).rejects.toThrow(/not found/)
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 20. tabId routing - action dispatches to the correct tab
+// ---------------------------------------------------------------------------
+test("tabId routing - actions target the correct tab via dispatch", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  // Open a second tab
+  const tabId = await handlePatrolPlatformAction(pageManager, {
+    action: "openNewTab",
+    params: { url: "about:blank" },
+  })
+  expect(tabId).toBe("tab_1")
+
+  // Set content on tab_1 directly (for setup purposes)
+  const tab1Page = pageManager.resolve("tab_1")
+  await tab1Page.setContent(`<input data-testid="tab1-input" type="text" />`)
+
+  // Dispatch enterText with tabId targeting tab_1
+  await handlePatrolPlatformAction(pageManager, {
+    action: "enterText",
+    params: {
+      _routeToTab: "tab_1",
+      selector: selector({ testId: "tab1-input" }),
+      text: "typed in tab 1",
+      iframeSelector: null,
+    },
+  })
+
+  const value = await tab1Page.locator('[data-testid="tab1-input"]').inputValue()
+  expect(value).toBe("typed in tab 1")
+
+  await context.close()
+})
+
+// ---------------------------------------------------------------------------
+// 21. addCookie with extra options (httpOnly, secure, sameSite)
+// ---------------------------------------------------------------------------
+test("addCookie - supports additional cookie properties", async ({ browser }) => {
+  const { context, page, pageManager } = await setup(browser)
+
+  await context.route("**/cookie-page", route =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<html><body>Cookie Page</body></html>",
+    }),
+  )
+  await page.goto("http://localhost/cookie-page")
+
+  await handlePatrolPlatformAction(pageManager, {
+    action: "addCookie",
+    params: {
+      name: "session_id",
+      value: "xyz789",
+      domain: "localhost",
+      path: "/",
+      url: null,
+      expires: null,
+      httpOnly: true,
+      secure: false,
+      sameSite: "Lax",
+    },
+  })
+
+  const cookies = (await handlePatrolPlatformAction(pageManager, {
+    action: "getCookies",
+    params: {},
+  })) as any[]
+
+  const sessionCookie = cookies.find((c: any) => c.name === "session_id")
+  expect(sessionCookie).toBeDefined()
+  expect(sessionCookie.value).toBe("xyz789")
+  expect(sessionCookie.httpOnly).toBe(true)
+  expect(sessionCookie.sameSite).toBe("Lax")
+
+  await context.close()
+})

--- a/packages/patrol/web_runner/tests/__tests__/multiTab.integration.test.ts
+++ b/packages/patrol/web_runner/tests/__tests__/multiTab.integration.test.ts
@@ -1,0 +1,193 @@
+import { test, expect, BrowserContext } from "@playwright/test"
+import { PageManager } from "../pageManager"
+import { openNewTab } from "../actions/openNewTab"
+import { closeTab } from "../actions/closeTab"
+import { switchToTab } from "../actions/switchToTab"
+import { getTabs } from "../actions/getTabs"
+import { getCurrentTab } from "../actions/getCurrentTab"
+import { handlePatrolPlatformAction } from "../patrolPlatformHandler"
+
+// Local HTML content served via route interception — no network access needed.
+const TEST_PAGE_HTML = `<!DOCTYPE html>
+<html><head><title>Test Page</title></head>
+<body><h1>Test Page</h1><p>Local content for integration tests.</p></body></html>`
+
+const TEST_PAGE_2_HTML = `<!DOCTYPE html>
+<html><head><title>Second Page</title></head>
+<body><h1>Second Page</h1><p>Another local page.</p></body></html>`
+
+const POPUP_TARGET_HTML = `<!DOCTYPE html>
+<html><head><title>Popup Target</title></head>
+<body><h1>Popup Target</h1><p>Opened via window.open().</p></body></html>`
+
+/**
+ * Intercept all requests to https://test.local/** and serve local HTML.
+ * This lets us exercise the full openNewTab code path (newPage + goto)
+ * without any real network access.
+ */
+async function interceptTestRoutes(context: BrowserContext) {
+  await context.route("https://test.local/page1", (route) => {
+    route.fulfill({ contentType: "text/html", body: TEST_PAGE_HTML })
+  })
+  await context.route("https://test.local/page2", (route) => {
+    route.fulfill({ contentType: "text/html", body: TEST_PAGE_2_HTML })
+  })
+  await context.route("https://test.local/popup-target", (route) => {
+    route.fulfill({ contentType: "text/html", body: POPUP_TARGET_HTML })
+  })
+}
+
+test("open a new tab, switch to it, interact, and switch back", async ({ browser }) => {
+  const context = await browser.newContext()
+  await interceptTestRoutes(context)
+  const page = await context.newPage()
+  const pageManager = new PageManager(context, page)
+
+  // Open a new tab to locally-served page
+  const tabId = await openNewTab(page, { url: "https://test.local/page1" }, pageManager, context)
+  expect(tabId).toBe("tab_1")
+
+  // Verify 2 tabs exist
+  const tabsResult = await getTabs(page, {} as Record<string, never>, pageManager)
+  expect(tabsResult.tabs).toHaveLength(2)
+  expect(tabsResult.tabs).toContain("tab_0")
+  expect(tabsResult.tabs).toContain("tab_1")
+
+  // Switch to the new tab
+  await switchToTab(page, { tabId: "tab_1" }, pageManager)
+
+  // Verify active tab is tab_1
+  const currentTab = await getCurrentTab(page, {} as Record<string, never>, pageManager)
+  expect(currentTab).toBe("tab_1")
+
+  // Verify the new tab loaded the local page
+  const newPage = pageManager.resolve("tab_1")
+  await newPage.waitForLoadState("domcontentloaded")
+  const heading = await newPage.locator("h1").textContent()
+  expect(heading).toContain("Test Page")
+
+  // Switch back to tab_0 and verify
+  await switchToTab(page, { tabId: "tab_0" }, pageManager)
+  const backToTab = await getCurrentTab(page, {} as Record<string, never>, pageManager)
+  expect(backToTab).toBe("tab_0")
+
+  await context.close()
+})
+
+test("close a tab and verify cleanup", async ({ browser }) => {
+  const context = await browser.newContext()
+  await interceptTestRoutes(context)
+  const page = await context.newPage()
+  const pageManager = new PageManager(context, page)
+
+  // Open 2 new tabs
+  await openNewTab(page, { url: "https://test.local/page1" }, pageManager, context)
+  await openNewTab(page, { url: "https://test.local/page2" }, pageManager, context)
+
+  // Verify 3 tabs total
+  const before = await getTabs(page, {} as Record<string, never>, pageManager)
+  expect(before.tabs).toHaveLength(3)
+  expect(before.tabs).toEqual(expect.arrayContaining(["tab_0", "tab_1", "tab_2"]))
+
+  // Close tab_1
+  await closeTab(page, { tabId: "tab_1" }, pageManager)
+
+  // Verify 2 remain with stable IDs (tab_0 and tab_2)
+  const after = await getTabs(page, {} as Record<string, never>, pageManager)
+  expect(after.tabs).toHaveLength(2)
+  expect(after.tabs).toContain("tab_0")
+  expect(after.tabs).toContain("tab_2")
+  expect(after.tabs).not.toContain("tab_1")
+
+  // Verify resolving tab_1 throws
+  expect(() => pageManager.resolve("tab_1")).toThrow(/No page found for tab ID "tab_1"/)
+
+  await context.close()
+})
+
+test("dispatch via handlePatrolPlatformAction routes correctly", async ({ browser }) => {
+  const context = await browser.newContext()
+  await interceptTestRoutes(context)
+  const page = await context.newPage()
+  const pageManager = new PageManager(context, page)
+
+  // Dispatch openNewTab through the handler
+  const tabId = await handlePatrolPlatformAction(pageManager, {
+    action: "openNewTab",
+    params: { url: "https://test.local/page1" },
+  })
+
+  // Verify it returned a tab ID and the tab was registered
+  expect(tabId).toBe("tab_1")
+  expect(pageManager.count).toBe(2)
+  expect(pageManager.ids).toContain("tab_1")
+
+  // Verify the new tab actually loaded the page
+  const newPage = pageManager.resolve("tab_1")
+  await newPage.waitForLoadState("domcontentloaded")
+  const heading = await newPage.locator("h1").textContent()
+  expect(heading).toContain("Test Page")
+
+  await context.close()
+})
+
+test("tabs persist correct content after switching", async ({ browser }) => {
+  const context = await browser.newContext()
+  await interceptTestRoutes(context)
+  const page = await context.newPage()
+  const pageManager = new PageManager(context, page)
+
+  // Open tab_1 to locally-served page
+  await openNewTab(page, { url: "https://test.local/page1" }, pageManager, context)
+
+  // Switch to tab_1 and read the page title
+  await switchToTab(page, { tabId: "tab_1" }, pageManager)
+  const tab1Page = pageManager.resolve("tab_1")
+  await tab1Page.waitForLoadState("domcontentloaded")
+  const title = await tab1Page.title()
+  expect(title).toContain("Test Page")
+
+  // Switch back to tab_0 and verify its URL is still about:blank
+  await switchToTab(page, { tabId: "tab_0" }, pageManager)
+  const tab0Page = pageManager.resolve("tab_0")
+  expect(tab0Page.url()).toBe("about:blank")
+
+  // Switch to tab_1 again and verify content is still there
+  await switchToTab(page, { tabId: "tab_1" }, pageManager)
+  const tab1PageAgain = pageManager.resolve("tab_1")
+  const headingText = await tab1PageAgain.locator("h1").textContent()
+  expect(headingText).toContain("Test Page")
+
+  await context.close()
+})
+
+test("PageManager auto-registers popup from window.open", async ({ browser }) => {
+  const context = await browser.newContext()
+  await interceptTestRoutes(context)
+  const page = await context.newPage()
+  const pageManager = new PageManager(context, page)
+
+  // Set initial page content with a button that opens a popup to a routed URL
+  await page.setContent('<button onclick="window.open(\'https://test.local/popup-target\')">Open</button>')
+
+  // Click the button and wait for the popup to appear
+  const [popup] = await Promise.all([
+    context.waitForEvent("page"),
+    page.locator("button").click(),
+  ])
+
+  // Wait for the popup to finish loading
+  await popup.waitForLoadState("domcontentloaded")
+
+  // Verify PageManager has 2 tabs
+  expect(pageManager.count).toBe(2)
+
+  // Verify the popup page loaded the local content
+  const popupId = pageManager.idOf(popup)
+  expect(popupId).toBeDefined()
+  const popupPage = pageManager.resolve(popupId!)
+  const heading = await popupPage.locator("h1").textContent()
+  expect(heading).toContain("Popup Target")
+
+  await context.close()
+})

--- a/packages/patrol/web_runner/tests/__tests__/pageManager.test.ts
+++ b/packages/patrol/web_runner/tests/__tests__/pageManager.test.ts
@@ -1,0 +1,267 @@
+import { test, expect } from "@playwright/test"
+import { EventEmitter } from "events"
+import { PageManager } from "../pageManager"
+
+// ---------------------------------------------------------------------------
+// Lightweight mocks for Playwright's Page and BrowserContext.
+// These use Node's EventEmitter so we can simulate 'close', 'crash', and
+// 'page' events without spinning up a real browser.
+// ---------------------------------------------------------------------------
+
+function createMockPage(): MockPage {
+  const emitter = new EventEmitter()
+  return Object.assign(emitter, {
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    once: emitter.once.bind(emitter),
+    removeListener: emitter.removeListener.bind(emitter),
+    isClosed: () => false,
+  }) as MockPage
+}
+
+type MockPage = EventEmitter & {
+  on: EventEmitter["on"]
+  off: EventEmitter["off"]
+  once: EventEmitter["once"]
+  removeListener: EventEmitter["removeListener"]
+  isClosed: () => boolean
+}
+
+function createMockContext(): MockContext {
+  const emitter = new EventEmitter()
+  return Object.assign(emitter, {
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    once: emitter.once.bind(emitter),
+    removeListener: emitter.removeListener.bind(emitter),
+  }) as MockContext
+}
+
+type MockContext = EventEmitter & {
+  on: EventEmitter["on"]
+  off: EventEmitter["off"]
+  once: EventEmitter["once"]
+  removeListener: EventEmitter["removeListener"]
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("PageManager", () => {
+  test("initial state: constructor registers the initial page as tab_0, sets it as active, count = 1", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    expect(manager.activeId).toBe("tab_0")
+    expect(manager.count).toBe(1)
+    expect(manager.ids).toEqual(["tab_0"])
+  })
+
+  test("resolve() with no args returns the active page", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const resolved = manager.resolve()
+    expect(resolved).toBe(initialPage)
+  })
+
+  test("resolve() with a valid tabId returns the correct page", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const resolved = manager.resolve("tab_0")
+    expect(resolved).toBe(initialPage)
+  })
+
+  test("resolve() with an invalid tabId throws an error", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    expect(() => manager.resolve("nonexistent")).toThrow()
+  })
+
+  test("activeId setter: switching to a valid tab updates activeId", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    // Simulate a new page opening
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+
+    manager.activeId = "tab_1"
+    expect(manager.activeId).toBe("tab_1")
+  })
+
+  test("activeId setter with invalid ID throws an error", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    expect(() => {
+      manager.activeId = "nonexistent"
+    }).toThrow()
+  })
+
+  test("auto-registration: new page from context event is registered as tab_1 with incremented count", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+
+    expect(manager.count).toBe(2)
+    expect(manager.ids).toContain("tab_1")
+    expect(manager.resolve("tab_1")).toBe(secondPage)
+  })
+
+  test("page close cleanup: when a page closes, it is removed from the registry", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+    expect(manager.count).toBe(2)
+
+    // Simulate the second page closing
+    secondPage.emit("close")
+
+    expect(manager.count).toBe(1)
+    expect(manager.ids).not.toContain("tab_1")
+  })
+
+  test("page crash cleanup: when a page crashes, it is removed from the registry", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+    expect(manager.count).toBe(2)
+
+    // Simulate the second page crashing
+    secondPage.emit("crash")
+
+    expect(manager.count).toBe(1)
+    expect(manager.ids).not.toContain("tab_1")
+  })
+
+  test("closing active tab: if the active tab closes, active switches to tab_0 (initial page)", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+
+    // Switch to the second tab, then close it
+    manager.activeId = "tab_1"
+    expect(manager.activeId).toBe("tab_1")
+
+    secondPage.emit("close")
+
+    expect(manager.activeId).toBe("tab_0")
+  })
+
+  test("stable IDs: closing tab_1 when tab_2 exists does not change tab_2 ID", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+
+    const thirdPage = createMockPage()
+    context.emit("page", thirdPage)
+
+    expect(manager.count).toBe(3)
+    expect(manager.ids).toEqual(expect.arrayContaining(["tab_0", "tab_1", "tab_2"]))
+
+    // Close tab_1 — tab_2 must keep its ID
+    secondPage.emit("close")
+
+    expect(manager.count).toBe(2)
+    expect(manager.ids).toContain("tab_0")
+    expect(manager.ids).toContain("tab_2")
+    expect(manager.ids).not.toContain("tab_1")
+    expect(manager.resolve("tab_2")).toBe(thirdPage)
+  })
+
+  test("ids: returns all currently tracked tab IDs", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    expect(manager.ids).toEqual(["tab_0"])
+
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+
+    const thirdPage = createMockPage()
+    context.emit("page", thirdPage)
+
+    expect(manager.ids).toEqual(expect.arrayContaining(["tab_0", "tab_1", "tab_2"]))
+    expect(manager.ids).toHaveLength(3)
+  })
+
+  test("idOf: returns the ID for a given Page instance", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(manager.idOf(initialPage as any)).toBe("tab_0")
+
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(manager.idOf(secondPage as any)).toBe("tab_1")
+  })
+
+  test("idOf: returns undefined for an untracked Page instance", () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const unknownPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(manager.idOf(unknownPage as any)).toBeUndefined()
+  })
+})

--- a/packages/patrol/web_runner/tests/__tests__/patrolPlatformHandler.test.ts
+++ b/packages/patrol/web_runner/tests/__tests__/patrolPlatformHandler.test.ts
@@ -1,0 +1,278 @@
+import { test, expect } from "@playwright/test"
+import { EventEmitter } from "events"
+import {
+  exposePatrolPlatformHandler,
+  handlePatrolPlatformAction,
+} from "../patrolPlatformHandler"
+import { PageManager } from "../pageManager"
+import type { PatrolNativeRequest } from "../contracts"
+
+// ---------------------------------------------------------------------------
+// Lightweight mocks — same EventEmitter pattern as pageManager.test.ts
+// ---------------------------------------------------------------------------
+
+function createMockPage(): MockPage {
+  const emitter = new EventEmitter()
+  return Object.assign(emitter, {
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    once: emitter.once.bind(emitter),
+    removeListener: emitter.removeListener.bind(emitter),
+    isClosed: () => false,
+  }) as MockPage
+}
+
+type MockPage = EventEmitter & {
+  on: EventEmitter["on"]
+  off: EventEmitter["off"]
+  once: EventEmitter["once"]
+  removeListener: EventEmitter["removeListener"]
+  isClosed: () => boolean
+}
+
+function createMockContext(): MockContext {
+  const emitter = new EventEmitter()
+  return Object.assign(emitter, {
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    once: emitter.once.bind(emitter),
+    removeListener: emitter.removeListener.bind(emitter),
+    exposeBinding: (async () => {}) as MockContext["exposeBinding"],
+  }) as MockContext
+}
+
+type MockContext = EventEmitter & {
+  on: EventEmitter["on"]
+  off: EventEmitter["off"]
+  once: EventEmitter["once"]
+  removeListener: EventEmitter["removeListener"]
+  exposeBinding: (name: string, callback: (...args: unknown[]) => unknown) => Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build a PageManager with mock objects
+// ---------------------------------------------------------------------------
+
+function buildPageManager() {
+  const context = createMockContext()
+  const initialPage = createMockPage()
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const manager = new PageManager(context as any, initialPage as any)
+
+  return { context, initialPage, manager }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("patrolPlatformHandler", () => {
+  // -------------------------------------------------------------------------
+  // 1. exposePatrolPlatformHandler calls context.exposeBinding
+  // -------------------------------------------------------------------------
+
+  test("exposePatrolPlatformHandler calls context.exposeBinding with '__patrol__platformHandler'", async () => {
+    const { context, manager } = buildPageManager()
+
+    let boundName: string | undefined
+    let boundCallback: ((...args: unknown[]) => unknown) | undefined
+
+    context.exposeBinding = async (name: string, callback: (...args: unknown[]) => unknown) => {
+      boundName = name
+      boundCallback = callback
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await exposePatrolPlatformHandler(context as any, manager)
+
+    expect(boundName).toBe("__patrol__platformHandler")
+    expect(typeof boundCallback).toBe("function")
+  })
+
+  // -------------------------------------------------------------------------
+  // 2. handlePatrolPlatformAction dispatches to the correct action
+  // -------------------------------------------------------------------------
+
+  test("handlePatrolPlatformAction dispatches to the correct action with the active page", async () => {
+    const { initialPage, manager } = buildPageManager()
+
+    // Replace enableDarkMode with a spy so we can verify the page and params
+    const actionsModule = await import("../actions")
+    const originalAction = actionsModule.actions.enableDarkMode
+
+    let receivedPage: unknown
+    let receivedParams: unknown
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(actionsModule.actions as any).enableDarkMode = async (page: unknown, params: unknown) => {
+      receivedPage = page
+      receivedParams = params
+    }
+
+    const request: PatrolNativeRequest = {
+      action: "enableDarkMode",
+      params: {},
+    }
+
+    try {
+      // For the RED phase: this will fail because handlePatrolPlatformAction
+      // currently takes (page: Page, request) instead of (pageManager, request).
+      await handlePatrolPlatformAction(manager, request)
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(actionsModule.actions as any).enableDarkMode = originalAction
+    }
+
+    // The handler should resolve the active page from PageManager and pass it
+    // to the action function
+    expect(receivedPage).toBe(initialPage)
+    expect(receivedParams).toEqual({})
+  })
+
+  // -------------------------------------------------------------------------
+  // 3. handlePatrolPlatformAction resolves _routeToTab to the correct page
+  // -------------------------------------------------------------------------
+
+  test("handlePatrolPlatformAction resolves _routeToTab to the correct page instead of the active page", async () => {
+    const { context, initialPage, manager } = buildPageManager()
+
+    // Add a second page
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+
+    // Active page is still tab_0; we explicitly request tab_1
+    const request: PatrolNativeRequest = {
+      action: "enableDarkMode",
+      params: { _routeToTab: "tab_1" },
+    }
+
+    // Spy on resolve to verify the correct tabId is passed
+    const originalResolve = manager.resolve.bind(manager)
+    let resolvedTabId: string | undefined
+    manager.resolve = (tabId?: string) => {
+      resolvedTabId = tabId
+      return originalResolve(tabId)
+    }
+
+    // Replace enableDarkMode with a no-op spy so the real action doesn't run
+    // against the mock page (which lacks emulateMedia, etc.)
+    const actionsModule = await import("../actions")
+    const originalAction = actionsModule.actions.enableDarkMode
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(actionsModule.actions as any).enableDarkMode = async () => {}
+
+    try {
+      await handlePatrolPlatformAction(manager, request)
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(actionsModule.actions as any).enableDarkMode = originalAction
+    }
+
+    expect(resolvedTabId).toBe("tab_1")
+  })
+
+  // -------------------------------------------------------------------------
+  // 4. handlePatrolPlatformAction falls back to active page when no _routeToTab
+  // -------------------------------------------------------------------------
+
+  test("handlePatrolPlatformAction falls back to active page when no _routeToTab is provided", async () => {
+    const { context, manager } = buildPageManager()
+
+    // Add a second page and switch active to it
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+    manager.activeId = "tab_1"
+
+    const request: PatrolNativeRequest = {
+      action: "enableDarkMode",
+      params: {},
+    }
+
+    // Spy on resolve to verify it's called without a tabId (falls back to active)
+    const originalResolve = manager.resolve.bind(manager)
+    let resolvedTabId: string | undefined = "SENTINEL"
+    manager.resolve = (tabId?: string) => {
+      resolvedTabId = tabId
+      return originalResolve(tabId)
+    }
+
+    // Replace enableDarkMode with a no-op spy so the real action doesn't run
+    // against the mock page (which lacks emulateMedia, etc.)
+    const actionsModule = await import("../actions")
+    const originalAction = actionsModule.actions.enableDarkMode
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(actionsModule.actions as any).enableDarkMode = async () => {}
+
+    try {
+      await handlePatrolPlatformAction(manager, request)
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(actionsModule.actions as any).enableDarkMode = originalAction
+    }
+
+    // resolve() should have been called with undefined (no tabId), causing
+    // it to fall back to the active page internally
+    expect(resolvedTabId).toBeUndefined()
+  })
+
+  // -------------------------------------------------------------------------
+  // 5. handlePatrolPlatformAction throws for unknown action
+  // -------------------------------------------------------------------------
+
+  test("handlePatrolPlatformAction throws for an unknown action", async () => {
+    const { manager } = buildPageManager()
+
+    const request = {
+      action: "unknown-placeholder-nonexistent",
+      params: {},
+    } as PatrolNativeRequest
+
+    await expect(handlePatrolPlatformAction(manager, request)).rejects.toThrow(
+      /not found/i,
+    )
+  })
+
+  // -------------------------------------------------------------------------
+  // 6. handlePatrolPlatformAction strips _routeToTab from params before passing
+  //    to the action function
+  // -------------------------------------------------------------------------
+
+  test("handlePatrolPlatformAction strips _routeToTab from params before passing to the action", async () => {
+    const { context, manager } = buildPageManager()
+
+    // Add a second page so tab_1 is valid
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+
+    let capturedParams: unknown
+
+    // Replace enableDarkMode with a spy that captures the params it receives.
+    // This lets us verify that _routeToTab (a routing concern) is stripped before
+    // the action function sees the params.
+    const actionsModule = await import("../actions")
+    const originalAction = actionsModule.actions.enableDarkMode
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(actionsModule.actions as any).enableDarkMode = async (_page: unknown, params: unknown) => {
+      capturedParams = params
+    }
+
+    const request: PatrolNativeRequest = {
+      action: "enableDarkMode",
+      params: { _routeToTab: "tab_1" },
+    }
+
+    try {
+      await handlePatrolPlatformAction(manager, request)
+    } finally {
+      // Restore original action
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(actionsModule.actions as any).enableDarkMode = originalAction
+    }
+
+    // _routeToTab is a routing concern — it must NOT leak into action params
+    expect(capturedParams).toBeDefined()
+    expect(capturedParams).not.toHaveProperty("_routeToTab")
+  })
+})

--- a/packages/patrol/web_runner/tests/__tests__/tabActions.test.ts
+++ b/packages/patrol/web_runner/tests/__tests__/tabActions.test.ts
@@ -1,0 +1,458 @@
+import { test, expect } from "@playwright/test"
+import { EventEmitter } from "events"
+import { PageManager } from "../pageManager"
+
+// --- Imports from action files that DO NOT EXIST yet (RED phase) -----------
+import { openNewTab } from "../actions/openNewTab"
+import { closeTab } from "../actions/closeTab"
+import { switchToTab } from "../actions/switchToTab"
+import { getTabs } from "../actions/getTabs"
+import { getCurrentTab } from "../actions/getCurrentTab"
+import { waitForPopup } from "../actions/waitForPopup"
+
+// ---------------------------------------------------------------------------
+// Lightweight mocks for Playwright's Page and BrowserContext.
+// Extended from the pattern in pageManager.test.ts with goto, close, and
+// newPage capabilities needed by the tab management actions.
+// ---------------------------------------------------------------------------
+
+type MockPage = EventEmitter & {
+  on: EventEmitter["on"]
+  off: EventEmitter["off"]
+  once: EventEmitter["once"]
+  removeListener: EventEmitter["removeListener"]
+  isClosed: () => boolean
+  goto: (url: string) => Promise<void>
+  close: () => Promise<void>
+  bringToFront: () => Promise<void>
+  url: () => string
+}
+
+type MockContext = EventEmitter & {
+  on: EventEmitter["on"]
+  off: EventEmitter["off"]
+  once: EventEmitter["once"]
+  removeListener: EventEmitter["removeListener"]
+  newPage: () => Promise<MockPage>
+  waitForEvent: (event: string) => Promise<MockPage>
+}
+
+function createMockPage(): MockPage {
+  const emitter = new EventEmitter()
+  let currentUrl = "about:blank"
+  let closed = false
+
+  const page = Object.assign(emitter, {
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    once: emitter.once.bind(emitter),
+    removeListener: emitter.removeListener.bind(emitter),
+    isClosed: () => closed,
+    goto: async (url: string) => {
+      currentUrl = url
+    },
+    close: async () => {
+      closed = true
+      emitter.emit("close")
+    },
+    bringToFront: async () => {},
+    url: () => currentUrl,
+  }) as MockPage
+
+  return page
+}
+
+function createMockContext(): MockContext {
+  const emitter = new EventEmitter()
+
+  const context = Object.assign(emitter, {
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    once: emitter.once.bind(emitter),
+    removeListener: emitter.removeListener.bind(emitter),
+    newPage: async (): Promise<MockPage> => {
+      const page = createMockPage()
+      // Simulate Playwright behavior: context emits 'page' when a new page is created
+      emitter.emit("page", page)
+      return page
+    },
+    waitForEvent: (event: string): Promise<MockPage> => {
+      return new Promise((resolve) => {
+        emitter.once(event, (page: MockPage) => {
+          resolve(page)
+        })
+      })
+    },
+  }) as MockContext
+
+  return context
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("openNewTab", () => {
+  test("creates a new page via context.newPage()", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const tabId = await openNewTab(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPage as any,
+      { url: "https://example.com" },
+      manager,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      context as any,
+    )
+
+    // A new page should have been registered in the manager
+    expect(manager.count).toBe(2)
+    expect(tabId).toBeDefined()
+    expect(typeof tabId).toBe("string")
+  })
+
+  test("navigates the new page to the given URL", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const tabId = await openNewTab(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPage as any,
+      { url: "https://example.com/test" },
+      manager,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      context as any,
+    )
+
+    // The newly created page should have navigated to the URL
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const newPage = manager.resolve(tabId) as any as MockPage
+    expect(newPage.url()).toBe("https://example.com/test")
+  })
+
+  test("returns the tab ID assigned by PageManager", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const tabId = await openNewTab(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPage as any,
+      { url: "https://example.com" },
+      manager,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      context as any,
+    )
+
+    // tab_0 is the initial page, so new tab should be tab_1
+    expect(tabId).toBe("tab_1")
+    expect(manager.ids).toContain(tabId)
+  })
+})
+
+test.describe("closeTab", () => {
+  test("resolves the page from pageManager and closes it", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    // Add a second page to close
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+    expect(manager.count).toBe(2)
+
+    await closeTab(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPage as any,
+      { tabId: "tab_1" },
+      manager,
+    )
+
+    // The page should be removed from the manager (via the close event)
+    expect(manager.count).toBe(1)
+    expect(manager.ids).not.toContain("tab_1")
+  })
+
+  test("calls page.close() on the resolved page", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+
+    await closeTab(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPage as any,
+      { tabId: "tab_1" },
+      manager,
+    )
+
+    expect(secondPage.isClosed()).toBe(true)
+  })
+
+  test("throws if tabId does not exist", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    await expect(
+      closeTab(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        initialPage as any,
+        { tabId: "nonexistent" },
+        manager,
+      ),
+    ).rejects.toThrow()
+  })
+
+  test("throws when trying to close tab_0", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    await expect(
+      closeTab(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        initialPage as any,
+        { tabId: "tab_0" },
+        manager,
+      ),
+    ).rejects.toThrow("Cannot close the initial Flutter tab")
+  })
+})
+
+test.describe("switchToTab", () => {
+  test("sets pageManager.activeId to the given tabId", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+
+    await switchToTab(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPage as any,
+      { tabId: "tab_1" },
+      manager,
+    )
+
+    expect(manager.activeId).toBe("tab_1")
+  })
+
+  test("throws if tabId does not exist", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    await expect(
+      switchToTab(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        initialPage as any,
+        { tabId: "nonexistent" },
+        manager,
+      ),
+    ).rejects.toThrow()
+  })
+})
+
+test.describe("getTabs", () => {
+  test("returns all tab IDs from pageManager.ids", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+
+    const thirdPage = createMockPage()
+    context.emit("page", thirdPage)
+
+    const result = await getTabs(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPage as any,
+      {} as Record<string, never>,
+      manager,
+    )
+
+    expect(result.tabs).toEqual(expect.arrayContaining(["tab_0", "tab_1", "tab_2"]))
+    expect(result.tabs).toHaveLength(3)
+  })
+
+  test("returns the active tab ID from pageManager.activeId", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+    manager.activeId = "tab_1"
+
+    const result = await getTabs(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPage as any,
+      {} as Record<string, never>,
+      manager,
+    )
+
+    expect(result.activeTabId).toBe("tab_1")
+  })
+})
+
+test.describe("getCurrentTab", () => {
+  test("returns pageManager.activeId (default is tab_0)", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const result = await getCurrentTab(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPage as any,
+      {} as Record<string, never>,
+      manager,
+    )
+
+    expect(result).toBe("tab_0")
+  })
+
+  test("returns the updated activeId after switching tabs", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const secondPage = createMockPage()
+    context.emit("page", secondPage)
+    manager.activeId = "tab_1"
+
+    const result = await getCurrentTab(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPage as any,
+      {} as Record<string, never>,
+      manager,
+    )
+
+    expect(result).toBe("tab_1")
+  })
+})
+
+test.describe("waitForPopup", () => {
+  test("sets up context.waitForEvent('page') before executing the trigger action", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    // Simulate a popup appearing during the trigger action.
+    // We schedule the popup emission so that waitForPopup can catch it.
+    const popupPage = createMockPage()
+    setTimeout(() => {
+      context.emit("page", popupPage)
+    }, 10)
+
+    const tabId = await waitForPopup(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPage as any,
+      {
+        triggerAction: "tap",
+        triggerParams: { selector: { text: "Open popup" } },
+      },
+      manager,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      context as any,
+    )
+
+    expect(tabId).toBeDefined()
+    expect(typeof tabId).toBe("string")
+  })
+
+  test("returns the tab ID of the newly appeared popup page", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const popupPage = createMockPage()
+    setTimeout(() => {
+      context.emit("page", popupPage)
+    }, 10)
+
+    const tabId = await waitForPopup(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPage as any,
+      {
+        triggerAction: "tap",
+        triggerParams: { selector: { text: "Open popup" } },
+      },
+      manager,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      context as any,
+    )
+
+    // The popup should be registered and the returned ID should resolve to it
+    expect(manager.ids).toContain(tabId)
+    expect(manager.resolve(tabId)).toBe(popupPage)
+  })
+
+  test("the popup page is registered in the PageManager", async () => {
+    const context = createMockContext()
+    const initialPage = createMockPage()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manager = new PageManager(context as any, initialPage as any)
+
+    const popupPage = createMockPage()
+    setTimeout(() => {
+      context.emit("page", popupPage)
+    }, 10)
+
+    const countBefore = manager.count
+
+    const tabId = await waitForPopup(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPage as any,
+      {
+        triggerAction: "tap",
+        triggerParams: { selector: { text: "Open popup" } },
+      },
+      manager,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      context as any,
+    )
+
+    expect(manager.count).toBe(countBefore + 1)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(manager.idOf(popupPage as any)).toBe(tabId)
+  })
+})

--- a/packages/patrol/web_runner/tests/actions.ts
+++ b/packages/patrol/web_runner/tests/actions.ts
@@ -2,46 +2,58 @@ import { acceptNextDialog } from "./actions/acceptNextDialog"
 import { addCookie } from "./actions/addCookie"
 import { clearCookies } from "./actions/clearCookies"
 import { clearPermissions } from "./actions/clearPermissions"
+import { closeTab } from "./actions/closeTab"
 import { disableDarkMode } from "./actions/disableDarkMode"
 import { dismissNextDialog } from "./actions/dismissNextDialog"
 import { enableDarkMode } from "./actions/enableDarkMode"
 import { enterText } from "./actions/enterText"
 import { getClipboard } from "./actions/getClipboard"
 import { getCookies } from "./actions/getCookies"
+import { getCurrentTab } from "./actions/getCurrentTab"
+import { getTabs } from "./actions/getTabs"
 import { goBack } from "./actions/goBack"
 import { goForward } from "./actions/goForward"
 import { grantPermissions } from "./actions/grantPermissions"
+import { openNewTab } from "./actions/openNewTab"
 import { pressKey } from "./actions/pressKey"
 import { pressKeyCombo } from "./actions/pressKeyCombo"
 import { resizeWindow } from "./actions/resizeWindow"
 import { scrollTo } from "./actions/scrollTo"
 import { setClipboard } from "./actions/setClipboard"
 import { startTest } from "./actions/startTest"
+import { switchToTab } from "./actions/switchToTab"
 import { tap } from "./actions/tap"
 import { uploadFile } from "./actions/uploadFile"
 import { verifyFileDownloads } from "./actions/verifyFileDownloads"
+import { waitForPopup } from "./actions/waitForPopup"
 
 export const actions = {
-  startTest,
-  grantPermissions,
-  enableDarkMode,
-  disableDarkMode,
-  tap,
-  enterText,
-  scrollTo,
-  clearPermissions,
-  addCookie,
-  getCookies,
-  clearCookies,
-  uploadFile,
   acceptNextDialog,
+  addCookie,
+  clearCookies,
+  clearPermissions,
+  closeTab,
+  disableDarkMode,
   dismissNextDialog,
-  pressKey,
-  pressKeyCombo,
-  verifyFileDownloads,
+  enableDarkMode,
+  enterText,
+  getClipboard,
+  getCookies,
+  getCurrentTab,
+  getTabs,
   goBack,
   goForward,
-  getClipboard,
-  setClipboard,
+  grantPermissions,
+  openNewTab,
+  pressKey,
+  pressKeyCombo,
   resizeWindow,
+  scrollTo,
+  setClipboard,
+  startTest,
+  switchToTab,
+  tap,
+  uploadFile,
+  verifyFileDownloads,
+  waitForPopup,
 } as const

--- a/packages/patrol/web_runner/tests/actions/closeTab.ts
+++ b/packages/patrol/web_runner/tests/actions/closeTab.ts
@@ -1,0 +1,15 @@
+import type { Page } from "playwright"
+import type { CloseTabRequest } from "../contracts"
+import type { PageManager } from "../pageManager"
+
+export async function closeTab(
+  _page: Page,
+  params: CloseTabRequest["params"],
+  pageManager: PageManager,
+): Promise<void> {
+  if (params.tabId === "tab_0") {
+    throw new Error("Cannot close the initial Flutter tab (tab_0)")
+  }
+  const page = pageManager.resolve(params.tabId)
+  await page.close()
+}

--- a/packages/patrol/web_runner/tests/actions/getCurrentTab.ts
+++ b/packages/patrol/web_runner/tests/actions/getCurrentTab.ts
@@ -1,0 +1,11 @@
+import type { Page } from "playwright"
+import type { GetCurrentTabRequest } from "../contracts"
+import type { PageManager } from "../pageManager"
+
+export async function getCurrentTab(
+  _page: Page,
+  _params: GetCurrentTabRequest["params"],
+  pageManager: PageManager,
+): Promise<string> {
+  return pageManager.activeId
+}

--- a/packages/patrol/web_runner/tests/actions/getTabs.ts
+++ b/packages/patrol/web_runner/tests/actions/getTabs.ts
@@ -1,0 +1,11 @@
+import type { Page } from "playwright"
+import type { GetTabsRequest } from "../contracts"
+import type { PageManager } from "../pageManager"
+
+export async function getTabs(
+  _page: Page,
+  _params: GetTabsRequest["params"],
+  pageManager: PageManager,
+): Promise<{ tabs: string[]; activeTabId: string }> {
+  return { tabs: pageManager.ids, activeTabId: pageManager.activeId }
+}

--- a/packages/patrol/web_runner/tests/actions/openNewTab.ts
+++ b/packages/patrol/web_runner/tests/actions/openNewTab.ts
@@ -1,0 +1,14 @@
+import type { BrowserContext, Page } from "playwright"
+import type { OpenNewTabRequest } from "../contracts"
+import type { PageManager } from "../pageManager"
+
+export async function openNewTab(
+  _page: Page,
+  params: OpenNewTabRequest["params"],
+  pageManager: PageManager,
+  context: BrowserContext,
+): Promise<string> {
+  const newPage = await context.newPage()
+  await newPage.goto(params.url)
+  return pageManager.idOf(newPage)!
+}

--- a/packages/patrol/web_runner/tests/actions/startTest.ts
+++ b/packages/patrol/web_runner/tests/actions/startTest.ts
@@ -4,9 +4,7 @@ import { logger } from "../logger"
 export const downloadedFiles: string[] = []
 const initializedPages = new WeakSet<Page>()
 
-export async function startTest(page: Page) {
-  downloadedFiles.splice(0, downloadedFiles.length)
-
+function registerDownloadListener(page: Page) {
   if (!initializedPages.has(page)) {
     initializedPages.add(page)
     page.on("download", async download => {
@@ -15,4 +13,20 @@ export async function startTest(page: Page) {
       logger.info(`File downloaded: ${filename}`)
     })
   }
+}
+
+export async function startTest(page: Page) {
+  downloadedFiles.splice(0, downloadedFiles.length)
+  registerDownloadListener(page)
+
+  // Register on all currently tracked pages from the context
+  const context = page.context()
+  for (const p of context.pages()) {
+    registerDownloadListener(p)
+  }
+
+  // Listen for future pages in this context
+  context.on("page", (newPage: Page) => {
+    registerDownloadListener(newPage)
+  })
 }

--- a/packages/patrol/web_runner/tests/actions/switchToTab.ts
+++ b/packages/patrol/web_runner/tests/actions/switchToTab.ts
@@ -1,0 +1,13 @@
+import type { Page } from "playwright"
+import type { SwitchToTabRequest } from "../contracts"
+import type { PageManager } from "../pageManager"
+
+export async function switchToTab(
+  _page: Page,
+  params: SwitchToTabRequest["params"],
+  pageManager: PageManager,
+): Promise<void> {
+  pageManager.activeId = params.tabId
+  const page = pageManager.resolve(params.tabId)
+  await page.bringToFront()
+}

--- a/packages/patrol/web_runner/tests/actions/waitForPopup.ts
+++ b/packages/patrol/web_runner/tests/actions/waitForPopup.ts
@@ -1,0 +1,30 @@
+import type { BrowserContext, Page } from "playwright"
+import type { WaitForPopupRequest } from "../contracts"
+import type { PageManager } from "../pageManager"
+import { actions } from "../actions"
+import { logger } from "../logger"
+
+export async function waitForPopup(
+  page: Page,
+  params: WaitForPopupRequest["params"],
+  pageManager: PageManager,
+  context: BrowserContext,
+): Promise<string> {
+  const actionFn = actions[params.triggerAction as keyof typeof actions]
+  if (!actionFn) {
+    throw new Error(`Unknown trigger action: "${params.triggerAction}"`)
+  }
+
+  const [newPage] = await Promise.all([
+    context.waitForEvent("page"),
+    (actionFn as Function)(page, params.triggerParams, pageManager, context).catch((err: unknown) => {
+      logger.warn(`Trigger action "${params.triggerAction}" failed: ${err}`)
+    }),
+  ])
+
+  const tabId = pageManager.idOf(newPage as Page)
+  if (!tabId) {
+    throw new Error("Popup page was not registered by PageManager")
+  }
+  return tabId
+}

--- a/packages/patrol/web_runner/tests/contracts.ts
+++ b/packages/patrol/web_runner/tests/contracts.ts
@@ -1,6 +1,6 @@
 type PatrolNativeRequestBase<TAction extends string, TParams> = {
   action: TAction
-  params: TParams
+  params: TParams & { _routeToTab?: string }
 }
 
 export type WebSelector = {
@@ -105,6 +105,33 @@ export type ResizeWindowRequest = PatrolNativeRequestBase<
     height: number
   }
 >
+export type OpenNewTabRequest = PatrolNativeRequestBase<
+  "openNewTab",
+  {
+    url: string
+  }
+>
+export type CloseTabRequest = PatrolNativeRequestBase<
+  "closeTab",
+  {
+    tabId: string
+  }
+>
+export type SwitchToTabRequest = PatrolNativeRequestBase<
+  "switchToTab",
+  {
+    tabId: string
+  }
+>
+export type GetTabsRequest = PatrolNativeRequestBase<"getTabs", {}>
+export type GetCurrentTabRequest = PatrolNativeRequestBase<"getCurrentTab", {}>
+export type WaitForPopupRequest = PatrolNativeRequestBase<
+  "waitForPopup",
+  {
+    triggerAction: string
+    triggerParams: Record<string, unknown>
+  }
+>
 type UnknownRequest = PatrolNativeRequestBase<`unknown-placeholder-${string}`, unknown>
 
 export type PatrolNativeRequest =
@@ -112,22 +139,28 @@ export type PatrolNativeRequest =
   | AddCookieRequest
   | ClearCookiesRequest
   | ClearPermissionsRequest
+  | CloseTabRequest
   | DisableDarkModeRequest
   | DismissNextDialogRequest
   | EnableDarkModeRequest
   | EnterTextRequest
   | GetClipboardRequest
   | GetCookiesRequest
+  | GetCurrentTabRequest
+  | GetTabsRequest
   | GoBackRequest
   | GoForwardRequest
   | GrantPermissionsRequest
+  | OpenNewTabRequest
   | PressKeyComboRequest
   | PressKeyRequest
   | ResizeWindowRequest
   | ScrollToRequest
   | SetClipboardRequest
   | StartTestRequest
+  | SwitchToTabRequest
   | TapRequest
   | UnknownRequest
   | UploadFileRequest
   | VerifyFileDownloadsRequest
+  | WaitForPopupRequest

--- a/packages/patrol/web_runner/tests/develop.ts
+++ b/packages/patrol/web_runner/tests/develop.ts
@@ -1,6 +1,7 @@
 import { chromium } from "playwright"
 import { initialise } from "./initialise"
 import { logger } from "./logger"
+import { PageManager } from "./pageManager"
 import { exposePatrolPlatformHandler } from "./patrolPlatformHandler"
 import "./types"
 
@@ -17,7 +18,8 @@ async function develop() {
 
     const page = context.pages().at(0) ?? (await context.newPage())
 
-    await exposePatrolPlatformHandler(page)
+    const pageManager = new PageManager(context, page)
+    await exposePatrolPlatformHandler(context, pageManager)
 
     await initialise(page)
 

--- a/packages/patrol/web_runner/tests/pageManager.ts
+++ b/packages/patrol/web_runner/tests/pageManager.ts
@@ -1,0 +1,70 @@
+import type { Page, BrowserContext } from "playwright"
+
+export class PageManager {
+  private _registry = new Map<string, Page>()
+  private _reverse = new Map<Page, string>()
+  private _activeId: string
+  private _nextIndex = 0
+  readonly context: BrowserContext
+
+  constructor(context: BrowserContext, initialPage: Page) {
+    this.context = context
+    this._register(initialPage)
+    this._activeId = "tab_0"
+
+    context.on("page", (page: Page) => {
+      this._register(page)
+    })
+  }
+
+  private _register(page: Page): string {
+    const id = `tab_${this._nextIndex++}`
+    this._registry.set(id, page)
+    this._reverse.set(page, id)
+
+    const cleanup = () => {
+      this._registry.delete(id)
+      this._reverse.delete(page)
+      if (this._activeId === id) {
+        this._activeId = "tab_0"
+      }
+    }
+
+    page.on("close", cleanup)
+    page.on("crash", cleanup)
+
+    return id
+  }
+
+  resolve(tabId?: string): Page {
+    const id = tabId ?? this._activeId
+    const page = this._registry.get(id)
+    if (!page) {
+      throw new Error(`No page found for tab ID "${id}"`)
+    }
+    return page
+  }
+
+  get activeId(): string {
+    return this._activeId
+  }
+
+  set activeId(tabId: string) {
+    if (!this._registry.has(tabId)) {
+      throw new Error(`No page found for tab ID "${tabId}"`)
+    }
+    this._activeId = tabId
+  }
+
+  get count(): number {
+    return this._registry.size
+  }
+
+  get ids(): string[] {
+    return Array.from(this._registry.keys())
+  }
+
+  idOf(page: Page): string | undefined {
+    return this._reverse.get(page)
+  }
+}

--- a/packages/patrol/web_runner/tests/patrolPlatformHandler.ts
+++ b/packages/patrol/web_runner/tests/patrolPlatformHandler.ts
@@ -1,15 +1,19 @@
-import { Page } from "playwright"
+import { BrowserContext } from "playwright"
 import { actions } from "./actions"
 import { PatrolNativeRequest } from "./contracts"
 import { logger } from "./logger"
+import { PageManager } from "./pageManager"
 
-export async function exposePatrolPlatformHandler(page: Page) {
-  await page.exposeBinding("__patrol__platformHandler", async ({ page }, request) =>
-    handlePatrolPlatformAction(page, request),
-  )
+export async function exposePatrolPlatformHandler(context: BrowserContext, pageManager: PageManager) {
+  await context.exposeBinding("__patrol__platformHandler", async ({ page }, request) => {
+    if (pageManager.idOf(page) !== "tab_0") {
+      throw new Error("Unauthorized: only the main test page (tab_0) can call the platform handler")
+    }
+    return handlePatrolPlatformAction(pageManager, request)
+  })
 }
 
-async function handlePatrolPlatformAction(page: Page, { action, params }: PatrolNativeRequest) {
+export async function handlePatrolPlatformAction(pageManager: PageManager, { action, params }: PatrolNativeRequest) {
   logger.info(params, `Received action: ${action}`)
 
   const actionFn = actions[action as keyof typeof actions]
@@ -18,8 +22,11 @@ async function handlePatrolPlatformAction(page: Page, { action, params }: Patrol
     throw new Error(`Action ${action} not found`)
   }
 
+  const { _routeToTab, ...cleanParams } = params as Record<string, unknown>
+  const page = pageManager.resolve(_routeToTab as string | undefined)
+
   try {
-    return await actionFn(page, params as any)
+    return await actionFn(page, cleanParams as any, pageManager, pageManager.context)
   } catch (e) {
     logger.error(e, "Failed to handle patrol platform request")
     throw e

--- a/packages/patrol/web_runner/tests/test.spec.ts
+++ b/packages/patrol/web_runner/tests/test.spec.ts
@@ -1,6 +1,7 @@
 import { test as base } from "@playwright/test"
 import { initialise } from "./initialise"
 import { logger } from "./logger"
+import { PageManager } from "./pageManager"
 import { exposePatrolPlatformHandler } from "./patrolPlatformHandler"
 import { PatrolTestEntry } from "./types"
 
@@ -10,7 +11,7 @@ if (tests.length === 0) {
 }
 
 export const patrolTest = base.extend({
-  page: async ({ page }, use) => {
+  page: async ({ page, context }, use) => {
     page.on("console", message => {
       const text = message.text()
       if (text.startsWith("PATROL_LOG")) {
@@ -25,11 +26,19 @@ export const patrolTest = base.extend({
 
     await page.goto("/", { waitUntil: "load" })
 
-    await exposePatrolPlatformHandler(page)
+    const pageManager = new PageManager(context, page)
+    await exposePatrolPlatformHandler(context, pageManager)
 
     await initialise(page)
 
     await use(page)
+
+    // Teardown: close all secondary pages (not the initial one)
+    for (const p of context.pages()) {
+      if (p !== page && !p.isClosed()) {
+        await p.close().catch(() => {})
+      }
+    }
   },
 })
 

--- a/packages/patrol_devtools_extension/pubspec.lock
+++ b/packages/patrol_devtools_extension/pubspec.lock
@@ -500,10 +500,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -705,10 +705,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Adds multi-tab browser support for Patrol web tests, enabling interaction with content across multiple browser tabs during test execution.

Resolves #2871

### New API methods on `$.platform.web`:
- `openNewTab(url:)` — open a URL in a new browser tab
- `switchToTab(tabId:)` — switch active tab by stable ID
- `closeTab(tabId:)` — close a tab and revert to the Flutter tab
- `getTabs()` — list all open tabs with IDs and URLs
- `getCurrentTab()` — get the active tab's ID
- `waitForPopup(triggerAction:, ...)` — capture a popup triggered by a DOM action

### Architecture
- `PageManager` class manages tab lifecycle with stable string IDs (`tab_0`, `tab_1`, ...)
- Uses `context.exposeBinding` (once, covers all pages) instead of per-page binding
- Existing actions (`tap`, `enterText`, `scrollTo`, etc.) automatically route to the active tab

### Test coverage
- 76 Playwright unit tests (PageManager, contracts, tab actions, handler dispatch)
- 32 Playwright integration tests (multi-tab flows, existing action compatibility)
- 4 Flutter E2E tests on real Chrome (form interaction in new tabs, cross-tab cookies, navigation coexistence)

### Also includes
- Changelog entry (`## Unreleased`) referencing #2871
- Documentation update in `docs/documentation/web.mdx`

## Test plan

- [x] Playwright unit tests pass (`npx playwright test --config playwright.unit.config.ts`)
- [x] Playwright integration tests pass (`npx playwright test --config playwright.integration.config.ts`)
- [x] Flutter E2E tests pass (`patrol test --target patrol_test/web/ -d chrome`)
- [ ] Android emulator CI — expected to fail for contributors without write access (per CONTRIBUTING.md)