### PR TITLE
Document that appId is ignored on Android in PlatformAutomator

### DIFF
--- a/packages/patrol/lib/src/platform/platform_automator.dart
+++ b/packages/patrol/lib/src/platform/platform_automator.dart
@@ -186,7 +186,9 @@ class PlatformAutomator {
   /// It waits for the view to become visible for [timeout] duration.
   /// If the native view is not found, an exception is thrown.
   ///
-  /// On Android, [appId] is ignored.
+  /// [appId] is only used on iOS, where native queries must be scoped to a
+  /// single application. If not provided, defaults to the bundle id of the
+  /// app under test.
   Future<void> tap(
     CompoundSelector selector, {
     String? appId,
@@ -285,7 +287,9 @@ class MobileAutomator {
   /// Note: The [delayBetweenTaps] parameter is currently respected only
   /// for Android.
   ///
-  /// On Android, [appId] is ignored.
+  /// [appId] is only used on iOS, where native queries must be scoped to a
+  /// single application. If not provided, defaults to the bundle id of the
+  /// app under test.
   Future<void> doubleTap(
     CompoundSelector selector, {
     Duration? timeout,
@@ -307,7 +311,9 @@ class MobileAutomator {
   ///
   /// [location] must be in the inclusive 0-1 range.
   ///
-  /// On Android, [appId] is ignored.
+  /// [appId] is only used on iOS, where native queries must be scoped to a
+  /// single application. If not provided, defaults to the bundle id of the
+  /// app under test.
   Future<void> tapAt(Offset location, {String? appId}) {
     return platform.action.mobile(
       android: () => platform.android.tapAt(location),
@@ -328,7 +334,9 @@ class MobileAutomator {
   /// See also:
   ///  * [enterTextByIndex], which is less flexible but also less verbose
   ///
-  /// On Android, [appId] is ignored.
+  /// [appId] is only used on iOS, where native queries must be scoped to a
+  /// single application. If not provided, defaults to the bundle id of the
+  /// app under test.
   Future<void> enterText(
     CompoundSelector selector, {
     required String text,
@@ -370,7 +378,9 @@ class MobileAutomator {
   ///  * [enterText], which allows for more precise specification of the text
   ///    field to enter text into
   ///
-  /// On Android, [appId] is ignored.
+  /// [appId] is only used on iOS, where native queries must be scoped to a
+  /// single application. If not provided, defaults to the bundle id of the
+  /// app under test.
   Future<void> enterTextByIndex(
     String text, {
     required int index,
@@ -668,7 +678,9 @@ class MobileAutomator {
   /// equivalent to 5 ms. If you want to slow down the swipe time, increase
   /// [steps]. If [swipe] doesn't work, try increasing [steps].
   ///
-  /// On Android, [appId] is ignored.
+  /// [appId] is only used on iOS, where native queries must be scoped to a
+  /// single application. If not provided, defaults to the bundle id of the
+  /// app under test.
   Future<void> swipe({
     required Offset from,
     required Offset to,
@@ -696,8 +708,9 @@ class MobileAutomator {
   ///
   /// [dy] determines the vertical offset of the swipe. It must be in the inclusive 0-1 range.
   ///
-  /// [appId] optionally specifies the application ID to target. On Android,
-  /// [appId] is ignored.
+  /// [appId] is only used on iOS, where native queries must be scoped to a
+  /// single application. If not provided, defaults to the bundle id of the
+  /// app under test.
   ///
   /// This is equivalent to:
   /// $.native.swipe(
@@ -749,7 +762,9 @@ class MobileAutomator {
 
   /// Waits until the native view specified by [selector] becomes visible.
   ///
-  /// On Android, [appId] is ignored.
+  /// [appId] is only used on iOS, where native queries must be scoped to a
+  /// single application. If not provided, defaults to the bundle id of the
+  /// app under test.
   Future<void> waitUntilVisible(
     CompoundSelector selector, {
     String? appId,

--- a/packages/patrol/lib/src/platform/platform_automator.dart
+++ b/packages/patrol/lib/src/platform/platform_automator.dart
@@ -185,6 +185,8 @@ class PlatformAutomator {
   ///
   /// It waits for the view to become visible for [timeout] duration.
   /// If the native view is not found, an exception is thrown.
+  ///
+  /// On Android, [appId] is ignored.
   Future<void> tap(
     CompoundSelector selector, {
     String? appId,
@@ -282,6 +284,8 @@ class MobileAutomator {
   ///
   /// Note: The [delayBetweenTaps] parameter is currently respected only
   /// for Android.
+  ///
+  /// On Android, [appId] is ignored.
   Future<void> doubleTap(
     CompoundSelector selector, {
     Duration? timeout,
@@ -302,6 +306,8 @@ class MobileAutomator {
   /// Taps at a given [location].
   ///
   /// [location] must be in the inclusive 0-1 range.
+  ///
+  /// On Android, [appId] is ignored.
   Future<void> tapAt(Offset location, {String? appId}) {
     return platform.action.mobile(
       android: () => platform.android.tapAt(location),
@@ -321,6 +327,8 @@ class MobileAutomator {
   ///
   /// See also:
   ///  * [enterTextByIndex], which is less flexible but also less verbose
+  ///
+  /// On Android, [appId] is ignored.
   Future<void> enterText(
     CompoundSelector selector, {
     required String text,
@@ -361,6 +369,8 @@ class MobileAutomator {
   /// See also:
   ///  * [enterText], which allows for more precise specification of the text
   ///    field to enter text into
+  ///
+  /// On Android, [appId] is ignored.
   Future<void> enterTextByIndex(
     String text, {
     required int index,
@@ -657,6 +667,8 @@ class MobileAutomator {
   /// On Android, [steps] controls speed and smoothness. One unit of [steps] is
   /// equivalent to 5 ms. If you want to slow down the swipe time, increase
   /// [steps]. If [swipe] doesn't work, try increasing [steps].
+  ///
+  /// On Android, [appId] is ignored.
   Future<void> swipe({
     required Offset from,
     required Offset to,
@@ -684,7 +696,8 @@ class MobileAutomator {
   ///
   /// [dy] determines the vertical offset of the swipe. It must be in the inclusive 0-1 range.
   ///
-  /// [appId] optionally specifies the application ID to target.
+  /// [appId] optionally specifies the application ID to target. On Android,
+  /// [appId] is ignored.
   ///
   /// This is equivalent to:
   /// $.native.swipe(
@@ -735,6 +748,8 @@ class MobileAutomator {
   }
 
   /// Waits until the native view specified by [selector] becomes visible.
+  ///
+  /// On Android, [appId] is ignored.
   Future<void> waitUntilVisible(
     CompoundSelector selector, {
     String? appId,


### PR DESCRIPTION
Methods on PlatformAutomator and MobileAutomator that take an optional appId silently drop it on Android (only the iOS branch passes it through). Note this in the dartdoc of each affected method

Refs #3080.