### PR TITLE
docs: clarify agent-skills update instructions

### DIFF
--- a/docs/documentation/other/agent-skills.mdx
+++ b/docs/documentation/other/agent-skills.mdx
@@ -10,4 +10,4 @@ teach an AI coding agent *how* to write Patrol tests following best practices. T
 a skill teaches it how to use those tools to write tests well.
 
 See the [skills catalog in the Patrol repo](https://github.com/leancodepl/patrol/tree/master/skills)
-for the available skills and per-agent install instructions.
+for the available skills and per-agent install and update instructions.

--- a/skills/README.md
+++ b/skills/README.md
@@ -31,6 +31,12 @@ To update later:
 npx skills update
 ```
 
+> **Claude Code:** `npx skills update` can write to `.agents/skills` instead of `.claude/skills`
+> (where Claude Code reads them), due to
+> [vercel-labs/skills#744](https://github.com/vercel-labs/skills/issues/744). If your skills stop
+> being picked up, regenerate them with
+> `npx skills add leancodepl/patrol -s '*' -a claude-code -y`.
+
 ## Available skills
 
 | Skill | Description | Example prompt |


### PR DESCRIPTION
Add note for updating skills in Claude specifically (due to existing [bug](https://github.com/vercel-labs/skills/issues/744) in skills repo)