### PR TITLE
Add dismissible docs banner

### DIFF
--- a/docs_app/app/(docs)/layout.tsx
+++ b/docs_app/app/(docs)/layout.tsx
@@ -15,10 +15,12 @@ export default function Layout({ children }: LayoutProps<"/">) {
         className: "patrol-docs-layout-with-banner",
       }}>
       <Banner id="patrol-webinar-banner" changeLayout={false} className="patrol-docs-webinar-banner">
-        Webinar: Mastering Patrol & AI: Next-Level E2E Testing.{" "}
-        <a href={webinarUrl} className="font-bold underline underline-offset-2">
-          Register now
-        </a>
+        <span>
+          Webinar: Mastering Patrol & AI: Next-Level E2E Testing.{" "}
+          <a href={webinarUrl} className="font-bold underline underline-offset-2">
+            Register now
+          </a>
+        </span>
       </Banner>
       {children}
     </DocsLayout>

--- a/docs_app/app/(docs)/layout.tsx
+++ b/docs_app/app/(docs)/layout.tsx
@@ -1,27 +1,10 @@
 import { baseOptions } from "@/lib/layout.shared"
 import { source } from "@/lib/source"
-import { Banner } from "fumadocs-ui/components/banner"
 import { DocsLayout } from "fumadocs-ui/layouts/notebook"
-
-const webinarUrl =
-  "https://leancode.co/webinar/mastering-patrol-and-ai-next-level-e2e-testing?utm_source=patrol_page&utm_medium=yellow_banner&utm_campaign=webinar"
 
 export default function Layout({ children }: LayoutProps<"/">) {
   return (
-    <DocsLayout
-      tree={source.pageTree}
-      {...baseOptions()}
-      containerProps={{
-        className: "patrol-docs-layout-with-banner",
-      }}>
-      <Banner id="patrol-webinar-banner" changeLayout={false} className="patrol-docs-webinar-banner">
-        <span>
-          Webinar: Mastering Patrol & AI: Next-Level E2E Testing.{" "}
-          <a href={webinarUrl} className="font-bold underline underline-offset-2">
-            Register now
-          </a>
-        </span>
-      </Banner>
+    <DocsLayout tree={source.pageTree} {...baseOptions()}>
       {children}
     </DocsLayout>
   )

--- a/docs_app/app/(docs)/layout.tsx
+++ b/docs_app/app/(docs)/layout.tsx
@@ -1,10 +1,25 @@
 import { baseOptions } from "@/lib/layout.shared"
 import { source } from "@/lib/source"
+import { Banner } from "fumadocs-ui/components/banner"
 import { DocsLayout } from "fumadocs-ui/layouts/notebook"
+
+const webinarUrl =
+  "https://leancode.co/webinar/mastering-patrol-and-ai-next-level-e2e-testing?utm_source=patrol_page&utm_medium=yellow_banner&utm_campaign=webinar"
 
 export default function Layout({ children }: LayoutProps<"/">) {
   return (
-    <DocsLayout tree={source.pageTree} {...baseOptions()}>
+    <DocsLayout
+      tree={source.pageTree}
+      {...baseOptions()}
+      containerProps={{
+        className: "patrol-docs-layout-with-banner",
+      }}>
+      <Banner id="patrol-webinar-banner" changeLayout={false} className="patrol-docs-webinar-banner">
+        Webinar: Mastering Patrol & AI: Next-Level E2E Testing.{" "}
+        <a href={webinarUrl} className="font-bold underline underline-offset-2">
+          Register now
+        </a>
+      </Banner>
       {children}
     </DocsLayout>
   )

--- a/docs_app/app/global.css
+++ b/docs_app/app/global.css
@@ -64,7 +64,7 @@
   }
 
   .patrol-docs-webinar-banner {
-    background-color: rgb(240, 255, 0);
+    background-color: rgb(255, 255, 255);
     color: rgb(0, 0, 0);
     grid-area: banner;
     min-height: var(--patrol-docs-banner-height);

--- a/docs_app/app/global.css
+++ b/docs_app/app/global.css
@@ -38,4 +38,37 @@
   aside [data-radix-scroll-area-viewport] {
     padding-bottom: 44px;
   }
+
+  .patrol-docs-layout-with-banner {
+    --patrol-docs-banner-height: 0px;
+    grid-template:
+      ". header header header ."
+      ". banner banner banner ."
+      "sidebar sidebar toc-popover toc-popover ."
+      "sidebar sidebar main toc ." 1fr / minmax(min-content, 1fr) var(--fd-sidebar-col) minmax(
+        0,
+        calc(var(--fd-layout-width, 97rem) - var(--fd-sidebar-col) - var(--fd-toc-width))
+      )
+      var(--fd-toc-width) minmax(min-content, 1fr) !important;
+    --fd-docs-row-1: 0px !important;
+    --fd-docs-row-2: calc(var(--fd-header-height) + var(--patrol-docs-banner-height, 0px)) !important;
+    --fd-docs-row-3: calc(var(--fd-docs-row-2) + var(--fd-toc-popover-height)) !important;
+  }
+
+  .patrol-docs-layout-with-banner:has(#patrol-webinar-banner) {
+    --patrol-docs-banner-height: 3rem;
+  }
+
+  .nd-banner-patrol-webinar-banner .patrol-docs-layout-with-banner {
+    --patrol-docs-banner-height: 0px;
+  }
+
+  .patrol-docs-webinar-banner {
+    background-color: rgb(240, 255, 0);
+    color: rgb(0, 0, 0);
+    grid-area: banner;
+    min-height: var(--patrol-docs-banner-height);
+    top: var(--fd-header-height);
+    z-index: 9;
+  }
 }

--- a/docs_app/app/global.css
+++ b/docs_app/app/global.css
@@ -39,36 +39,8 @@
     padding-bottom: 44px;
   }
 
-  .patrol-docs-layout-with-banner {
-    --patrol-docs-banner-height: 0px;
-    grid-template:
-      ". header header header ."
-      ". banner banner banner ."
-      "sidebar sidebar toc-popover toc-popover ."
-      "sidebar sidebar main toc ." 1fr / minmax(min-content, 1fr) var(--fd-sidebar-col) minmax(
-        0,
-        calc(var(--fd-layout-width, 97rem) - var(--fd-sidebar-col) - var(--fd-toc-width))
-      )
-      var(--fd-toc-width) minmax(min-content, 1fr) !important;
-    --fd-docs-row-1: 0px !important;
-    --fd-docs-row-2: calc(var(--fd-header-height) + var(--patrol-docs-banner-height, 0px)) !important;
-    --fd-docs-row-3: calc(var(--fd-docs-row-2) + var(--fd-toc-popover-height)) !important;
-  }
-
-  .patrol-docs-layout-with-banner:has(#patrol-webinar-banner) {
-    --patrol-docs-banner-height: 3rem;
-  }
-
-  .nd-banner-patrol-webinar-banner .patrol-docs-layout-with-banner {
-    --patrol-docs-banner-height: 0px;
-  }
-
   .patrol-docs-webinar-banner {
-    background-color: rgb(255, 255, 255);
+    background-color: rgb(240, 255, 0);
     color: rgb(0, 0, 0);
-    grid-area: banner;
-    min-height: var(--patrol-docs-banner-height);
-    top: var(--fd-header-height);
-    z-index: 9;
   }
 }

--- a/docs_app/app/layout.tsx
+++ b/docs_app/app/layout.tsx
@@ -1,5 +1,6 @@
 import { config } from "@fortawesome/fontawesome-svg-core"
 import { GoogleTagManager } from "@next/third-parties/google"
+import { Banner } from "fumadocs-ui/components/banner"
 import { RootProvider } from "fumadocs-ui/provider/next"
 import { Inter } from "next/font/google"
 import Script from "next/script"
@@ -12,6 +13,16 @@ const inter = Inter({
   subsets: ["latin"],
 })
 
+const patrolBannerRainbowColors = [
+  "rgba(240, 255, 0, 0.45)",
+  "rgba(255, 160, 63, 0.55)",
+  "transparent",
+  "rgba(255, 160, 63, 0.55)",
+  "rgba(240, 255, 0, 0.45)",
+  "transparent",
+  "rgba(255, 160, 63, 0.55)",
+]
+
 export default function Layout({ children }: LayoutProps<"/">) {
   return (
     <html lang="en" className={inter.className} suppressHydrationWarning>
@@ -19,7 +30,16 @@ export default function Layout({ children }: LayoutProps<"/">) {
         <Script src="//cdn.cookie-script.com/s/3aee4f412722d00911596bace9d15935.js" />
       </head>
       <body className="flex flex-col min-h-screen">
-        <RootProvider>{children}</RootProvider>
+        <RootProvider>
+          <Banner
+            id="patrol-best-e2e-framework-banner"
+            variant="rainbow"
+            rainbowColors={patrolBannerRainbowColors}
+            className="font-medium">
+            Patrol is the best e2e testing framework ever
+          </Banner>
+          {children}
+        </RootProvider>
       </body>
       <GoogleTagManager gtmId="GTM-PBMQJ8GM" />
     </html>

--- a/docs_app/app/layout.tsx
+++ b/docs_app/app/layout.tsx
@@ -1,5 +1,6 @@
 import { config } from "@fortawesome/fontawesome-svg-core"
 import { GoogleTagManager } from "@next/third-parties/google"
+import { Banner } from "fumadocs-ui/components/banner"
 import { RootProvider } from "fumadocs-ui/provider/next"
 import { Inter } from "next/font/google"
 import Script from "next/script"
@@ -12,6 +13,9 @@ const inter = Inter({
   subsets: ["latin"],
 })
 
+const webinarUrl =
+  "https://leancode.co/webinar/mastering-patrol-and-ai-next-level-e2e-testing?utm_source=patrol_page&utm_medium=yellow_banner&utm_campaign=webinar"
+
 export default function Layout({ children }: LayoutProps<"/">) {
   return (
     <html lang="en" className={inter.className} suppressHydrationWarning>
@@ -19,7 +23,17 @@ export default function Layout({ children }: LayoutProps<"/">) {
         <Script src="//cdn.cookie-script.com/s/3aee4f412722d00911596bace9d15935.js" />
       </head>
       <body className="flex flex-col min-h-screen">
-        <RootProvider>{children}</RootProvider>
+        <RootProvider>
+          <Banner id="patrol-webinar-banner" className="patrol-docs-webinar-banner w-full">
+            <span>
+              Webinar: Mastering Patrol & AI: Next-Level E2E Testing.{" "}
+              <a href={webinarUrl} className="font-bold underline underline-offset-2">
+                Register now
+              </a>
+            </span>
+          </Banner>
+          {children}
+        </RootProvider>
       </body>
       <GoogleTagManager gtmId="GTM-PBMQJ8GM" />
     </html>

--- a/docs_app/app/layout.tsx
+++ b/docs_app/app/layout.tsx
@@ -1,6 +1,5 @@
 import { config } from "@fortawesome/fontawesome-svg-core"
 import { GoogleTagManager } from "@next/third-parties/google"
-import { Banner } from "fumadocs-ui/components/banner"
 import { RootProvider } from "fumadocs-ui/provider/next"
 import { Inter } from "next/font/google"
 import Script from "next/script"
@@ -13,16 +12,6 @@ const inter = Inter({
   subsets: ["latin"],
 })
 
-const patrolBannerRainbowColors = [
-  "rgba(240, 255, 0, 0.45)",
-  "rgba(255, 160, 63, 0.55)",
-  "transparent",
-  "rgba(255, 160, 63, 0.55)",
-  "rgba(240, 255, 0, 0.45)",
-  "transparent",
-  "rgba(255, 160, 63, 0.55)",
-]
-
 export default function Layout({ children }: LayoutProps<"/">) {
   return (
     <html lang="en" className={inter.className} suppressHydrationWarning>
@@ -30,16 +19,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
         <Script src="//cdn.cookie-script.com/s/3aee4f412722d00911596bace9d15935.js" />
       </head>
       <body className="flex flex-col min-h-screen">
-        <RootProvider>
-          <Banner
-            id="patrol-best-e2e-framework-banner"
-            variant="rainbow"
-            rainbowColors={patrolBannerRainbowColors}
-            className="font-medium">
-            Patrol is the best e2e testing framework ever
-          </Banner>
-          {children}
-        </RootProvider>
+        <RootProvider>{children}</RootProvider>
       </body>
       <GoogleTagManager gtmId="GTM-PBMQJ8GM" />
     </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move the dismissible Fumadocs banner back to the root layout so it appears at the very top above the navigation and spans the full viewport width.
- Keep the webinar announcement with the `Register now` link and preserved spacing.
- Style the banner as a flat Patrol yellow strip with black text.
- Remove the extra notebook grid overrides that were only needed for the below-navigation placement.

## Verification
- `npm run format` (passes)
- `git diff --check` (passes)
- `npm run lint` (fails before linting due to existing ESLint config validation error for `perfectionist/sort-imports`)
- `npm run build` (fails due to generated `.source` imports not resolving MDX files from `../docs` in this local setup)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://leancode.slack.com/archives/C05035JGPNH/p1777382775734939?thread_ts=1777382775.734939&cid=C05035JGPNH)

<div><a href="https://cursor.com/agents/bc-3626af6b-e0d6-52a5-b3e6-ef5e0e99365d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3626af6b-e0d6-52a5-b3e6-ef5e0e99365d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

