### PR TITLE
ci(e2e): bump Android compileSdk to 36 + AGP 8.9.1 (fix androidx.core 1.17 break)

### DIFF
--- a/dev/e2e_app/android/app/build.gradle.kts
+++ b/dev/e2e_app/android/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdk = 35
+    compileSdk = 36
     ndkVersion = flutter.ndkVersion
 
     namespace = "pl.leancode.patrol.e2e_app"

--- a/dev/e2e_app/android/settings.gradle.kts
+++ b/dev/e2e_app/android/settings.gradle.kts
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.0" apply false
+    id("com.android.application") version "8.9.1" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 


### PR DESCRIPTION
## Problem

All Android E2E workflows started failing (every PR + `master`), unrelated to any change:

```
:app:checkDebugAarMetadata FAILED
> Dependency 'androidx.core:core-ktx:1.17.0' requires ... compile against version 36 or later
  :app is currently compiled against android-35.
> Dependency 'androidx.core:core-ktx:1.17.0' requires Android Gradle plugin 8.9.1 or higher.
  This build currently uses Android Gradle plugin 8.7.0.
```

`androidx.core` **1.17.0** was just published and now requires consumers to compile against **SDK 36** and use **AGP 8.9.1+**. It's pulled transitively, so it silently upgraded and broke every Android build.

## Fix

Bump the e2e app to **compileSdk 36** and **AGP 8.9.1** (Gradle 8.12 already supports it). `targetSdk` stays 35.

This is the forward-correct fix (vs pinning androidx.core to 1.16.0). Validating on CI whether the patrol Android plugin (AGP 8.2.2) needs the same bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)