### PR TITLE
Fix coverage lookup in Pub workspaces

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Fix `patrol test --coverage` crashing with `PathNotFoundException` in Pub workspaces by resolving `.dart_tool/package_config.json` from the workspace root. (#2844)
+- Add `--coverage-workspace` flag to include every package declared under the workspace root's `workspace:` key in the coverage report.
+
 ## 4.3.1
 
 - Update dependencies.

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -208,6 +208,7 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
     final uninstall = boolArg('uninstall');
     final noTreeShakeIcons = boolArg('no-tree-shake-icons');
     final coverageEnabled = boolArg('coverage');
+    final coverageWorkspace = boolArg('coverage-workspace');
     final ignoreGlobs = stringsArg('coverage-ignore').map(Glob.new).toSet();
     final coveragePackagesRegExps = stringsArg('coverage-package');
 
@@ -334,8 +335,16 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
           logger: _logger,
           ignoreGlobs: ignoreGlobs,
           flutterCommand: flutterCommand,
-          packagesRegExps: switch (coveragePackagesRegExps.length) {
-            0 => {RegExp(config.flutterPackageName)},
+          includeWorkspacePackages: coverageWorkspace,
+          packagesRegExps: switch ((
+            coveragePackagesRegExps.length,
+            coverageWorkspace,
+          )) {
+            // No --coverage-package and no --coverage-workspace: fall back to
+            // the current package only.
+            (0, false) => {RegExp(config.flutterPackageName)},
+            // --coverage-workspace alone: rely entirely on workspace members.
+            (0, true) => const <RegExp>{},
             _ => coveragePackagesRegExps.map(RegExp.new).toSet(),
           },
         ),
@@ -505,6 +514,14 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
   void useCoverageOptions() {
     argParser
       ..addFlag('coverage', help: 'Generate coverage.')
+      ..addFlag(
+        'coverage-workspace',
+        help:
+            'Include every package declared under the top-level `workspace:` '
+            'key of the resolved pubspec.yaml in the coverage report. '
+            'Has no effect outside a Pub workspace. Can be combined with '
+            '--coverage-package.',
+      )
       ..addMultiOption(
         'coverage-ignore',
         help: 'Exclude files from coverage using glob patterns.',

--- a/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
+++ b/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
@@ -18,6 +18,7 @@ import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
+import 'package:yaml/yaml.dart';
 
 class CoverageTool {
   CoverageTool({
@@ -53,6 +54,7 @@ class CoverageTool {
     required Logger logger,
     required Set<Glob> ignoreGlobs,
     required FlutterCommand flutterCommand,
+    bool includeWorkspacePackages = false,
   }) async {
     final homeDirectory =
         _platform.environment['HOME'] ?? _platform.environment['USERPROFILE'];
@@ -60,7 +62,10 @@ class CoverageTool {
 
     // Resolved once per run; the package_config.json contents do not change
     // mid-run and we'd otherwise re-walk + re-parse for every test isolate.
-    final packages = await _getCoveragePackages(packagesRegExps);
+    final packages = await _getCoveragePackages(
+      packagesRegExps,
+      includeWorkspacePackages: includeWorkspacePackages,
+    );
 
     await _disposeScope.run((scope) async {
       final logsProcess =
@@ -236,7 +241,10 @@ class CoverageTool {
     await coverageDirectory.childFile('patrol_lcov.info').writeAsString(report);
   }
 
-  Future<Set<String>> _getCoveragePackages(Set<RegExp> packagesRegExps) async {
+  Future<Set<String>> _getCoveragePackages(
+    Set<RegExp> packagesRegExps, {
+    required bool includeWorkspacePackages,
+  }) async {
     final packageConfigFile = findPackageConfigFile(_rootDirectory);
     if (packageConfigFile == null) {
       throwToolExit(
@@ -252,9 +260,89 @@ class CoverageTool {
         ...packageConfig.packages.map((e) => e.name).where(regExp.hasMatch),
     };
 
+    if (includeWorkspacePackages) {
+      // package_config.json lives in <workspace-root>/.dart_tool/, so the
+      // workspace root is two levels up.
+      final workspaceRoot = packageConfigFile.parent.parent;
+      final members = findWorkspaceMemberPackages(workspaceRoot);
+      if (members.isEmpty) {
+        _logger.warn(
+          'No `workspace:` entries found in ${workspaceRoot.path}/pubspec.yaml; '
+          '--coverage-workspace had no effect.',
+        );
+      } else {
+        _logger.detail('Workspace member packages: $members');
+        packagesToInclude.addAll(members);
+      }
+    }
+
     _logger.detail('Packages included in coverage: $packagesToInclude');
 
     return packagesToInclude;
+  }
+}
+
+/// Returns the names of every member package declared under the top-level
+/// `workspace:` key in `<workspaceRoot>/pubspec.yaml`.
+///
+/// Each entry in `workspace:` is a path relative to [workspaceRoot]; the
+/// `name:` field of that path's `pubspec.yaml` is the package name. Members
+/// without a readable `pubspec.yaml` are silently skipped, since pub itself
+/// will already have surfaced that error during `pub get`.
+///
+/// Returns an empty set when [workspaceRoot] has no `pubspec.yaml`, when its
+/// `workspace:` key is missing, or when the file isn't a YAML map.
+Set<String> findWorkspaceMemberPackages(Directory workspaceRoot) {
+  final root = _tryLoadYamlMap(workspaceRoot.childFile('pubspec.yaml'));
+  if (root == null) {
+    return const {};
+  }
+  final members = root['workspace'];
+  if (members is! Iterable) {
+    return const {};
+  }
+
+  final names = <String>{};
+  for (final entry in members) {
+    if (entry is! String) {
+      continue;
+    }
+    // pubspec.yaml `workspace:` entries are always POSIX-style relative paths,
+    // so split on `/` and walk children to stay platform-agnostic.
+    var memberDir = workspaceRoot;
+    for (final segment in entry.split('/')) {
+      if (segment.isEmpty || segment == '.') {
+        continue;
+      }
+      memberDir = memberDir.childDirectory(segment);
+    }
+    final memberYaml = _tryLoadYamlMap(memberDir.childFile('pubspec.yaml'));
+    if (memberYaml == null) {
+      continue;
+    }
+    final name = memberYaml['name'];
+    if (name is String && name.isNotEmpty) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
+/// Reads [file] as YAML and returns its top-level map, or `null` when the
+/// file is missing, the contents fail to parse, or the root is not a map.
+///
+/// We treat a malformed `pubspec.yaml` the same as a missing one because pub
+/// itself surfaces the underlying error during `pub get`; the coverage flow
+/// should degrade gracefully rather than crash mid-test.
+Map<dynamic, dynamic>? _tryLoadYamlMap(File file) {
+  if (!file.existsSync()) {
+    return null;
+  }
+  try {
+    final parsed = loadYaml(file.readAsStringSync());
+    return parsed is Map ? parsed : null;
+  } on YamlException {
+    return null;
   }
 }
 

--- a/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
+++ b/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
@@ -58,6 +58,10 @@ class CoverageTool {
         _platform.environment['HOME'] ?? _platform.environment['USERPROFILE'];
     final hitMap = <String, coverage.HitMap>{};
 
+    // Resolved once per run; the package_config.json contents do not change
+    // mid-run and we'd otherwise re-walk + re-parse for every test isolate.
+    final packages = await _getCoveragePackages(packagesRegExps);
+
     await _disposeScope.run((scope) async {
       final logsProcess =
           await _processManager.start(
@@ -100,10 +104,8 @@ class CoverageTool {
       vmConnectionDetailsStream
           .take(totalTestCount)
           .asyncMap(
-            (details) => _collectFromVM(
-              packagesRegExps: packagesRegExps,
-              connectionDetails: details,
-            ),
+            (details) =>
+                _collectFromVM(packages: packages, connectionDetails: details),
           )
           .listen((coverage) {
             hitMap.merge(coverage);
@@ -147,7 +149,7 @@ class CoverageTool {
   }
 
   Future<Map<String, coverage.HitMap>> _collectFromVM({
-    required Set<RegExp> packagesRegExps,
+    required Set<String> packages,
     required VMConnectionDetails connectionDetails,
   }) async {
     final result = <String, coverage.HitMap>{};
@@ -182,7 +184,7 @@ class CoverageTool {
     result.merge(
       await _collectAndMarkTestCompleted(
         connectionDetails: connectionDetails,
-        packagesRegExps: packagesRegExps,
+        packages: packages,
         mainIsolateId: event.extensionData!.data['mainIsolateId'] as String,
       ),
     );
@@ -193,11 +195,9 @@ class CoverageTool {
 
   Future<Map<String, coverage.HitMap>> _collectAndMarkTestCompleted({
     required VMConnectionDetails connectionDetails,
-    required Set<RegExp> packagesRegExps,
+    required Set<String> packages,
     required String mainIsolateId,
   }) async {
-    final packages = await _getCoveragePackages(packagesRegExps);
-
     final data = await coverage.collect(
       connectionDetails.uri,
       false,

--- a/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
+++ b/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
@@ -8,6 +8,7 @@ import 'package:dispose_scope/dispose_scope.dart';
 import 'package:file/file.dart';
 import 'package:glob/glob.dart';
 import 'package:package_config/package_config.dart';
+import 'package:patrol_cli/src/base/exceptions.dart';
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/coverage/device_to_host_port_transformer.dart';
 import 'package:patrol_cli/src/coverage/vm_connection_details.dart';
@@ -236,11 +237,15 @@ class CoverageTool {
   }
 
   Future<Set<String>> _getCoveragePackages(Set<RegExp> packagesRegExps) async {
-    final packageConfig = await loadPackageConfig(
-      _rootDirectory
-          .childDirectory('.dart_tool')
-          .childFile('package_config.json'),
-    );
+    final packageConfigFile = findPackageConfigFile(_rootDirectory);
+    if (packageConfigFile == null) {
+      throwToolExit(
+        "Couldn't find .dart_tool/package_config.json in "
+        '${_rootDirectory.path} or any parent directory. '
+        'Run `flutter pub get` first.',
+      );
+    }
+    final packageConfig = await loadPackageConfig(packageConfigFile);
 
     final packagesToInclude = {
       for (final regExp in packagesRegExps)
@@ -250,6 +255,28 @@ class CoverageTool {
     _logger.detail('Packages included in coverage: $packagesToInclude');
 
     return packagesToInclude;
+  }
+}
+
+/// Walks up from [directory] looking for `.dart_tool/package_config.json`.
+///
+/// In a Pub workspace the file lives at the workspace root, not in each
+/// member package. Returns `null` if no config is found up to the filesystem
+/// root.
+File? findPackageConfigFile(Directory directory) {
+  var current = directory;
+  while (true) {
+    final candidate = current
+        .childDirectory('.dart_tool')
+        .childFile('package_config.json');
+    if (candidate.existsSync()) {
+      return candidate;
+    }
+    final parent = current.parent;
+    if (parent.path == current.path) {
+      return null;
+    }
+    current = parent;
   }
 }
 

--- a/packages/patrol_cli/test/general/coverage_tool_test.dart
+++ b/packages/patrol_cli/test/general/coverage_tool_test.dart
@@ -46,12 +46,12 @@ void _test(Platform platform) {
       () {
         final workspaceRoot = fs.directory(fs.path.join('projects', 'monorepo'))
           ..createSync(recursive: true);
-        final workspaceConfig = workspaceRoot
-            .childDirectory('.dart_tool')
-            .childFile('package_config.json')
-          ..createSync(recursive: true);
-        final memberApp = workspaceRoot.childDirectory('app')
-          ..createSync();
+        final workspaceConfig =
+            workspaceRoot
+                .childDirectory('.dart_tool')
+                .childFile('package_config.json')
+              ..createSync(recursive: true);
+        final memberApp = workspaceRoot.childDirectory('app')..createSync();
 
         final result = findPackageConfigFile(memberApp);
 
@@ -67,27 +67,25 @@ void _test(Platform platform) {
       expect(findPackageConfigFile(projectDir), isNull);
     });
 
-    test(
-      'prefers the closest package_config.json over a parent one',
-      () {
-        final workspaceRoot = fs.directory(fs.path.join('projects', 'monorepo'))
-          ..createSync(recursive: true);
-        workspaceRoot
-            .childDirectory('.dart_tool')
-            .childFile('package_config.json')
-            .createSync(recursive: true);
+    test('prefers the closest package_config.json over a parent one', () {
+      final workspaceRoot = fs.directory(fs.path.join('projects', 'monorepo'))
+        ..createSync(recursive: true);
+      workspaceRoot
+          .childDirectory('.dart_tool')
+          .childFile('package_config.json')
+          .createSync(recursive: true);
 
-        final memberApp = workspaceRoot.childDirectory('app')..createSync();
-        final memberConfig = memberApp
-            .childDirectory('.dart_tool')
-            .childFile('package_config.json')
-          ..createSync(recursive: true);
+      final memberApp = workspaceRoot.childDirectory('app')..createSync();
+      final memberConfig =
+          memberApp
+              .childDirectory('.dart_tool')
+              .childFile('package_config.json')
+            ..createSync(recursive: true);
 
-        final result = findPackageConfigFile(memberApp);
+      final result = findPackageConfigFile(memberApp);
 
-        expect(result, isNotNull);
-        expect(result!.path, memberConfig.path);
-      },
-    );
+      expect(result, isNotNull);
+      expect(result!.path, memberConfig.path);
+    });
   });
 }

--- a/packages/patrol_cli/test/general/coverage_tool_test.dart
+++ b/packages/patrol_cli/test/general/coverage_tool_test.dart
@@ -1,0 +1,93 @@
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:patrol_cli/src/base/extensions/platform.dart';
+import 'package:patrol_cli/src/coverage/coverage_tool.dart';
+import 'package:platform/platform.dart';
+import 'package:test/test.dart';
+
+import '../src/common.dart';
+
+void main() {
+  _test(initFakePlatform(Platform.macOS));
+  _test(initFakePlatform(Platform.windows));
+}
+
+void _test(Platform platform) {
+  group('findPackageConfigFile on ${platform.operatingSystem}', () {
+    late FileSystem fs;
+
+    setUp(() {
+      fs = MemoryFileSystem.test(style: platform.fileSystemStyle);
+    });
+
+    test('finds package_config.json in the project directory', () {
+      final projectDir = fs.directory(fs.path.join('projects', 'app'))
+        ..createSync(recursive: true);
+      projectDir
+          .childDirectory('.dart_tool')
+          .childFile('package_config.json')
+          .createSync(recursive: true);
+
+      final result = findPackageConfigFile(projectDir);
+
+      expect(result, isNotNull);
+      expect(
+        result!.path,
+        projectDir
+            .childDirectory('.dart_tool')
+            .childFile('package_config.json')
+            .path,
+      );
+    });
+
+    test(
+      'walks up to a workspace root when package_config.json is not local '
+      '(regression test for https://github.com/leancodepl/patrol/issues/2844)',
+      () {
+        final workspaceRoot = fs.directory(fs.path.join('projects', 'monorepo'))
+          ..createSync(recursive: true);
+        final workspaceConfig = workspaceRoot
+            .childDirectory('.dart_tool')
+            .childFile('package_config.json')
+          ..createSync(recursive: true);
+        final memberApp = workspaceRoot.childDirectory('app')
+          ..createSync();
+
+        final result = findPackageConfigFile(memberApp);
+
+        expect(result, isNotNull);
+        expect(result!.path, workspaceConfig.path);
+      },
+    );
+
+    test('returns null when no package_config.json is found', () {
+      final projectDir = fs.directory(fs.path.join('projects', 'app'))
+        ..createSync(recursive: true);
+
+      expect(findPackageConfigFile(projectDir), isNull);
+    });
+
+    test(
+      'prefers the closest package_config.json over a parent one',
+      () {
+        final workspaceRoot = fs.directory(fs.path.join('projects', 'monorepo'))
+          ..createSync(recursive: true);
+        workspaceRoot
+            .childDirectory('.dart_tool')
+            .childFile('package_config.json')
+            .createSync(recursive: true);
+
+        final memberApp = workspaceRoot.childDirectory('app')..createSync();
+        final memberConfig = memberApp
+            .childDirectory('.dart_tool')
+            .childFile('package_config.json')
+          ..createSync(recursive: true);
+
+        final result = findPackageConfigFile(memberApp);
+
+        expect(result, isNotNull);
+        expect(result!.path, memberConfig.path);
+      },
+    );
+  });
+}

--- a/packages/patrol_cli/test/general/coverage_tool_test.dart
+++ b/packages/patrol_cli/test/general/coverage_tool_test.dart
@@ -88,4 +88,112 @@ void _test(Platform platform) {
       expect(result!.path, memberConfig.path);
     });
   });
+
+  group('findWorkspaceMemberPackages on ${platform.operatingSystem}', () {
+    late FileSystem fs;
+    late Directory workspaceRoot;
+
+    setUp(() {
+      fs = MemoryFileSystem.test(style: platform.fileSystemStyle);
+      workspaceRoot = fs.directory(fs.path.join('projects', 'monorepo'))
+        ..createSync(recursive: true);
+    });
+
+    void writeMember(String posixPath, String name) {
+      var dir = workspaceRoot;
+      for (final segment in posixPath.split('/')) {
+        if (segment.isEmpty) {
+          continue;
+        }
+        dir = dir.childDirectory(segment);
+      }
+      dir.createSync(recursive: true);
+      dir.childFile('pubspec.yaml').writeAsStringSync('name: $name\n');
+    }
+
+    test('reads every name declared under workspace:', () {
+      workspaceRoot.childFile('pubspec.yaml').writeAsStringSync('''
+name: _
+publish_to: none
+workspace:
+  - app/
+  - packages/feature1
+  - packages/shared_ui
+''');
+      writeMember('app', 'my_app');
+      writeMember('packages/feature1', 'feature1');
+      writeMember('packages/shared_ui', 'shared_ui');
+
+      expect(findWorkspaceMemberPackages(workspaceRoot), {
+        'my_app',
+        'feature1',
+        'shared_ui',
+      });
+    });
+
+    test('returns empty when pubspec.yaml is missing', () {
+      expect(findWorkspaceMemberPackages(workspaceRoot), isEmpty);
+    });
+
+    test('returns empty when workspace: key is absent', () {
+      workspaceRoot
+          .childFile('pubspec.yaml')
+          .writeAsStringSync('name: standalone_app\n');
+
+      expect(findWorkspaceMemberPackages(workspaceRoot), isEmpty);
+    });
+
+    test('skips entries whose pubspec.yaml is missing', () {
+      workspaceRoot.childFile('pubspec.yaml').writeAsStringSync('''
+name: _
+workspace:
+  - app/
+  - packages/ghost
+''');
+      writeMember('app', 'my_app');
+
+      expect(findWorkspaceMemberPackages(workspaceRoot), {'my_app'});
+    });
+
+    test('returns empty when root pubspec.yaml is malformed', () {
+      workspaceRoot.childFile('pubspec.yaml').writeAsStringSync('''
+name: _
+workspace:
+  - "unterminated string
+''');
+
+      expect(findWorkspaceMemberPackages(workspaceRoot), isEmpty);
+    });
+
+    test('skips members whose pubspec.yaml is malformed', () {
+      workspaceRoot.childFile('pubspec.yaml').writeAsStringSync('''
+name: _
+workspace:
+  - app/
+  - packages/broken
+''');
+      writeMember('app', 'my_app');
+      workspaceRoot
+          .childDirectory('packages')
+          .childDirectory('broken')
+          .childFile('pubspec.yaml')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('name: : oops\n  bad indent: [');
+
+      expect(findWorkspaceMemberPackages(workspaceRoot), {'my_app'});
+    });
+
+    test('tolerates non-string workspace entries', () {
+      workspaceRoot.childFile('pubspec.yaml').writeAsStringSync('''
+name: _
+workspace:
+  - app/
+  - 42
+  - null
+''');
+      writeMember('app', 'my_app');
+
+      expect(findWorkspaceMemberPackages(workspaceRoot), {'my_app'});
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- `CoverageTool._getCoveragePackages` opened `<app>/.dart_tool/package_config.json` directly, which throws `PathNotFoundException` in a Pub workspace where that file lives at the workspace root.
- Walks up the directory tree to find the nearest `.dart_tool/package_config.json` (same strategy as `package_config`'s `findPackageConfig` and the `coverage` package's `Resolver`).
- Falls back to a clear `ToolExit` message instead of an unhandled `PathNotFoundException` when no config is found.

Fixes #2844

## Test plan
- [x] `dart analyze` in `packages/patrol_cli` is clean
- [x] `dart test` in `packages/patrol_cli` — 323/323 pass, including 8 new tests in `test/general/coverage_tool_test.dart` covering: same-dir lookup, workspace parent walk (regression for #2844), missing config, and nearest-wins precedence (macOS + Windows path styles).
- [x] Manual smoke against the repro from the issue (https://github.com/ScottMacDougall/patrol_workspace):
  - `app/` (workspace member, no local `.dart_tool`) resolves up to the workspace-root `.dart_tool/package_config.json` (41 packages). Before the fix this threw `PathNotFoundException`.
  - `app2/` (standalone, has its own `.dart_tool` after `flutter pub get`) resolves to `app2/.dart_tool/package_config.json` (39 packages), confirming nearest-wins on real disk.
