### PR TITLE
Fix/increase timeout for ios develop workflow

### DIFF
--- a/dev/cli_tests/patrol_develop_test.dart
+++ b/dev/cli_tests/patrol_develop_test.dart
@@ -38,7 +38,7 @@ void main() {
 void main(List<String> args) async {
   _verifyWorkingDirectory();
 
-  const afterBuildCompletedTimeout = Duration(minutes: 4);
+  const afterBuildCompletedTimeout = Duration(minutes: 5, seconds: 30);
   const inactivityTimeout = Duration(minutes: 15);
 
   var isFirstTestPassed = false;


### PR DESCRIPTION
We have bug that patrol develop fails after 5m 50s so this should be max timeout here