### PR TITLE
fix: rename vendored HTTPParserC enums to avoid macOS http.h conflicts

### DIFF
--- a/packages/patrol/darwin/Classes/Telegraph/HTTPParserC/http_parser.c
+++ b/packages/patrol/darwin/Classes/Telegraph/HTTPParserC/http_parser.c
@@ -937,7 +937,7 @@ reexecute:
           goto error;
         }
 
-        parser->method = (enum http_method) 0;
+        parser->method = (enum http_parser_method) 0;
         parser->index = 1;
         switch (ch) {
           case 'A': parser->method = PARSER_HTTP_ACL; break;
@@ -2205,13 +2205,13 @@ http_should_keep_alive (const http_parser *parser)
 
 
 const char *
-http_method_str (enum http_method m)
+http_method_str (enum http_parser_method m)
 {
   return ELEM_AT(method_strings, m, "<unknown>");
 }
 
 const char *
-http_status_str (enum http_status s)
+http_status_str (enum http_parser_status s)
 {
   switch (s) {
 #define XX(num, name, string) case PARSER_HTTP_STATUS_##name: return #string;
@@ -2239,13 +2239,13 @@ http_parser_settings_init(http_parser_settings *settings)
 }
 
 const char *
-http_errno_name(enum http_errno err) {
+http_errno_name(enum http_parser_errno err) {
   assert(((size_t) err) < ARRAY_SIZE(http_strerror_tab));
   return http_strerror_tab[err].name;
 }
 
 const char *
-http_errno_description(enum http_errno err) {
+http_errno_description(enum http_parser_errno err) {
   assert(((size_t) err) < ARRAY_SIZE(http_strerror_tab));
   return http_strerror_tab[err].description;
 }

--- a/packages/patrol/darwin/Classes/Telegraph/HTTPParserC/http_parser.h
+++ b/packages/patrol/darwin/Classes/Telegraph/HTTPParserC/http_parser.h
@@ -271,7 +271,7 @@ enum flags {
 enum http_parser_errno { HTTP_ERRNO_MAP(HTTP_ERRNO_GEN) };
 #undef HTTP_ERRNO_GEN
 
-/* Get an http_errno value from an http_parser */
+/* Get an http_parser_errno value from an http_parser */
 #define HTTP_PARSER_ERRNO(p) ((enum http_parser_errno)(p)->http_errno)
 
 struct http_parser {

--- a/packages/patrol/darwin/Classes/Telegraph/HTTPParserC/http_parser.h
+++ b/packages/patrol/darwin/Classes/Telegraph/HTTPParserC/http_parser.h
@@ -150,7 +150,7 @@ typedef int (*http_cb)(http_parser*);
   XX(510, NOT_EXTENDED, Not Extended)                                       \
   XX(511, NETWORK_AUTHENTICATION_REQUIRED, Network Authentication Required)
 
-enum http_status {
+enum http_parser_status {
 #define XX(num, name, string) PARSER_HTTP_STATUS_##name = num,
   HTTP_STATUS_MAP(XX)
 #undef XX
@@ -201,7 +201,7 @@ enum http_status {
   /* icecast */                    \
   XX(33, SOURCE, SOURCE)
 
-enum http_method {
+enum http_parser_method {
 #define XX(num, name, string) PARSER_HTTP_##name = num,
   HTTP_METHOD_MAP(XX)
 #undef XX
@@ -268,11 +268,11 @@ enum flags {
 
 /* Define HPE_* values for each errno value above */
 #define HTTP_ERRNO_GEN(n, s) HPE_##n,
-enum http_errno { HTTP_ERRNO_MAP(HTTP_ERRNO_GEN) };
+enum http_parser_errno { HTTP_ERRNO_MAP(HTTP_ERRNO_GEN) };
 #undef HTTP_ERRNO_GEN
 
 /* Get an http_errno value from an http_parser */
-#define HTTP_PARSER_ERRNO(p) ((enum http_errno)(p)->http_errno)
+#define HTTP_PARSER_ERRNO(p) ((enum http_parser_errno)(p)->http_errno)
 
 struct http_parser {
   /** PRIVATE **/
@@ -385,16 +385,16 @@ size_t http_parser_execute(http_parser* parser, const http_parser_settings* sett
 int http_should_keep_alive(const http_parser* parser);
 
 /* Returns a string version of the HTTP method. */
-const char* http_method_str(enum http_method m);
+const char* http_method_str(enum http_parser_method m);
 
 /* Returns a string version of the HTTP status code. */
-const char* http_status_str(enum http_status s);
+const char* http_status_str(enum http_parser_status s);
 
 /* Return a string name of the given error */
-const char* http_errno_name(enum http_errno err);
+const char* http_errno_name(enum http_parser_errno err);
 
 /* Return a string description of the given error */
-const char* http_errno_description(enum http_errno err);
+const char* http_errno_description(enum http_parser_errno err);
 
 /* Initialize all http_parser_url members to 0 */
 void http_parser_url_init(struct http_parser_url* u);

--- a/packages/patrol/darwin/Classes/Telegraph/Protocols/HTTP/Models/HTTPParser+Raw.swift
+++ b/packages/patrol/darwin/Classes/Telegraph/Protocols/HTTP/Models/HTTPParser+Raw.swift
@@ -12,7 +12,7 @@
 
 typealias HTTPRawParser = http_parser
 typealias HTTPRawParserSettings = http_parser_settings
-typealias HTTPRawParserErrorCode = http_errno
+typealias HTTPRawParserErrorCode = http_parser_errno
 typealias ChunkPointer = UnsafePointer<Int8>
 
 // MARK: HTTPRawParser
@@ -66,7 +66,7 @@ extension HTTPRawParser {
 
   /// Returns the HTTP method.
   var httpMethod: HTTPMethod {
-    let methodCode = http_method(method)
+    let methodCode = http_parser_method(method)
     let methodName = String(cString: http_method_str(methodCode))
     return HTTPMethod(name: methodName)
   }


### PR DESCRIPTION
## Problem

The vendored `http_parser.h` (inside `darwin/Classes/Telegraph/HTTPParserC/`) defines enum types (`http_method`, `http_status`, `http_errno`) that conflict with macOS system header `<http.h>`, causing compilation failures on macOS targets.

A previous fix already prefixed the **enum values** (`HTTP_GET` → `PARSER_HTTP_GET`), but the **enum type names** and **function signatures** were not updated.

## Solution

Rename the enum types to avoid namespace collisions:
- `enum http_method` → `enum http_parser_method`
- `enum http_status` → `enum http_parser_status`
- `enum http_errno` → `enum http_parser_errno`

Also updates the Swift typealias and usage in `HTTPParser+Raw.swift` to reference the renamed types.

This matches the approach from the now-closed [HTTPParserC PR #4](https://github.com/Building42/HTTPParserC/pull/4) (upstream has since moved to `llhttp`).

## Files Changed (3 files, 15 line swaps)
- `http_parser.h` — renamed enum type declarations and function signatures
- `http_parser.c` — renamed enum type references in function implementations
- `HTTPParser+Raw.swift` — updated typealias and constructor call

Fixes #1976