### PR TITLE
fix(patrol_cli): wire `--clear-permissions` into `patrol build ios`

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix `--clear-permissions` being ignored by `patrol build ios`. The flag was wired into `patrol test` but dropped from `build ios`, so prebuilt iOS test bundles (e.g. for BrowserStack/Firebase Test Lab) never had `CLEAR_PERMISSIONS` enabled.
 - Don't listen for `SIGTERM` on Windows, where it is not supported and throws an unhandled `SignalException`. (#3035)
 - Fix `--exclude` not working. (#2990)
 

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -197,6 +197,7 @@ class BuildIOSCommand extends PatrolCommand {
       appServerPort: super.appServerPort,
       testServerPort: super.testServerPort,
       fullIsolation: boolArg('full-isolation'),
+      clearIOSPermissions: boolArg('clear-permissions'),
     );
 
     if (!iosOpts.simulator && iosOpts.fullIsolation) {


### PR DESCRIPTION
## Summary

`--clear-permissions` is **registered** for `patrol build ios` (via `usesIOSOptions()` in `patrol_command.dart`) and is **honored** by `patrol test` (`test.dart` passes `clearIOSPermissions: boolArg('clear-permissions')` into `IOSAppOptions`). But `build_ios.dart` constructs `IOSAppOptions(...)` **without** passing it — so `clearIOSPermissions` defaults to `false` and the `xcodebuild` invocation always emits `OTHER_CFLAGS=... -D CLEAR_PERMISSIONS=0`.

Result: on the **build** path, `--clear-permissions` is accepted (it shows in `patrol build ios --help`) but silently does nothing. This affects every workflow that runs a **prebuilt** iOS test bundle rather than `patrol test` — e.g. **BrowserStack** and **Firebase Test Lab** — where permissions are never reset between tests even with the flag passed.

The fix mirrors the wiring already present in `test.dart`:

```dart
final iosOpts = IOSAppOptions(
  ...
  fullIsolation: boolArg('full-isolation'),
  clearIOSPermissions: boolArg('clear-permissions'),   // <-- restored
);
```

## How it regressed

#2367 originally wired `--clear-permissions` into **both** `build_ios.dart` and `test.dart`. A later refactor (param rename `clearPermissions` → `clearIOSPermissions`) updated `test.dart` but dropped the call site from `build_ios.dart` — note `fullIsolation` survived in `build_ios.dart` while `clearIOSPermissions` did not.

## Validation

Verified against a real device on BrowserStack (iPhone 16 Pro Max, iOS 18.6):

- **Without** this fix: `App permissions cleared` appears **0×** in the instrumentation log — reset never runs.
- **With** this fix (validated via a local `dart pub global activate --source path` build): `App permissions cleared` appears before every test after the first (`if (CLEAR_PERMISSIONS && i > 0)`), and location-permission tests progress past steps that previously failed due to leaked state.

FIX FOR: #3112
