### PR TITLE
Add --coverage-workspace flag for monorepo coverage

### DIFF
--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -208,6 +208,7 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
     final uninstall = boolArg('uninstall');
     final noTreeShakeIcons = boolArg('no-tree-shake-icons');
     final coverageEnabled = boolArg('coverage');
+    final coverageWorkspace = boolArg('coverage-workspace');
     final ignoreGlobs = stringsArg('coverage-ignore').map(Glob.new).toSet();
     final coveragePackagesRegExps = stringsArg('coverage-package');
 
@@ -334,8 +335,16 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
           logger: _logger,
           ignoreGlobs: ignoreGlobs,
           flutterCommand: flutterCommand,
-          packagesRegExps: switch (coveragePackagesRegExps.length) {
-            0 => {RegExp(config.flutterPackageName)},
+          includeWorkspacePackages: coverageWorkspace,
+          packagesRegExps: switch ((
+            coveragePackagesRegExps.length,
+            coverageWorkspace,
+          )) {
+            // No --coverage-package and no --coverage-workspace: fall back to
+            // the current package only.
+            (0, false) => {RegExp(config.flutterPackageName)},
+            // --coverage-workspace alone: rely entirely on workspace members.
+            (0, true) => const <RegExp>{},
             _ => coveragePackagesRegExps.map(RegExp.new).toSet(),
           },
         ),
@@ -505,6 +514,14 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
   void useCoverageOptions() {
     argParser
       ..addFlag('coverage', help: 'Generate coverage.')
+      ..addFlag(
+        'coverage-workspace',
+        help:
+            'Include every package declared under the top-level `workspace:` '
+            'key of the resolved pubspec.yaml in the coverage report. '
+            'Has no effect outside a Pub workspace. Can be combined with '
+            '--coverage-package.',
+      )
       ..addMultiOption(
         'coverage-ignore',
         help: 'Exclude files from coverage using glob patterns.',

--- a/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
+++ b/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
@@ -18,6 +18,7 @@ import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
+import 'package:yaml/yaml.dart';
 
 class CoverageTool {
   CoverageTool({
@@ -53,6 +54,7 @@ class CoverageTool {
     required Logger logger,
     required Set<Glob> ignoreGlobs,
     required FlutterCommand flutterCommand,
+    bool includeWorkspacePackages = false,
   }) async {
     final homeDirectory =
         _platform.environment['HOME'] ?? _platform.environment['USERPROFILE'];
@@ -60,7 +62,10 @@ class CoverageTool {
 
     // Resolved once per run; the package_config.json contents do not change
     // mid-run and we'd otherwise re-walk + re-parse for every test isolate.
-    final packages = await _getCoveragePackages(packagesRegExps);
+    final packages = await _getCoveragePackages(
+      packagesRegExps,
+      includeWorkspacePackages: includeWorkspacePackages,
+    );
 
     await _disposeScope.run((scope) async {
       final logsProcess =
@@ -236,7 +241,10 @@ class CoverageTool {
     await coverageDirectory.childFile('patrol_lcov.info').writeAsString(report);
   }
 
-  Future<Set<String>> _getCoveragePackages(Set<RegExp> packagesRegExps) async {
+  Future<Set<String>> _getCoveragePackages(
+    Set<RegExp> packagesRegExps, {
+    required bool includeWorkspacePackages,
+  }) async {
     final packageConfigFile = findPackageConfigFile(_rootDirectory);
     if (packageConfigFile == null) {
       throwToolExit(
@@ -252,9 +260,89 @@ class CoverageTool {
         ...packageConfig.packages.map((e) => e.name).where(regExp.hasMatch),
     };
 
+    if (includeWorkspacePackages) {
+      // package_config.json lives in <workspace-root>/.dart_tool/, so the
+      // workspace root is two levels up.
+      final workspaceRoot = packageConfigFile.parent.parent;
+      final members = findWorkspaceMemberPackages(workspaceRoot);
+      if (members.isEmpty) {
+        _logger.warn(
+          'No `workspace:` entries found in ${workspaceRoot.path}/pubspec.yaml; '
+          '--coverage-workspace had no effect.',
+        );
+      } else {
+        _logger.detail('Workspace member packages: $members');
+        packagesToInclude.addAll(members);
+      }
+    }
+
     _logger.detail('Packages included in coverage: $packagesToInclude');
 
     return packagesToInclude;
+  }
+}
+
+/// Returns the names of every member package declared under the top-level
+/// `workspace:` key in `<workspaceRoot>/pubspec.yaml`.
+///
+/// Each entry in `workspace:` is a path relative to [workspaceRoot]; the
+/// `name:` field of that path's `pubspec.yaml` is the package name. Members
+/// without a readable `pubspec.yaml` are silently skipped, since pub itself
+/// will already have surfaced that error during `pub get`.
+///
+/// Returns an empty set when [workspaceRoot] has no `pubspec.yaml`, when its
+/// `workspace:` key is missing, or when the file isn't a YAML map.
+Set<String> findWorkspaceMemberPackages(Directory workspaceRoot) {
+  final root = _tryLoadYamlMap(workspaceRoot.childFile('pubspec.yaml'));
+  if (root == null) {
+    return const {};
+  }
+  final members = root['workspace'];
+  if (members is! Iterable) {
+    return const {};
+  }
+
+  final names = <String>{};
+  for (final entry in members) {
+    if (entry is! String) {
+      continue;
+    }
+    // pubspec.yaml `workspace:` entries are always POSIX-style relative paths,
+    // so split on `/` and walk children to stay platform-agnostic.
+    var memberDir = workspaceRoot;
+    for (final segment in entry.split('/')) {
+      if (segment.isEmpty || segment == '.') {
+        continue;
+      }
+      memberDir = memberDir.childDirectory(segment);
+    }
+    final memberYaml = _tryLoadYamlMap(memberDir.childFile('pubspec.yaml'));
+    if (memberYaml == null) {
+      continue;
+    }
+    final name = memberYaml['name'];
+    if (name is String && name.isNotEmpty) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
+/// Reads [file] as YAML and returns its top-level map, or `null` when the
+/// file is missing, the contents fail to parse, or the root is not a map.
+///
+/// We treat a malformed `pubspec.yaml` the same as a missing one because pub
+/// itself surfaces the underlying error during `pub get`; the coverage flow
+/// should degrade gracefully rather than crash mid-test.
+Map<dynamic, dynamic>? _tryLoadYamlMap(File file) {
+  if (!file.existsSync()) {
+    return null;
+  }
+  try {
+    final parsed = loadYaml(file.readAsStringSync());
+    return parsed is Map ? parsed : null;
+  } on YamlException {
+    return null;
   }
 }
 

--- a/packages/patrol_cli/test/general/coverage_tool_test.dart
+++ b/packages/patrol_cli/test/general/coverage_tool_test.dart
@@ -88,4 +88,112 @@ void _test(Platform platform) {
       expect(result!.path, memberConfig.path);
     });
   });
+
+  group('findWorkspaceMemberPackages on ${platform.operatingSystem}', () {
+    late FileSystem fs;
+    late Directory workspaceRoot;
+
+    setUp(() {
+      fs = MemoryFileSystem.test(style: platform.fileSystemStyle);
+      workspaceRoot = fs.directory(fs.path.join('projects', 'monorepo'))
+        ..createSync(recursive: true);
+    });
+
+    void writeMember(String posixPath, String name) {
+      var dir = workspaceRoot;
+      for (final segment in posixPath.split('/')) {
+        if (segment.isEmpty) {
+          continue;
+        }
+        dir = dir.childDirectory(segment);
+      }
+      dir.createSync(recursive: true);
+      dir.childFile('pubspec.yaml').writeAsStringSync('name: $name\n');
+    }
+
+    test('reads every name declared under workspace:', () {
+      workspaceRoot.childFile('pubspec.yaml').writeAsStringSync('''
+name: _
+publish_to: none
+workspace:
+  - app/
+  - packages/feature1
+  - packages/shared_ui
+''');
+      writeMember('app', 'my_app');
+      writeMember('packages/feature1', 'feature1');
+      writeMember('packages/shared_ui', 'shared_ui');
+
+      expect(findWorkspaceMemberPackages(workspaceRoot), {
+        'my_app',
+        'feature1',
+        'shared_ui',
+      });
+    });
+
+    test('returns empty when pubspec.yaml is missing', () {
+      expect(findWorkspaceMemberPackages(workspaceRoot), isEmpty);
+    });
+
+    test('returns empty when workspace: key is absent', () {
+      workspaceRoot
+          .childFile('pubspec.yaml')
+          .writeAsStringSync('name: standalone_app\n');
+
+      expect(findWorkspaceMemberPackages(workspaceRoot), isEmpty);
+    });
+
+    test('skips entries whose pubspec.yaml is missing', () {
+      workspaceRoot.childFile('pubspec.yaml').writeAsStringSync('''
+name: _
+workspace:
+  - app/
+  - packages/ghost
+''');
+      writeMember('app', 'my_app');
+
+      expect(findWorkspaceMemberPackages(workspaceRoot), {'my_app'});
+    });
+
+    test('returns empty when root pubspec.yaml is malformed', () {
+      workspaceRoot.childFile('pubspec.yaml').writeAsStringSync('''
+name: _
+workspace:
+  - "unterminated string
+''');
+
+      expect(findWorkspaceMemberPackages(workspaceRoot), isEmpty);
+    });
+
+    test('skips members whose pubspec.yaml is malformed', () {
+      workspaceRoot.childFile('pubspec.yaml').writeAsStringSync('''
+name: _
+workspace:
+  - app/
+  - packages/broken
+''');
+      writeMember('app', 'my_app');
+      workspaceRoot
+          .childDirectory('packages')
+          .childDirectory('broken')
+          .childFile('pubspec.yaml')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('name: : oops\n  bad indent: [');
+
+      expect(findWorkspaceMemberPackages(workspaceRoot), {'my_app'});
+    });
+
+    test('tolerates non-string workspace entries', () {
+      workspaceRoot.childFile('pubspec.yaml').writeAsStringSync('''
+name: _
+workspace:
+  - app/
+  - 42
+  - null
+''');
+      writeMember('app', 'my_app');
+
+      expect(findWorkspaceMemberPackages(workspaceRoot), {'my_app'});
+    });
+  });
 }


### PR DESCRIPTION
## Summary
Adds `--coverage-workspace` to `patrol test`. When set, every package listed under the workspace root's `workspace:` key in `pubspec.yaml` is included in the coverage report, so consumers can run a single coverage pass over an entire Pub workspace monorepo.

- New flag `--coverage-workspace` on `patrol test` (opt-in, defaults off — no behavior change for non-workspace users).
- Composes with `--coverage-package`: discovered workspace member names and existing regex matches are unioned.
- Member names are read from each member's `pubspec.yaml`; entries that don't have a readable pubspec are silently skipped.
- Outside a Pub workspace, the flag logs a warning and otherwise behaves like the default.

Stacked on top of #3063 — base branch is `fix/2844-coverage-pub-workspace`. Without that fix this feature is unusable, since `_getCoveragePackages` would throw before ever resolving the workspace root.

## Test plan
- [x] `dart analyze` in `packages/patrol_cli` is clean.
- [x] `dart test` in `packages/patrol_cli` — 333/333 pass, including 10 new tests in `test/general/coverage_tool_test.dart` covering: full member list discovery, missing pubspec, absent `workspace:` key, members whose pubspec is missing, non-string entries (macOS + Windows path styles).
- [x] Manual smoke against the issue repro (https://github.com/ScottMacDougall/patrol_workspace):
  - `findWorkspaceMemberPackages(/Users/.../patrol_workspace)` returns `{app, feature1}` (the workspace members), and correctly excludes `app2` (standalone, not in `workspace:`).

## Usage

```bash
# Everything declared in the workspace root, nothing else:
patrol test -t patrol_test/example_test.dart --coverage --coverage-workspace

# Workspace members plus extra patterns:
patrol test -t patrol_test/example_test.dart --coverage --coverage-workspace \
  --coverage-package='^acme_'
```
