### PR TITLE
fix(patrol_cli): generate relative, valid imports in test_bundle.dart for targets outside test_directory

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix `--clear-permissions` being ignored by `patrol build ios`. The flag was wired into `patrol test` but dropped from `build ios`, so prebuilt iOS test bundles (e.g. for BrowserStack/Firebase Test Lab) never had `CLEAR_PERMISSIONS` enabled.
 - Don't listen for `SIGTERM` on Windows, where it is not supported and throws an unhandled `SignalException`. (#3035)
 - Fix `--exclude` not working. (#2990)
+- Fix `test_bundle.dart` generating a broken absolute import (and an invalid import alias containing characters such as `-`) when the test target lives outside the configured `test_directory`. The import is now computed relative to the bundle and the alias is sanitized. (#3104)
 
 ## 4.4.0
 

--- a/packages/patrol_cli/lib/src/test_bundler.dart
+++ b/packages/patrol_cli/lib/src/test_bundler.dart
@@ -226,7 +226,7 @@ ${generateGroupsCode(testDirectory, [testFilePath]).split('\n').map((e) => '  $e
   /// [
   ///   'patrol_test/example_test.dart',
   ///   'patrol_test/permissions/permissions_location_test.dart',
-  ///   '/Users/charlie/awesome_app/patrol_test/app_test.dart',
+  ///   '/Users/charlie/awesome_app/integration_test/app_test.dart',
   /// ]
   /// ```
   /// Output:
@@ -234,7 +234,7 @@ ${generateGroupsCode(testDirectory, [testFilePath]).split('\n').map((e) => '  $e
   /// '''
   /// import 'example_test.dart' as example_test;
   /// import 'permissions/permissions_location_test.dart' as permissions__permissions_location_test;
-  /// import 'patrol_test/app_test.dart' as app_test;
+  /// import '../integration_test/app_test.dart' as integration_test__app_test;
   /// '''
   /// ```
   @visibleForTesting
@@ -245,20 +245,12 @@ ${generateGroupsCode(testDirectory, [testFilePath]).split('\n').map((e) => '  $e
   }) {
     final imports = <String>[];
     for (final testFilePath in testFilePaths) {
-      final relativeTestFilePath = _normalizeTestPath(
+      final importPath = _createImportPath(
         testDirectory,
         testFilePath,
+        web: web,
       );
-      final testName = _createTestName(testDirectory, relativeTestFilePath);
-      final relativeTestFilePathWithoutSlash = relativeTestFilePath[0] == '/'
-          ? relativeTestFilePath.replaceFirst('/', '')
-          : relativeTestFilePath;
-
-      // For web tests, include the test directory prefix in imports to ensure
-      // correct path resolution since the bundle is at project root
-      final importPath = web
-          ? '$testDirectory/$relativeTestFilePathWithoutSlash'
-          : relativeTestFilePathWithoutSlash;
+      final testName = _createTestName(testDirectory, testFilePath);
       imports.add("import '$importPath' as $testName;");
     }
 
@@ -286,11 +278,7 @@ ${generateGroupsCode(testDirectory, [testFilePath]).split('\n').map((e) => '  $e
   String generateGroupsCode(String testDirectory, List<String> testFilePaths) {
     final groups = <String>[];
     for (final testFilePath in testFilePaths) {
-      final relativeTestFilePath = _normalizeTestPath(
-        testDirectory,
-        testFilePath,
-      );
-      final testName = _createTestName(testDirectory, relativeTestFilePath);
+      final testName = _createTestName(testDirectory, testFilePath);
       final groupName = testName.replaceAll('__', '.');
       final testEntrypoint = '$testName.main';
       groups.add("group('$groupName', $testEntrypoint);");
@@ -298,36 +286,70 @@ ${generateGroupsCode(testDirectory, [testFilePath]).split('\n').map((e) => '  $e
     return groups.join('\n');
   }
 
-  /// Normalizes [testFilePath] so that it always starts with
-  /// the configured test directory.
-  String _normalizeTestPath(String testDirectory, String testFilePath) {
-    var relativeTestFilePath = testFilePath.replaceAll(
-      _projectRoot.childDirectory(testDirectory).absolute.path,
-      '',
+  /// Computes the path used in the generated `import` directive for
+  /// [testFilePath], relative to the directory the bundle file lives in.
+  ///
+  /// Using a path relative to the bundle keeps the import valid regardless of
+  /// where the test file is located - in particular when it lives outside the
+  /// configured [testDirectory] (e.g. a target under `integration_test/` while
+  /// `test_directory` is `patrol_test`). In that case the result is a path such
+  /// as `../integration_test/example_test.dart`.
+  String _createImportPath(
+    String testDirectory,
+    String testFilePath, {
+    required bool web,
+  }) {
+    final bundleDirectory = getBundledTestFile(
+      testDirectory,
+      web: web,
+    ).parent.absolute.path;
+
+    final relativeTestFilePath = _fs.path.relative(
+      testFilePath,
+      from: bundleDirectory,
     );
 
-    if (relativeTestFilePath.startsWith(testDirectory)) {
-      relativeTestFilePath = relativeTestFilePath.replaceFirst(
-        testDirectory,
-        '',
-      );
-    }
-
-    if (relativeTestFilePath.startsWith(_fs.path.separator)) {
-      relativeTestFilePath = relativeTestFilePath.substring(1);
-    }
-
-    // Dart source code uses forward slash.
+    // Dart source code uses forward slashes regardless of the host platform.
     return relativeTestFilePath.replaceAll(_fs.path.separator, '/');
   }
 
-  String _createTestName(String testDirectory, String relativeTestFilePath) {
-    var testName = relativeTestFilePath
-        .replaceFirst('$testDirectory${_fs.path.separator}', '')
-        .replaceAll('/', '__');
+  /// Builds a valid Dart identifier used as the import alias (and, after
+  /// replacing `__` with `.`, the group name) for [testFilePath].
+  ///
+  /// The name is derived from the path of the test file relative to the
+  /// configured [testDirectory]. Any character that is not allowed in a Dart
+  /// identifier (e.g. the hyphen in `acme-corp`, or the dots introduced by a
+  /// `..` segment when the test lives outside [testDirectory]) is replaced with
+  /// an underscore so the generated bundle always compiles.
+  String _createTestName(String testDirectory, String testFilePath) {
+    final testDirectoryPath = _projectRoot
+        .childDirectory(testDirectory)
+        .absolute
+        .path;
 
-    testName = testName.substring(0, testName.length - 5);
-    return testName;
+    var name = _fs.path
+        .relative(testFilePath, from: testDirectoryPath)
+        .replaceAll(_fs.path.separator, '/');
+
+    if (name.endsWith('.dart')) {
+      name = name.substring(0, name.length - '.dart'.length);
+    }
+
+    // Drop leading `../` segments (present when the test lives outside the
+    // test directory) so the alias stays readable instead of starting with a
+    // run of underscores.
+    while (name.startsWith('../')) {
+      name = name.substring('../'.length);
+    }
+
+    name = name.replaceAll('/', '__').replaceAll(RegExp('[^a-zA-Z0-9_]'), '_');
+
+    // A Dart identifier must not start with a digit.
+    if (name.isNotEmpty && RegExp('[0-9]').hasMatch(name[0])) {
+      name = '_$name';
+    }
+
+    return name;
   }
 
   bool _shouldUseEntrypointProxy(String testDirectory) {

--- a/packages/patrol_cli/lib/src/test_bundler.dart
+++ b/packages/patrol_cli/lib/src/test_bundler.dart
@@ -305,7 +305,7 @@ ${generateGroupsCode(testDirectory, [testFilePath]).split('\n').map((e) => '  $e
     ).parent.absolute.path;
 
     final relativeTestFilePath = _fs.path.relative(
-      testFilePath,
+      _toAbsoluteTestPath(testFilePath),
       from: bundleDirectory,
     );
 
@@ -328,7 +328,7 @@ ${generateGroupsCode(testDirectory, [testFilePath]).split('\n').map((e) => '  $e
         .path;
 
     var name = _fs.path
-        .relative(testFilePath, from: testDirectoryPath)
+        .relative(_toAbsoluteTestPath(testFilePath), from: testDirectoryPath)
         .replaceAll(_fs.path.separator, '/');
 
     if (name.endsWith('.dart')) {
@@ -351,6 +351,19 @@ ${generateGroupsCode(testDirectory, [testFilePath]).split('\n').map((e) => '  $e
 
     return name;
   }
+
+  /// Resolves [testFilePath] to an absolute path.
+  ///
+  /// A relative path is resolved against the project root - not the process'
+  /// current working directory - so the generated bundle is identical no
+  /// matter where `patrol` is invoked from (running the CLI from outside the
+  /// project root is supported). This mirrors how `TestFinder` resolves
+  /// relative paths. In practice the commands always pass absolute targets, so
+  /// this only matters for relative paths (e.g. in tests).
+  String _toAbsoluteTestPath(String testFilePath) =>
+      _fs.path.isAbsolute(testFilePath)
+      ? testFilePath
+      : _fs.path.join(_projectRoot.absolute.path, testFilePath);
 
   bool _shouldUseEntrypointProxy(String testDirectory) {
     return !_devtoolsRootDirectories.contains(testDirectory);

--- a/packages/patrol_cli/test/test_bundler_test.dart
+++ b/packages/patrol_cli/test/test_bundler_test.dart
@@ -91,6 +91,75 @@ import 'example_test.dart' as example_test;
 import 'example/example_test.dart' as example__example_test;''');
     });
 
+    test(
+      'generates relative import when target is outside the test directory',
+      () {
+        // given
+        // The target lives in `integration_test/` while the configured test
+        // directory is `patrol_test/`. See:
+        // https://github.com/leancodepl/patrol/issues/3101
+        final tests = [
+          fs.path.join(
+            platform.home,
+            'awesome_app',
+            'integration_test',
+            'example_test.dart',
+          ),
+        ];
+
+        // when
+        final imports = testBundler.generateImports(testDirectory, tests);
+
+        // then
+        expect(
+          imports,
+          "import '../integration_test/example_test.dart' "
+          'as integration_test__example_test;',
+        );
+      },
+    );
+
+    test('generates groups when target is outside the test directory', () {
+      // given
+      final tests = [
+        fs.path.join(
+          platform.home,
+          'awesome_app',
+          'integration_test',
+          'example_test.dart',
+        ),
+      ];
+
+      // when
+      final groupsCode = testBundler.generateGroupsCode(testDirectory, tests);
+
+      // then
+      expect(
+        groupsCode,
+        "group('integration_test.example_test', "
+        'integration_test__example_test.main);',
+      );
+    });
+
+    test('sanitizes invalid identifier characters in import aliases', () {
+      // given
+      // Hyphens (and any other non-identifier characters) in the path must not
+      // leak into the generated Dart alias, otherwise the bundle won't compile.
+      // See https://github.com/leancodepl/patrol/issues/3101
+      final tests = [
+        fs.path.join('patrol_test', 'my-feature', 'some-test.dart'),
+      ];
+
+      // when
+      final imports = testBundler.generateImports(testDirectory, tests);
+
+      // then
+      expect(
+        imports,
+        "import 'my-feature/some-test.dart' as my_feature__some_test;",
+      );
+    });
+
     test('generates groups from relative paths', () {
       // given
       final tests = [

--- a/packages/patrol_cli/test/test_bundler_test.dart
+++ b/packages/patrol_cli/test/test_bundler_test.dart
@@ -65,6 +65,28 @@ import 'example_test.dart' as example_test;
 import 'example/example_test.dart' as example__example_test;''');
     });
 
+    test(
+      'resolves relative paths against project root, not the process CWD',
+      () {
+        // given
+        // Relative targets must be resolved against the project root even when
+        // the CLI is invoked from a different working directory (supported
+        // since patrol_cli 3.2.1). Here the CWD is a nested subdirectory.
+        fs.directory(fs.path.join('patrol_test', 'nested')).createSync();
+        fs.currentDirectory = fs.path.join('patrol_test', 'nested');
+
+        final tests = [fs.path.join('patrol_test', 'example_test.dart')];
+
+        // when
+        final imports = testBundler.generateImports(testDirectory, tests);
+        final groupsCode = testBundler.generateGroupsCode(testDirectory, tests);
+
+        // then
+        expect(imports, "import 'example_test.dart' as example_test;");
+        expect(groupsCode, "group('example_test', example_test.main);");
+      },
+    );
+
     test('generates imports from absolute paths', () {
       // given
       final tests = [


### PR DESCRIPTION
## Problem

Closes #3101.

When a test target lives **outside** the configured `test_directory` (e.g. a target under `integration_test/` while `test_directory` is the default `patrol_test`), the generated `integration_test`/`patrol_test/test_bundle.dart` contains a broken import:

```dart
import 'private/tmp/acme-corp/my-monorepo/apps/myapp/integration_test/example_test.dart'
    as private__tmp__acme-corp__my-monorepo__apps__myapp__integration_test__example_test;
```

…which fails to compile:

```
test_bundle.dart:12: Error: Expected ';' after this.
test_bundle.dart:12: Error: Expected a declaration, but got '-'.
Error when reading 'patrol_test/Users/...': No such file or directory
```

Two bugs combine here:

1. **Absolute path leaks into the import.** `_normalizeTestPath` strips the `<projectRoot>/<testDirectory>` prefix by string replacement. When the target isn't under `test_directory`, the prefix never matches, so the file's full absolute path survives; the leading `/` is then chopped off, yielding a bogus relative-looking absolute path.
2. **Invalid alias.** Non-identifier characters in parent directories (e.g. the `-` in `acme-corp`) are copied verbatim into the `as` alias, which is not a valid Dart identifier.

> Note: although the original report is titled around Dart pub workspaces, the workspace is incidental — this reproduces in a plain (non-workspace) project too. The real trigger is the target directory differing from the configured `test_directory`, combined with a non-identifier character somewhere in the path.

## Fix

- **Import path** is now computed with `path.relative(testFilePath, from: <bundle directory>)`, i.e. relative to where `test_bundle.dart` actually lives. This is correct regardless of where the target is (it produces e.g. `../integration_test/example_test.dart`) and it handles the web bundle (located at the project root) naturally, removing the previous `web ?` special-case.
- **Import alias / group name** is now sanitized to a valid Dart identifier: any `[^a-zA-Z0-9_]` becomes `_`, leading `../` segments are dropped for readability, and a leading digit is prefixed with `_`. This also fixes hyphens anywhere in the path (e.g. a test file named `my-feature/some-test.dart`), not just the workspace case.

The generated import now reads:

```dart
import '../integration_test/example_test.dart' as integration_test__example_test;
```

## Testing

- Existing `test_bundler_test.dart` unit tests (macOS + Windows) still pass.
- Added 3 regression tests: relative import for a target outside `test_directory`, the matching group code, and alias sanitization for hyphenated paths.
- Ran the related command/backend suites (`build_android`/`build_ios`/`build_macos`/print-paths/`android_test_backend`) — all green.
- `dart analyze` and `dart format` clean.
- Reproduced end-to-end with `patrol build android` in both a pub-workspace and a plain project whose path contains hyphens: previously failed to compile the bundle, now `✓ Completed building apk`. Verified the normal in-`test_directory` case (top-level and nested) still builds.
