### PR TITLE
Fix/patrol cli windows hang bundle

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Don't listen for `SIGTERM` on Windows, where it is not supported and throws an unhandled `SignalException`. (#3035)
 - Fix `--exclude` not working. (#2990)
 - Fix `test_bundle.dart` generating a broken absolute import (and an invalid import alias containing characters such as `-`) when the test target lives outside the configured `test_directory`. The import is now computed relative to the bundle and the alias is sanitized. (#3104)
+- Fix `patrol test`/`patrol develop` hanging on Windows at `gradlew :app:dependencies` by also draining the gradle process stderr stream during orchestrator-version detection. (#2565)
 
 ## 4.4.0
 

--- a/packages/patrol_cli/lib/src/android/android_test_backend.dart
+++ b/packages/patrol_cli/lib/src/android/android_test_backend.dart
@@ -230,6 +230,11 @@ class AndroidTestBackend {
             }
           })
           .disposedBy(scope);
+      // `:app:dependencies` writes a lot to stderr (Gradle warnings, daemon
+      // and progress output). The stderr stream must be drained or the child
+      // process blocks once the OS pipe buffer fills, hanging the command
+      // forever on Windows. Same failure mode fixed in buildApkConfigOnly.
+      process.listenStdErr((l) => _logger.detail('\t$l')).disposedBy(scope);
 
       await process.exitCode;
     });

--- a/packages/patrol_cli/lib/src/android/android_test_backend.dart
+++ b/packages/patrol_cli/lib/src/android/android_test_backend.dart
@@ -230,10 +230,7 @@ class AndroidTestBackend {
             }
           })
           .disposedBy(scope);
-      // `:app:dependencies` writes a lot to stderr (Gradle warnings, daemon
-      // and progress output). The stderr stream must be drained or the child
-      // process blocks once the OS pipe buffer fills, hanging the command
-      // forever on Windows. Same failure mode fixed in buildApkConfigOnly.
+      // Drain stderr, or the process hangs on Windows when the pipe fills.
       process.listenStdErr((l) => _logger.detail('\t$l')).disposedBy(scope);
 
       await process.exitCode;

--- a/packages/patrol_cli/test/test_bundler_test.dart
+++ b/packages/patrol_cli/test/test_bundler_test.dart
@@ -114,12 +114,9 @@ import 'example/example_test.dart' as example__example_test;''');
     });
 
     test('generates clean imports from non-native path forms (#1428)', () {
-      // The target is not always passed in the host-native form: `patrol
-      // develop`/MCP hand over forward-slash absolute paths, and PowerShell
-      // tab-completion injects a leading `.\` segment. Both must still resolve
-      // to a valid, relative import rather than leaking a raw absolute path
-      // into the generated bundle. Regression test for:
-      // https://github.com/leancodepl/patrol/issues/1428
+      // Non-native target forms must still resolve to a relative import:
+      // forward-slash absolute paths (`patrol develop`/MCP) and `.\`-prefixed
+      // paths (PowerShell tab-completion).
       final absoluteNative = fs.path.join(
         platform.home,
         'awesome_app',

--- a/packages/patrol_cli/test/test_bundler_test.dart
+++ b/packages/patrol_cli/test/test_bundler_test.dart
@@ -113,6 +113,37 @@ import 'example_test.dart' as example_test;
 import 'example/example_test.dart' as example__example_test;''');
     });
 
+    test('generates clean imports from non-native path forms (#1428)', () {
+      // The target is not always passed in the host-native form: `patrol
+      // develop`/MCP hand over forward-slash absolute paths, and PowerShell
+      // tab-completion injects a leading `.\` segment. Both must still resolve
+      // to a valid, relative import rather than leaking a raw absolute path
+      // into the generated bundle. Regression test for:
+      // https://github.com/leancodepl/patrol/issues/1428
+      final absoluteNative = fs.path.join(
+        platform.home,
+        'awesome_app',
+        'patrol_test',
+        'example_test.dart',
+      );
+
+      // Forward-slash absolute path (e.g. `c:/Users/.../example_test.dart`).
+      final forwardSlashAbsolute = absoluteNative.replaceAll(r'\', '/');
+      expect(
+        testBundler.generateImports(testDirectory, [forwardSlashAbsolute]),
+        "import 'example_test.dart' as example_test;",
+      );
+
+      // `.\`-prefixed relative path.
+      final dotSlashRelative =
+          '.${fs.path.separator}'
+          '${fs.path.join('patrol_test', 'example_test.dart')}';
+      expect(
+        testBundler.generateImports(testDirectory, [dotSlashRelative]),
+        "import 'example_test.dart' as example_test;",
+      );
+    });
+
     test(
       'generates relative import when target is outside the test directory',
       () {


### PR DESCRIPTION
## Problem

`patrol test`/`build`/`develop` hang on Windows at `gradlew :app:dependencies`.
`detectOrchestratorVersion()` only drains the process's stdout, so once Gradle
fills the stderr pipe buffer the child blocks and `exitCode` never completes.
`buildApkConfigOnly()` already drains both streams (#2905); this method was missed.

## Fix

Drain stderr too. No change on macOS/Linux.

#2565 was closed after an unrelated NDK-warning fix that just cut stderr below
the buffer threshold and masked the deadlock — the root cause still reproduces
on `master`.

---

This PR also dropped its original `test_bundler.dart` change for #1428: `master`
now resolves those paths with `path.relative` (#3104), so it's obsolete. Kept a
regression test for the forward-slash / `.\` cases instead.

Fixes #2565.
