### PR TITLE
Add promo banner and learn-more links to patrol_mcp README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 A powerful, multiplatform E2E UI testing framework for Flutter apps that overcomes the limitations of integration_test by handling native interactions. Developed by LeanCode since 2022, battle-tested and shaped by production-grade experience.
 
-[![Patrol promotial graphics][promo_graphics]][docs]
+[![Patrol promotional graphics][promo_graphics]][docs]
 
 ## Learn more about Patrol:
 

--- a/packages/patrol/README.md
+++ b/packages/patrol/README.md
@@ -13,7 +13,7 @@ overcomes the limitations of integration_test by handling native interactions.
 Developed by [LeanCode](https://leancode.co) since 2022, battle-tested and
 shaped by production-grade experience.
 
-![Patrol promotial graphics][promo_graphics]
+![Patrol promotional graphics][promo_graphics]
 
 ## Learn more about Patrol:
 

--- a/packages/patrol_cli/README.md
+++ b/packages/patrol_cli/README.md
@@ -13,7 +13,7 @@ overcomes the limitations of integration_test by handling native interactions.
 Developed by [LeanCode](https://leancode.co) since 2022, battle-tested and
 shaped by production-grade experience.
 
-![Patrol promotial graphics][promo_graphics]
+![Patrol promotional graphics][promo_graphics]
 
 Learn more about Patrol:
 

--- a/packages/patrol_finders/README.md
+++ b/packages/patrol_finders/README.md
@@ -13,7 +13,7 @@ overcomes the limitations of integration_test by handling native interactions.
 Developed by [LeanCode](https://leancode.co) since 2022, battle-tested and
 shaped by production-grade experience.
 
-![Patrol promotial graphics][promo_graphics]
+![Patrol promotional graphics][promo_graphics]
 
 Learn more about Patrol:
 

--- a/packages/patrol_mcp/README.md
+++ b/packages/patrol_mcp/README.md
@@ -10,7 +10,7 @@
 
 MCP server that lets AI agents run and manage Patrol tests in Flutter projects.
 
-![Patrol promotial graphics][promo_graphics]
+![Patrol promotional graphics][promo_graphics]
 
 ## Learn more about Patrol:
 


### PR DESCRIPTION
Align the patrol_mcp README with the main patrol package README by adding the promotional banner image and documentation links.