### PR TITLE
fix: pass appId

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.4.1
+
+- Fix `appId` not being passed down on `$.platform.mobile.enterText` and `$.platform.mobile.enterTextByIndex` (#2992)
+
+
 ## 4.4.0
 - Add support for emulators with API lvl 36 for pickMultipleImagesFromGallery method. (#2977)
 - Fix `tapOnNotification` on iOS physical devices to Open button when tapping on notification. (#2972)

--- a/packages/patrol/lib/src/native/native_automator2.dart
+++ b/packages/patrol/lib/src/native/native_automator2.dart
@@ -379,6 +379,7 @@ class NativeAutomator2 {
     ios: () => _platform.ios.enterText(
       _getSafeIOSSelector(selector),
       text: text,
+      appId: appId,
       keyboardBehavior: keyboardBehavior,
       timeout: timeout,
       tapLocation: tapLocation,
@@ -532,6 +533,7 @@ class NativeAutomator2 {
       androidViews: [],
       iosViews: (await _platform.ios.getNativeViews(
         _getSafeIOSSelector(selector),
+        appId: appId,
       )).roots,
     ),
   );

--- a/packages/patrol/lib/src/platform/platform_automator.dart
+++ b/packages/patrol/lib/src/platform/platform_automator.dart
@@ -340,6 +340,7 @@ class MobileAutomator {
       ios: () => platform.ios.enterText(
         selector.ios,
         text: text,
+        appId: appId,
         keyboardBehavior: keyboardBehavior,
         timeout: timeout,
         tapLocation: tapLocation,
@@ -379,6 +380,7 @@ class MobileAutomator {
       ios: () => platform.ios.enterTextByIndex(
         text,
         index: index,
+        appId: appId,
         keyboardBehavior: keyboardBehavior,
         timeout: timeout,
         tapLocation: tapLocation,

--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -2,7 +2,7 @@ name: patrol
 description: >
   A powerful, multiplatform E2E UI testing framework for Flutter apps that
   overcomes the limitations of integration_test by handling native interactions.
-version: 4.4.0
+version: 4.4.1
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues


### PR DESCRIPTION
Hey Patrol Team,

thanks for your time and effort put into this cool testing framework.
While working today with Patrol I've encountered a _small bug_ with the `MobileAutomator` class' passing of the `String? appId` parameter. In some methods, it was simply forgotten to pass that parameter down the underlying iOS method.

We encountered the following issue in that way:

1. Be on a iOS App
2. Have some logic invoking the iOS local auth (Pin Code / Passcode).
3. Try entering in the special TextField outside of the Flutter app via:

```dart
$.platform.mobile.enterTextByIndex(x, index: 0, appId: "com.apple.springboard"); 
```
You will see the test throwing an error 400 no TextField found and it will display your own apps appId instead of the provided one.

4. If you call the underlying iOS method instead:

```dart
$.platform.ios.enterTextByIndex(x, index: 0, appId: "com.apple.springboard"); 
``` 
it will work because the iOS method does pass the appId down to the next method.

Out of completion reasons I've also updated that inside of the NativeAutomator2 class, as it was lacking there too, but I do understand that this class is marked deprecated and will be removed in the future. I can of course also remove that fix there if it is not needed.

I hope I do not break any rules, I've read the Contributing guideline and did not saw another PR/issue declared.

Thanks again for this package and the framework to make writing flutter tests easier for everyone.