### PR TITLE
Fix/wait for at

### DIFF
--- a/dev/e2e_app/lib/at_finder_screen.dart
+++ b/dev/e2e_app/lib/at_finder_screen.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+
+import 'package:e2e_app/keys.dart';
+import 'package:flutter/material.dart';
+
+class AtFinderScreen extends StatefulWidget {
+  const AtFinderScreen({super.key});
+
+  @override
+  State<AtFinderScreen> createState() => _AtFinderScreenState();
+}
+
+class _AtFinderScreenState extends State<AtFinderScreen> {
+  var _isFirstItemVisible = false;
+  var _isSecondItemVisible = false;
+  var _firstItemTapped = 0;
+  var _secondItemTapped = 0;
+
+  @override
+  void initState() {
+    super.initState();
+
+    unawaited(
+      Future<void>.delayed(const Duration(seconds: 1)).then((_) {
+        if (!mounted) {
+          return;
+        }
+
+        setState(() {
+          _isFirstItemVisible = true;
+        });
+      }),
+    );
+
+    unawaited(
+      Future<void>.delayed(const Duration(seconds: 3)).then((_) {
+        if (!mounted) {
+          return;
+        }
+
+        setState(() {
+          _isSecondItemVisible = true;
+        });
+      }),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('at() finder')),
+      body: ListView(
+        children: [
+          if (_isFirstItemVisible)
+            AtFinderItem(
+              onTap: () {
+                setState(() {
+                  _firstItemTapped++;
+                });
+              },
+            ),
+          if (_isSecondItemVisible)
+            AtFinderItem(
+              onTap: () {
+                setState(() {
+                  _secondItemTapped++;
+                });
+              },
+            ),
+          if (_secondItemTapped > 0)
+            Text(
+              'Second item tapped $_secondItemTapped',
+              key: K.atFinderSecondItemTapped,
+            ),
+          if (_firstItemTapped > 0)
+            Text(
+              'First item tapped $_firstItemTapped',
+              key: K.atFinderFirstItemTapped,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class AtFinderItem extends StatelessWidget {
+  const AtFinderItem({super.key, required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(key: K.atFinderItem, title: Text('Item'), onTap: onTap);
+  }
+}

--- a/dev/e2e_app/lib/keys.dart
+++ b/dev/e2e_app/lib/keys.dart
@@ -10,6 +10,12 @@ class Keys {
   static const bottomText = Key('bottomText');
   static const backButton = Key('backButton');
 
+  // at() finder screen
+  static const atFinderFirstItemTapped = Key('atFinderFirstItemTapped');
+  static const atFinderItem = Key('atFinderItem');
+  static const atFinderScreenButton = Key('atFinderScreenButton');
+  static const atFinderSecondItemTapped = Key('atFinderSecondItemTapped');
+
   // autofocus text field flow
   static const usernameTextField = Key('usernameTextField');
   static const usernameNextButton = Key('usernameNextButton');
@@ -77,4 +83,8 @@ class Keys {
   static const pickMultiplePhotosButton = Key('pickMultiplePhotosButton');
   static const smallImagePreview = Key('smallImagePreview');
   static const selectedPhotosCount = Key('selectedPhotosCount');
+}
+
+class AtFinderItemKey extends ValueKey<int> {
+  const AtFinderItemKey(super.value);
 }

--- a/dev/e2e_app/lib/main.dart
+++ b/dev/e2e_app/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:app_links/app_links.dart';
 import 'package:e2e_app/applink_screen.dart';
+import 'package:e2e_app/at_finder_screen.dart';
 import 'package:e2e_app/camera_screen.dart';
 import 'package:e2e_app/keys.dart';
 import 'package:e2e_app/loading_screen.dart';
@@ -211,6 +212,13 @@ class _ExampleHomePageState extends State<ExampleHomePage> {
               MaterialPageRoute<void>(builder: (_) => const LoadingScreen()),
             ),
             child: const Text('Open loading screen'),
+          ),
+          TextButton(
+            key: K.atFinderScreenButton,
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(builder: (_) => const AtFinderScreen()),
+            ),
+            child: const Text('Open at() finder screen'),
           ),
           TextButton(
             onPressed: () => Navigator.of(context).push(

--- a/dev/e2e_app/patrol_test/at_finder_test.dart
+++ b/dev/e2e_app/patrol_test/at_finder_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:e2e_app/keys.dart';
 
 import 'common.dart';
 
@@ -6,116 +6,17 @@ void main() {
   patrol(
     'at() waits until widget at index exists',
     ($) async {
-      await $.pumpWidgetAndSettle(const _AtFinderApp());
+      await createApp($);
+      await $(K.atFinderScreenButton).scrollTo().tap();
 
-      await $(_AtFinderItem).at(1).tap();
+      await $(K.atFinderItem).at(1).tap();
+      await $(K.atFinderItem).first.tap();
+      await $(K.atFinderItem).last.tap();
 
-      await $('Second item tapped 1').waitUntilVisible();
-
-      await $(_AtFinderItem).first.tap();
-      await $('First item tapped 1').waitUntilVisible();
-      await $(_AtFinderItem).last.tap();
-      await $('Second item tapped 2').waitUntilVisible();
+      await $(K.atFinderFirstItemTapped).waitUntilVisible();
+      await $(K.atFinderSecondItemTapped).waitUntilVisible();
+      expect($(K.atFinderSecondItemTapped).text, 'Second item tapped 2');
     },
     tags: ['android', 'emulator', 'ios', 'simulator'],
   );
-}
-
-class _AtFinderApp extends StatefulWidget {
-  const _AtFinderApp();
-
-  @override
-  State<_AtFinderApp> createState() => _AtFinderAppState();
-}
-
-class _AtFinderAppState extends State<_AtFinderApp> {
-  var _isFirstItemVisible = false;
-  var _isSecondItemVisible = false;
-  var _secondItemTapped = 0;
-  var _firstItemTapped = 0;
-
-  @override
-  void initState() {
-    super.initState();
-
-    Future<void>.delayed(const Duration(seconds: 1), () {
-      if (!mounted) {
-        return;
-      }
-
-      setState(() {
-        _isFirstItemVisible = true;
-      });
-    });
-
-    Future<void>.delayed(const Duration(seconds: 3), () {
-      if (!mounted) {
-        return;
-      }
-
-      setState(() {
-        _isSecondItemVisible = true;
-      });
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: ListView(
-          children: [
-            if (_isFirstItemVisible)
-              _AtFinderItem(
-                index: 0,
-                onTap: () {
-                  setState(() {
-                    _firstItemTapped++;
-                  });
-                },
-              ),
-            if (_isSecondItemVisible)
-              _AtFinderItem(
-                index: 1,
-                onTap: () {
-                  setState(() {
-                    _secondItemTapped++;
-                  });
-                },
-              ),
-            if (_secondItemTapped > 0)
-              Text(
-                'Second item tapped $_secondItemTapped',
-                key: Key('secondItemTapped'),
-              ),
-            if (_firstItemTapped > 0)
-              Text(
-                'First item tapped $_firstItemTapped',
-                key: Key('firstItemTapped'),
-              ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _AtFinderItem extends StatelessWidget {
-  const _AtFinderItem({required this.index, required this.onTap});
-
-  final int index;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return ListTile(
-      key: _AtFinderItemKey(index),
-      title: Text('Item $index'),
-      onTap: onTap,
-    );
-  }
-}
-
-class _AtFinderItemKey extends ValueKey<int> {
-  const _AtFinderItemKey(super.value);
 }

--- a/dev/e2e_app/patrol_test/at_finder_test.dart
+++ b/dev/e2e_app/patrol_test/at_finder_test.dart
@@ -10,7 +10,12 @@ void main() {
 
       await $(_AtFinderItem).at(1).tap();
 
-      await $(#secondItemTapped).waitUntilVisible();
+      await $('Second item tapped 1').waitUntilVisible();
+
+      await $(_AtFinderItem).first.tap();
+      await $('First item tapped 1').waitUntilVisible();
+      await $(_AtFinderItem).last.tap();
+      await $('Second item tapped 2').waitUntilVisible();
     },
     tags: ['android', 'emulator', 'ios', 'simulator'],
   );
@@ -26,7 +31,8 @@ class _AtFinderApp extends StatefulWidget {
 class _AtFinderAppState extends State<_AtFinderApp> {
   var _isFirstItemVisible = false;
   var _isSecondItemVisible = false;
-  var _isSecondItemTapped = false;
+  var _SecondItemTapped = 0;
+  var _FirstItemTapped = 0;
 
   @override
   void initState() {
@@ -59,18 +65,24 @@ class _AtFinderAppState extends State<_AtFinderApp> {
       home: Scaffold(
         body: ListView(
           children: [
-            if (_isFirstItemVisible) _AtFinderItem(index: 0, onTap: () {}),
+            if (_isFirstItemVisible) _AtFinderItem(index: 0, onTap: () {
+              setState(() {
+                _FirstItemTapped++;
+              });
+            }),
             if (_isSecondItemVisible)
               _AtFinderItem(
                 index: 1,
                 onTap: () {
                   setState(() {
-                    _isSecondItemTapped = true;
+                    _SecondItemTapped++;
                   });
                 },
               ),
-            if (_isSecondItemTapped)
-              const Text('Second item tapped', key: Key('secondItemTapped')),
+            if (_SecondItemTapped > 0)
+              Text('Second item tapped $_SecondItemTapped', key: Key('secondItemTapped')),
+            if (_FirstItemTapped > 0)
+              Text('First item tapped $_FirstItemTapped', key: Key('firstItemTapped')),
           ],
         ),
       ),

--- a/dev/e2e_app/patrol_test/at_finder_test.dart
+++ b/dev/e2e_app/patrol_test/at_finder_test.dart
@@ -31,8 +31,8 @@ class _AtFinderApp extends StatefulWidget {
 class _AtFinderAppState extends State<_AtFinderApp> {
   var _isFirstItemVisible = false;
   var _isSecondItemVisible = false;
-  var _SecondItemTapped = 0;
-  var _FirstItemTapped = 0;
+  var _secondItemTapped = 0;
+  var _firstItemTapped = 0;
 
   @override
   void initState() {
@@ -65,24 +65,34 @@ class _AtFinderAppState extends State<_AtFinderApp> {
       home: Scaffold(
         body: ListView(
           children: [
-            if (_isFirstItemVisible) _AtFinderItem(index: 0, onTap: () {
-              setState(() {
-                _FirstItemTapped++;
-              });
-            }),
+            if (_isFirstItemVisible)
+              _AtFinderItem(
+                index: 0,
+                onTap: () {
+                  setState(() {
+                    _firstItemTapped++;
+                  });
+                },
+              ),
             if (_isSecondItemVisible)
               _AtFinderItem(
                 index: 1,
                 onTap: () {
                   setState(() {
-                    _SecondItemTapped++;
+                    _secondItemTapped++;
                   });
                 },
               ),
-            if (_SecondItemTapped > 0)
-              Text('Second item tapped $_SecondItemTapped', key: Key('secondItemTapped')),
-            if (_FirstItemTapped > 0)
-              Text('First item tapped $_FirstItemTapped', key: Key('firstItemTapped')),
+            if (_secondItemTapped > 0)
+              Text(
+                'Second item tapped $_secondItemTapped',
+                key: Key('secondItemTapped'),
+              ),
+            if (_firstItemTapped > 0)
+              Text(
+                'First item tapped $_firstItemTapped',
+                key: Key('firstItemTapped'),
+              ),
           ],
         ),
       ),

--- a/dev/e2e_app/patrol_test/at_finder_test.dart
+++ b/dev/e2e_app/patrol_test/at_finder_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import 'common.dart';
+
+void main() {
+  patrol(
+    'at() waits until widget at index exists',
+    ($) async {
+      await $.pumpWidgetAndSettle(const _AtFinderApp());
+
+      await $(_AtFinderItem).at(1).tap();
+
+      await $(#secondItemTapped).waitUntilVisible();
+    },
+    tags: ['android', 'emulator', 'ios', 'simulator'],
+  );
+}
+
+class _AtFinderApp extends StatefulWidget {
+  const _AtFinderApp();
+
+  @override
+  State<_AtFinderApp> createState() => _AtFinderAppState();
+}
+
+class _AtFinderAppState extends State<_AtFinderApp> {
+  var _isFirstItemVisible = false;
+  var _isSecondItemVisible = false;
+  var _isSecondItemTapped = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    Future<void>.delayed(const Duration(seconds: 1), () {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _isFirstItemVisible = true;
+      });
+    });
+
+    Future<void>.delayed(const Duration(seconds: 3), () {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _isSecondItemVisible = true;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: ListView(
+          children: [
+            if (_isFirstItemVisible) _AtFinderItem(index: 0, onTap: () {}),
+            if (_isSecondItemVisible)
+              _AtFinderItem(
+                index: 1,
+                onTap: () {
+                  setState(() {
+                    _isSecondItemTapped = true;
+                  });
+                },
+              ),
+            if (_isSecondItemTapped)
+              const Text('Second item tapped', key: Key('secondItemTapped')),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AtFinderItem extends StatelessWidget {
+  const _AtFinderItem({required this.index, required this.onTap});
+
+  final int index;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      key: _AtFinderItemKey(index),
+      title: Text('Item $index'),
+      onTap: onTap,
+    );
+  }
+}
+
+class _AtFinderItemKey extends ValueKey<int> {
+  const _AtFinderItemKey(super.value);
+}

--- a/dev/e2e_app/pubspec.yaml
+++ b/dev/e2e_app/pubspec.yaml
@@ -29,8 +29,6 @@ dependencies:
 
 # Due to: https://github.com/Baseflow/flutter-permission-handler/issues/1450#issuecomment-2673836556
 dependency_overrides:
-  patrol_finders:
-    path: ../../packages/patrol_finders
   permission_handler_apple: 9.4.5
 
 dev_dependencies:

--- a/dev/e2e_app/pubspec.yaml
+++ b/dev/e2e_app/pubspec.yaml
@@ -29,6 +29,8 @@ dependencies:
 
 # Due to: https://github.com/Baseflow/flutter-permission-handler/issues/1450#issuecomment-2673836556
 dependency_overrides:
+  patrol_finders:
+    path: ../../packages/patrol_finders
   permission_handler_apple: 9.4.5
 
 dev_dependencies:

--- a/packages/patrol_finders/CHANGELOG.md
+++ b/packages/patrol_finders/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Fix `at()` to wait for widget to become visible.
+- Fix `at()`, `first` and `last` to wait for widget to become visible.
 
 ## 3.2.0
 

--- a/packages/patrol_finders/CHANGELOG.md
+++ b/packages/patrol_finders/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix `at()` to wait for widget to become visible.
+
 ## 3.2.0
 
 - Bump `patrol_log` to `^0.8.0`.

--- a/packages/patrol_finders/lib/src/custom_finders/patrol_finder.dart
+++ b/packages/patrol_finders/lib/src/custom_finders/patrol_finder.dart
@@ -554,7 +554,10 @@ class PatrolFinder implements MatchFinder {
   @override
   PatrolFinder at(int index) {
     // TODO: Throw a better error (https://github.com/leancodepl/patrol/issues/548)
-    return PatrolFinder(tester: tester, finder: finder.at(index));
+    return PatrolFinder(
+      tester: tester,
+      finder: _PatrolIndexFinder(finder, index),
+    );
   }
 
   @override
@@ -609,6 +612,38 @@ class PatrolFinder implements MatchFinder {
   // Do we still need to use deprecated method?
   // ignore: deprecated_member_use
   bool precache() => finder.precache();
+}
+
+class _PatrolIndexFinder extends ChainedFinder {
+  _PatrolIndexFinder(super.parent, this.index);
+
+  final int index;
+
+  @override
+  Iterable<Element> filter(Iterable<Element> parentCandidates) sync* {
+    if (index < 0) {
+      yield parentCandidates.elementAt(index);
+      return;
+    }
+
+    var currentIndex = 0;
+    for (final candidate in parentCandidates) {
+      if (currentIndex == index) {
+        yield candidate;
+        return;
+      }
+
+      currentIndex += 1;
+    }
+  }
+
+  @override
+  String describeMatch(Plurality plurality) {
+    return '${parent.describeMatch(plurality)} (ignoring all but index $index)';
+  }
+
+  @override
+  String get description => describeMatch(Plurality.many);
 }
 
 /// Useful methods that make chained finders more readable.

--- a/packages/patrol_finders/lib/src/custom_finders/patrol_finder.dart
+++ b/packages/patrol_finders/lib/src/custom_finders/patrol_finder.dart
@@ -622,7 +622,6 @@ class _PatrolIndexFinder extends ChainedFinder {
   @override
   Iterable<Element> filter(Iterable<Element> parentCandidates) sync* {
     if (index < 0) {
-      yield parentCandidates.elementAt(index);
       return;
     }
 

--- a/packages/patrol_finders/lib/src/custom_finders/patrol_finder.dart
+++ b/packages/patrol_finders/lib/src/custom_finders/patrol_finder.dart
@@ -541,19 +541,51 @@ class PatrolFinder implements MatchFinder {
 
   @override
   PatrolFinder get first {
-    return PatrolFinder(tester: tester, finder: finder.first);
+    return _select(
+      description: 'first',
+      selector: (candidates) => candidates.take(1),
+    );
   }
 
   @override
   PatrolFinder get last {
-    return PatrolFinder(tester: tester, finder: finder.last);
+    return _select(
+      description: 'last',
+      selector: (candidates) {
+        if (candidates.isEmpty) {
+          return const Iterable<Element>.empty();
+        }
+
+        return [candidates.last] as Iterable<Element>;
+      },
+    );
   }
 
   @override
   PatrolFinder at(int index) {
+    return _select(
+      description: 'index $index',
+      selector: (candidates) {
+        if (index < 0) {
+          return const Iterable<Element>.empty();
+        }
+
+        return candidates.skip(index).take(1);
+      },
+    );
+  }
+
+  PatrolFinder _select({
+    required String description,
+    required Iterable<Element> Function(Iterable<Element> candidates) selector,
+  }) {
     return PatrolFinder(
       tester: tester,
-      finder: _PatrolIndexFinder(finder, index),
+      finder: _PatrolSelectorFinder(
+        finder,
+        selectorDescription: description,
+        selector: selector,
+      ),
     );
   }
 
@@ -611,31 +643,24 @@ class PatrolFinder implements MatchFinder {
   bool precache() => finder.precache();
 }
 
-class _PatrolIndexFinder extends ChainedFinder {
-  _PatrolIndexFinder(super.parent, this.index);
+class _PatrolSelectorFinder extends ChainedFinder {
+  _PatrolSelectorFinder(
+    super.parent, {
+    required this.selectorDescription,
+    required this.selector,
+  });
 
-  final int index;
+  final String selectorDescription;
+  final Iterable<Element> Function(Iterable<Element> candidates) selector;
 
   @override
-  Iterable<Element> filter(Iterable<Element> parentCandidates) sync* {
-    if (index < 0) {
-      return;
-    }
-
-    var currentIndex = 0;
-    for (final candidate in parentCandidates) {
-      if (currentIndex == index) {
-        yield candidate;
-        return;
-      }
-
-      currentIndex += 1;
-    }
-  }
+  Iterable<Element> filter(Iterable<Element> parentCandidates) =>
+      selector(parentCandidates);
 
   @override
   String describeMatch(Plurality plurality) {
-    return '${parent.describeMatch(plurality)} (ignoring all but index $index)';
+    return '${parent.describeMatch(plurality)} '
+        '(ignoring all but $selectorDescription)';
   }
 
   @override

--- a/packages/patrol_finders/lib/src/custom_finders/patrol_finder.dart
+++ b/packages/patrol_finders/lib/src/custom_finders/patrol_finder.dart
@@ -541,19 +541,16 @@ class PatrolFinder implements MatchFinder {
 
   @override
   PatrolFinder get first {
-    // TODO: Throw a better error (https://github.com/leancodepl/patrol/issues/548)
     return PatrolFinder(tester: tester, finder: finder.first);
   }
 
   @override
   PatrolFinder get last {
-    // TODO: Throw a better error (https://github.com/leancodepl/patrol/issues/548)
     return PatrolFinder(tester: tester, finder: finder.last);
   }
 
   @override
   PatrolFinder at(int index) {
-    // TODO: Throw a better error (https://github.com/leancodepl/patrol/issues/548)
     return PatrolFinder(
       tester: tester,
       finder: _PatrolIndexFinder(finder, index),

--- a/packages/patrol_finders/test/patrol_finder_test.dart
+++ b/packages/patrol_finders/test/patrol_finder_test.dart
@@ -1200,6 +1200,12 @@ void main() {
         expect($('some text').at(1), findsNothing);
       });
 
+      patrolWidgetTest('finds nothing when index is negative', ($) async {
+        await $.pumpWidget(const MaterialApp(home: Text('some text')));
+
+        expect($('some text').at(-1), findsNothing);
+      });
+
       patrolWidgetTest('tap waits until widget at index exists', ($) async {
         var itemCount = 1;
         var tapCount = 0;
@@ -1266,23 +1272,55 @@ void main() {
         );
       });
 
-      patrolWidgetTest(
-        'throws StateError when widget at index does not exist',
-        ($) async {
-          await $.pumpWidget(const MaterialApp());
+      patrolWidgetTest('finds nothing when no widgets exist', ($) async {
+        await $.pumpWidget(const MaterialApp());
 
-          expect(
-            () => $('some text').last,
-            throwsA(
-              isA<StateError>().having(
-                (err) => err.message,
-                'message',
-                'No element',
+        expect($('some text').first, findsNothing);
+      });
+
+      patrolWidgetTest('tap waits until first widget exists', ($) async {
+        var itemCount = 0;
+        var tapCount = 0;
+        var itemScheduled = false;
+
+        await $.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (context, setState) {
+                  if (!itemScheduled) {
+                    itemScheduled = true;
+                    Future<void>.delayed(const Duration(milliseconds: 200), () {
+                      setState(() => itemCount = 1);
+                    });
+                  }
+
+                  return Column(
+                    children: [
+                      Text('taps: $tapCount'),
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: itemCount,
+                          itemBuilder: (context, index) {
+                            return ListTile(
+                              title: Text('item $index'),
+                              onTap: () => setState(() => tapCount++),
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  );
+                },
               ),
             ),
-          );
-        },
-      );
+          ),
+        );
+
+        await $(ListView).$(ListTile).first.tap();
+
+        expect($('taps: 1'), findsOneWidget);
+      });
     });
 
     group('last', () {
@@ -1306,23 +1344,57 @@ void main() {
         );
       });
 
-      patrolWidgetTest(
-        'throws StateError when widget at index does not exist',
-        ($) async {
-          await $.pumpWidget(const MaterialApp());
+      patrolWidgetTest('finds nothing when no widgets exist', ($) async {
+        await $.pumpWidget(const MaterialApp());
 
-          expect(
-            () => $('some text').last,
-            throwsA(
-              isA<StateError>().having(
-                (err) => err.message,
-                'message',
-                'No element',
+        expect($('some text').last, findsNothing);
+      });
+
+      patrolWidgetTest('tap waits until last widget exists', ($) async {
+        var itemCount = 0;
+        var tappedItem = 'none';
+        var itemScheduled = false;
+
+        await $.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (context, setState) {
+                  if (!itemScheduled) {
+                    itemScheduled = true;
+                    Future<void>.delayed(const Duration(milliseconds: 200), () {
+                      setState(() => itemCount = 2);
+                    });
+                  }
+
+                  return Column(
+                    children: [
+                      Text('tapped: $tappedItem'),
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: itemCount,
+                          itemBuilder: (context, index) {
+                            return ListTile(
+                              title: Text('item $index'),
+                              onTap: () {
+                                setState(() => tappedItem = 'item $index');
+                              },
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  );
+                },
               ),
             ),
-          );
-        },
-      );
+          ),
+        );
+
+        await $(ListView).$(ListTile).last.tap();
+
+        expect($('tapped: item 1'), findsOneWidget);
+      });
     });
 
     patrolWidgetTest(

--- a/packages/patrol_finders/test/patrol_finder_test.dart
+++ b/packages/patrol_finders/test/patrol_finder_test.dart
@@ -1192,14 +1192,57 @@ void main() {
         );
       });
 
-      patrolWidgetTest(
-        'throws IndexError when widget at index does not exist',
-        ($) async {
-          await $.pumpWidget(const MaterialApp(home: Text('some text')));
+      patrolWidgetTest('finds nothing when widget at index does not exist', (
+        $,
+      ) async {
+        await $.pumpWidget(const MaterialApp(home: Text('some text')));
 
-          expect(() => $('some text').at(1), throwsA(isA<IndexError>()));
-        },
-      );
+        expect($('some text').at(1), findsNothing);
+      });
+
+      patrolWidgetTest('tap waits until widget at index exists', ($) async {
+        var itemCount = 1;
+        var tapCount = 0;
+        var itemScheduled = false;
+
+        await $.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (context, setState) {
+                  if (!itemScheduled) {
+                    itemScheduled = true;
+                    Future<void>.delayed(const Duration(milliseconds: 200), () {
+                      setState(() => itemCount = 2);
+                    });
+                  }
+
+                  return Column(
+                    children: [
+                      Text('taps: $tapCount'),
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: itemCount,
+                          itemBuilder: (context, index) {
+                            return ListTile(
+                              title: Text('item $index'),
+                              onTap: () => setState(() => tapCount++),
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        await $(ListView).$(ListTile).at(1).tap();
+
+        expect($('taps: 1'), findsOneWidget);
+      });
     });
 
     group('first', () {


### PR DESCRIPTION
Fixes issue #1938
## Problem
`first`, `last`, and `at()` delegated directly to Flutter finders, which throw immediately for empty results (`StateError`/`RangeError`). That prevented Patrol’s normal waiting behavior in `tap()`/`waitUntilVisible()` from kicking in when a widget appeared later.
## Fix
Replaced those selectors with a Patrol wrapper that returns an empty result instead of throwing when the selected element is not available yet. This lets waitUntilVisible() keep retrying until the widget appears or the regular timeout is reached.
## Test plan
- [x] dart analyze in `packages/patrol_finders` clean
- [x] flutter test in `packages/patrol_finders/test` - 127/127 passed, including 7 new tests covering: 
   - negative numbers
   - widgets appearing after delay
   - non-existing widgets
- [x] patrol test in `dev/e2e_app/patrol_test/at_finder_test.dart` - successfully waits for a second widget to appear without throwing.

https://github.com/user-attachments/assets/c8b766e7-5968-45d7-84c0-0535f9b08134

## CI
- `test android emulator webview...` expected to fail

