### PR TITLE
Move PatrolLogReader to a separate export to fix WASM compatibility

### DIFF
--- a/packages/patrol_cli/lib/src/android/android_test_backend.dart
+++ b/packages/patrol_cli/lib/src/android/android_test_backend.dart
@@ -13,6 +13,7 @@ import 'package:patrol_cli/src/devices.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
 import 'package:patrol_cli/src/runner/flutter_command.dart';
 import 'package:patrol_log/patrol_log.dart';
+import 'package:patrol_log/patrol_log_reader.dart';
 import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 

--- a/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
+++ b/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
@@ -12,6 +12,7 @@ import 'package:patrol_cli/src/base/process.dart';
 import 'package:patrol_cli/src/crossplatform/app_options.dart';
 import 'package:patrol_cli/src/devices.dart';
 import 'package:patrol_log/patrol_log.dart';
+import 'package:patrol_log/patrol_log_reader.dart';
 import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 

--- a/packages/patrol_cli/lib/src/web/web_test_backend.dart
+++ b/packages/patrol_cli/lib/src/web/web_test_backend.dart
@@ -10,7 +10,7 @@ import 'package:patrol_cli/src/base/process.dart';
 import 'package:patrol_cli/src/crossplatform/app_options.dart';
 import 'package:patrol_cli/src/crossplatform/flutter_tool.dart';
 import 'package:patrol_cli/src/devices.dart';
-import 'package:patrol_log/patrol_log.dart';
+import 'package:patrol_log/patrol_log_reader.dart';
 import 'package:process/process.dart';
 
 const _kDefaultWebServerTimeoutSeconds = 120;

--- a/packages/patrol_log/CHANGELOG.md
+++ b/packages/patrol_log/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0
+
+- **Breaking:** Move `PatrolLogReader` to a separate `package:patrol_log/patrol_log_reader.dart` export, removing the transitive `dart:io` dependency from the main barrel file.
+
 ## 0.8.0
 
 - Add `onLogEntry` callback to `PatrolLogReader`.

--- a/packages/patrol_log/lib/patrol_log.dart
+++ b/packages/patrol_log/lib/patrol_log.dart
@@ -1,5 +1,4 @@
 export 'src/ansi_codes.dart';
 export 'src/entries/entry.dart';
-export 'src/patrol_log_reader.dart';
 export 'src/patrol_log_writer.dart';
 export 'src/patrol_single_test_entry.dart';

--- a/packages/patrol_log/lib/patrol_log_reader.dart
+++ b/packages/patrol_log/lib/patrol_log_reader.dart
@@ -1,0 +1,1 @@
+export 'src/patrol_log_reader.dart';

--- a/packages/patrol_log/pubspec.yaml
+++ b/packages/patrol_log/pubspec.yaml
@@ -1,7 +1,7 @@
 name: patrol_log
 description: >
   Log package for Patrol, a powerful Flutter-native UI testing framework.
-version: 0.8.0
+version: 0.9.0
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol_log
 issue_tracker: https://github.com/leancodepl/patrol/issues

--- a/packages/patrol_log/test/patrol_log_reader_test.dart
+++ b/packages/patrol_log/test/patrol_log_reader_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:dispose_scope/dispose_scope.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:patrol_log/patrol_log.dart';
+import 'package:patrol_log/patrol_log_reader.dart';
 import 'package:test/test.dart';
 
 class _MockStdout extends Mock implements Stdout {}


### PR DESCRIPTION
## Summary

  - Move `PatrolLogReader` out of the main `patrol_log.dart` barrel file into a dedicated `patrol_log_reader.dart` export
  - `PatrolLogReader` both directly and transitively depends on `dart:io`, which was making all consumers web and WASM-incompatible
  - `PatrolLogReader` is only used by `patrol_cli`, not by `patrol` or `patrol_finders`

## Follow-up

  After publishing `patrol_log` 0.9.0:
  - Bump `patrol_log` dependency in all Patrol packages
  - Add `import 'package:patrol_log/patrol_log_reader.dart'` in `patrol_cli` where `PatrolLogReader` is used