### PR TITLE
release patrol_finders 3.2.0

### DIFF
--- a/packages/patrol_finders/CHANGELOG.md
+++ b/packages/patrol_finders/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.0
+
+- Bump `patrol_log` to `^0.8.0`.
+
 ## 3.1.0
 
 - Bump `patrol_log` to `0.7.0`.

--- a/packages/patrol_finders/pubspec.yaml
+++ b/packages/patrol_finders/pubspec.yaml
@@ -1,6 +1,6 @@
 name: patrol_finders
 description: Streamlined, high-level API on top of flutter_test.
-version: 3.1.0
+version: 3.2.0
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol_finders
 issue_tracker: https://github.com/leancodepl/patrol/issues?q=is%3Aopen+is%3Aissue+label%3Apackage%3Apatrol_finders
@@ -28,7 +28,7 @@ dependencies:
   flutter_test:
     sdk: flutter
   meta: ^1.10.0
-  patrol_log: ^0.7.1
+  patrol_log: ^0.8.0
 
 dev_dependencies:
   leancode_lint: ^17.0.0


### PR DESCRIPTION
Bump patrol_log constraint to ^0.8.0 to align with patrol and patrol_cli. Required because pre-1.0 semver treats minor as breaking.