### PR TITLE
Run melos bootstrap in CI workflows that resolve overridden packages

### DIFF
--- a/.github/workflows/patrol_cli-prepare.yaml
+++ b/.github/workflows/patrol_cli-prepare.yaml
@@ -35,6 +35,12 @@ jobs:
       - name: Run flutter tool (to dismiss the first run experience)
         run: flutter
 
+      - name: Set up Melos and activate workspace
+        working-directory: .
+        run: |
+          dart pub global activate melos
+          melos bootstrap
+
       - name: dart pub get
         run: dart pub get
 

--- a/.github/workflows/patrol_finders-prepare.yaml
+++ b/.github/workflows/patrol_finders-prepare.yaml
@@ -31,6 +31,12 @@ jobs:
           flutter-version: ${{ matrix.flutter-version }}
           channel: ${{ matrix.flutter-channel }}
 
+      - name: Set up Melos and activate workspace
+        working-directory: .
+        run: |
+          dart pub global activate melos
+          melos bootstrap
+
       - name: flutter pub get
         run: flutter pub get
 

--- a/.github/workflows/test-android-emulator-webview.yaml
+++ b/.github/workflows/test-android-emulator-webview.yaml
@@ -87,6 +87,12 @@ jobs:
       - name: Preload Flutter artifacts
         run: flutter precache --android
 
+      - name: Set up Melos and activate workspace
+        working-directory: .
+        run: |
+          dart pub global activate melos
+          melos bootstrap
+
       - name: Set up Patrol CLI
         working-directory: packages/patrol_cli
         run: dart pub global activate --source path . && patrol


### PR DESCRIPTION
## Summary
- `test-android-emulator-webview`, `patrol_cli-prepare`, and `patrol_finders-prepare` resolve dependencies inside packages that declare local-path `dependency_overrides` via `pubspec_overrides.yaml`. Without `melos bootstrap`, those overrides aren't honored, so PRs that touch unpublished sibling packages (e.g. `patrol_log`) fail in CI by resolving from pub.dev.
- Add the canonical `Set up Melos and activate workspace` step to each of the three workflows, before the first `pub get` / `pub global activate`.