### PR TITLE
Fix warning in test

### DIFF
--- a/packages/patrol_cli/test/ios/ios_test_backend_test.dart
+++ b/packages/patrol_cli/test/ios/ios_test_backend_test.dart
@@ -74,13 +74,12 @@ void main() {
       }) {
         test(description, () async {
           final target = simulator ? 'iphonesimulator' : 'iphoneos';
-          if (arch != null) {
-            arch = '-$arch';
-          }
+          final archSuffix = arch != null ? '-$arch' : '';
 
           final xcTestPlan = testPlan != null ? '-$testPlan' : '';
 
-          final name = '${scheme}_$xcTestPlan${target}16.2$arch.xctestrun';
+          final name =
+              '${scheme}_$xcTestPlan${target}16.2$archSuffix.xctestrun';
 
           fs
               .file('build/ios_integ/Build/Products/$name')


### PR DESCRIPTION
There is warning in new flutter in this file. Analyzer reference: https://dart.dev/tools/linter-rules/parameter_assignments
* Need to change this on the commit that is used in Flutter tests, so also implement it here.