### PR TITLE
Enable Slack notification for patrol_mcp releases

### DIFF
--- a/.github/workflows/patrol_mcp-publish.yaml
+++ b/.github/workflows/patrol_mcp-publish.yaml
@@ -50,7 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish
 
-
     steps:
       - name: Share test results on Slack
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/patrol_mcp-publish.yaml
+++ b/.github/workflows/patrol_mcp-publish.yaml
@@ -49,7 +49,7 @@ jobs:
     name: Notify on Slack
     runs-on: ubuntu-latest
     needs: publish
-    if: needs.publish.outputs.prerelease == 'false'
+
 
     steps:
       - name: Share test results on Slack


### PR DESCRIPTION
## Summary
- Remove `prerelease` check from patrol_mcp publish workflow so Slack notifications are sent for 0.x.y versions

## Context
The `pub-release` action treats versions < 1.0.0 as prereleases, which skips the Slack notify job. Since patrol_mcp is still in 0.x, this means no Slack messages are sent on release.