### PR TITLE
Fix patrol_mcp orphaned process on client disconnect

### DIFF
--- a/packages/patrol_mcp/CHANGELOG.md
+++ b/packages/patrol_mcp/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 - Fix `screenshot` and `native-tree` MCP tools failing with `error: more than one device/emulator` (Android) or capturing the wrong simulator (iOS) when multiple devices are attached. Both now target the active session's device explicitly.
+- Exit on client disconnect (stdin EOF), not just `SIGTERM`/`SIGINT`, and tear down the active develop session on shutdown so it doesn't orphan.
+- Return structured output (`structuredContent`) from `run`/`status`/`native-tree`, and reply with a clear error instead of crashing when `quit` has no active session.
 - Don't listen for `SIGTERM` on Windows, where it is not supported and throws an unhandled `SignalException` that prevented the MCP server from starting. (#3035)
 - Update README: fix and simplify the GitHub Copilot MCP setup (#3089)
 

--- a/packages/patrol_mcp/bin/patrol_mcp.dart
+++ b/packages/patrol_mcp/bin/patrol_mcp.dart
@@ -58,30 +58,21 @@ class _PatrolRunArgs {
   final Duration timeout;
 }
 
-/// Output schema shared by `run` and `status` -- both return a serialized
-/// [PatrolStatus] (see PatrolStatus.toMap).
+/// Output schema for `run` and `status` -- a serialized [PatrolStatus].
+/// Keys mirror `PatrolStatus.toMap`.
 const _sessionStatusSchema = JsonObject(
   properties: {
-    'isDevelopRunning': JsonBoolean(
-      description: 'Whether a patrol develop session is currently running.',
-    ),
+    'isDevelopRunning': JsonBoolean(),
     'testState': JsonString(
-      description: 'Lifecycle state of the most recent test run.',
       enumValues: ['idle', 'running', 'finishedPassed', 'finishedFailed'],
     ),
-    'currentTestFile': JsonString(
-      description: 'Test file of the active session, if any.',
-    ),
-    'warning': JsonString(
-      description:
-          'Set when a request was blocked, e.g. a different test is already '
-          'running.',
-    ),
-    'deviceName': JsonString(description: 'Name of the target device.'),
-    'deviceId': JsonString(description: 'Id of the target device.'),
-    'devicePlatform': JsonString(description: 'Platform of the target device.'),
-    'output': JsonString(description: 'Recent captured session output.'),
-    'summary': JsonString(description: 'Human-readable summary of the state.'),
+    'currentTestFile': JsonString(),
+    'warning': JsonString(),
+    'deviceName': JsonString(),
+    'deviceId': JsonString(),
+    'devicePlatform': JsonString(),
+    'output': JsonString(),
+    'summary': JsonString(),
   },
   required: ['isDevelopRunning', 'testState', 'output', 'summary'],
 );

--- a/packages/patrol_mcp/bin/patrol_mcp.dart
+++ b/packages/patrol_mcp/bin/patrol_mcp.dart
@@ -58,6 +58,34 @@ class _PatrolRunArgs {
   final Duration timeout;
 }
 
+/// Output schema shared by `run` and `status` -- both return a serialized
+/// [PatrolStatus] (see PatrolStatus.toMap).
+const _sessionStatusSchema = JsonObject(
+  properties: {
+    'isDevelopRunning': JsonBoolean(
+      description: 'Whether a patrol develop session is currently running.',
+    ),
+    'testState': JsonString(
+      description: 'Lifecycle state of the most recent test run.',
+      enumValues: ['idle', 'running', 'finishedPassed', 'finishedFailed'],
+    ),
+    'currentTestFile': JsonString(
+      description: 'Test file of the active session, if any.',
+    ),
+    'warning': JsonString(
+      description:
+          'Set when a request was blocked, e.g. a different test is already '
+          'running.',
+    ),
+    'deviceName': JsonString(description: 'Name of the target device.'),
+    'deviceId': JsonString(description: 'Id of the target device.'),
+    'devicePlatform': JsonString(description: 'Platform of the target device.'),
+    'output': JsonString(description: 'Recent captured session output.'),
+    'summary': JsonString(description: 'Human-readable summary of the state.'),
+  },
+  required: ['isDevelopRunning', 'testState', 'output', 'summary'],
+);
+
 Future<int> main(List<String> args) async {
   final argParser = _buildParser();
   logging.Logger.root.level = logging.Level.INFO;
@@ -131,16 +159,32 @@ Future<int> main(List<String> args) async {
               },
               required: ['testFile'],
             ),
+            outputSchema: _sessionStatusSchema,
             annotations: const ToolAnnotations(title: 'Run Patrol Tests'),
             callback: (args, extra) async {
-              final runArgs = _PatrolRunArgs.fromJson(args);
+              final testFile = args['testFile'];
+              if (testFile is! String || testFile.trim().isEmpty) {
+                return const CallToolResult(
+                  content: [
+                    TextContent(
+                      text:
+                          'The "testFile" argument is required, e.g. '
+                          '{"testFile":"integration_test/app_test.dart"}.',
+                    ),
+                  ],
+                  isError: true,
+                );
+              }
 
+              final runArgs = _PatrolRunArgs.fromJson(args);
               final result = await patrolSession.startAndWait(
                 runArgs.testFile,
                 timeout: runArgs.timeout,
               );
+              final status = result.toMap();
               return CallToolResult(
-                content: [TextContent(text: jsonEncode(result.toMap()))],
+                content: [TextContent(text: jsonEncode(status))],
+                structuredContent: status,
               );
             },
           )
@@ -149,6 +193,18 @@ Future<int> main(List<String> args) async {
             description: 'Quit the active patrol session gracefully',
             annotations: const ToolAnnotations(title: 'Quit Patrol'),
             callback: (args, extra) {
+              if (!patrolSession.getStatus().isDevelopRunning) {
+                return const CallToolResult(
+                  content: [
+                    TextContent(
+                      text:
+                          'No active patrol session to quit. '
+                          'Start one with the run tool first.',
+                    ),
+                  ],
+                  isError: true,
+                );
+              }
               final result = patrolSession.sendCommand(PatrolCommand.quit);
               return CallToolResult(content: [TextContent(text: result)]);
             },
@@ -157,15 +213,17 @@ Future<int> main(List<String> args) async {
             'status',
             description:
                 'Get the current status of the patrol session and recent output',
+            outputSchema: _sessionStatusSchema,
             annotations: const ToolAnnotations(
               title: 'Get Status',
               readOnlyHint: true,
               idempotentHint: true,
             ),
             callback: (args, extra) {
-              final status = patrolSession.getStatus();
+              final status = patrolSession.getStatus().toMap();
               return CallToolResult(
-                content: [TextContent(text: jsonEncode(status.toMap()))],
+                content: [TextContent(text: jsonEncode(status))],
+                structuredContent: status,
               );
             },
           )
@@ -201,7 +259,7 @@ Future<int> main(List<String> args) async {
             },
           );
 
-    return await _runStdio(server);
+    return await _runStdio(server, patrolSession);
   } on FormatException catch (e) {
     stderr
       ..writeln(e.message)
@@ -216,9 +274,19 @@ Future<int> main(List<String> args) async {
   }
 }
 
-Future<int> _runStdio(McpServer server) async {
+Future<int> _runStdio(McpServer server, PatrolSession patrolSession) async {
   final logger = logging.Logger('patrol_mcp');
   final transport = StdioServerTransport();
+
+  // MCP clients disconnect by closing stdin (EOF), not always via SIGTERM, so
+  // wake on EOF too -- otherwise we'd block on _ExitSignal forever and orphan.
+  final closed = Completer<void>();
+  server.server.onclose = () {
+    if (!closed.isCompleted) {
+      closed.complete();
+    }
+  };
+
   try {
     logger.info('Running MCP server on stdio');
     await server.connect(transport);
@@ -228,10 +296,18 @@ Future<int> _runStdio(McpServer server) async {
     return 1;
   }
 
-  final signal = await _ExitSignal().wait;
-  logger.info('Received ${signal.name}, stopping');
-  await server.close();
-  await transport.close();
+  // Shut down on an OS signal or a client disconnect (stdin EOF).
+  final exitSignal = _ExitSignal();
+  await Future.any([exitSignal.wait, closed.future]);
+  // ProcessSignal.watch() keeps the VM alive; the EOF path skips _handleSignal,
+  // so cancel here.
+  exitSignal.cancel();
+  logger.info('Shutting down (signal or client disconnect)');
+
+  // Tear down any active session so its child processes don't outlive us.
+  await patrolSession.dispose();
+
+  await server.close(); // closes the transport too
   logger.info('Stopped');
   return 0;
 }
@@ -253,6 +329,9 @@ class _ExitSignal {
   late final StreamSubscription<ProcessSignal> _sigintSubscription;
 
   Future<ProcessSignal> get wait => _completer.future;
+
+  /// Cancels the signal subscriptions. Idempotent.
+  void cancel() => _cleanup();
 
   void _handleSignal(ProcessSignal signal) {
     if (!_completer.isCompleted) {

--- a/packages/patrol_mcp/lib/src/native_tree_service.dart
+++ b/packages/patrol_mcp/lib/src/native_tree_service.dart
@@ -51,6 +51,7 @@ abstract final class NativeTreeService {
             text: const JsonEncoder.withIndent('  ').convert(trimmed),
           ),
         ],
+        structuredContent: trimmed,
       );
     } on Exception catch (e) {
       return CallToolResult(

--- a/packages/patrol_mcp/lib/src/patrol_session.dart
+++ b/packages/patrol_mcp/lib/src/patrol_session.dart
@@ -343,11 +343,15 @@ final class PatrolSession {
   /// Stops an active develop session and waits for its child processes to be
   /// torn down. Safe to call when idle or repeatedly.
   Future<void> dispose() async {
-    if (!_isRunning) {
-      return;
+    if (_isRunning) {
+      sendCommand(PatrolCommand.quit);
     }
-    sendCommand(PatrolCommand.quit);
-    await _cleanup();
+    // Await any in-flight teardown -- the quit above, or one the session
+    // already started on its own -- so children are reaped before we exit.
+    final cleanup = _cleanupFuture;
+    if (cleanup != null) {
+      await cleanup;
+    }
   }
 
   /// Cleans up the session. Memoized -- callers share one teardown.
@@ -355,6 +359,10 @@ final class PatrolSession {
 
   Future<void> _doCleanup() async {
     final logger = Logger('PatrolSession');
+    // Capture this session's resources before the first await -- a new session
+    // could reassign these fields while we're awaiting below.
+    final scope = _disposeScope;
+    final stdinController = _stdinController;
     _isRunning = false;
     _currentTestFile = null;
     _testServerPort = null;
@@ -362,14 +370,13 @@ final class PatrolSession {
     await _logStreaming.stopLogging();
 
     try {
-      final scope = _disposeScope;
       if (scope != null && !scope.disposed) {
         await scope.dispose();
       }
     } catch (e) {
       logger.fine('Error disposing scope: $e');
     }
-    await _stdinController?.close();
+    await stdinController?.close();
     logger.fine('Develop session ended');
   }
 

--- a/packages/patrol_mcp/lib/src/patrol_session.dart
+++ b/packages/patrol_mcp/lib/src/patrol_session.dart
@@ -279,7 +279,7 @@ final class PatrolSession {
     _developService = developService;
 
     _isRunning = true;
-    _cleanupDone = false;
+    _cleanupFuture = null;
     _currentTestFile = testFile;
     _testState = TestState.running;
     _outputs.clear();
@@ -338,16 +338,22 @@ final class PatrolSession {
     });
   }
 
-  var _cleanupDone = false;
+  Future<void>? _cleanupFuture;
 
-  /// Clean up all resources for the current session.
-  /// Safe to call multiple times -- only the first call does actual work.
-  Future<void> _cleanup() async {
-    if (_cleanupDone) {
+  /// Stops an active develop session and waits for its child processes to be
+  /// torn down. Safe to call when idle or repeatedly.
+  Future<void> dispose() async {
+    if (!_isRunning) {
       return;
     }
-    _cleanupDone = true;
+    sendCommand(PatrolCommand.quit);
+    await _cleanup();
+  }
 
+  /// Cleans up the session. Memoized -- callers share one teardown.
+  Future<void> _cleanup() => _cleanupFuture ??= _doCleanup();
+
+  Future<void> _doCleanup() async {
     final logger = Logger('PatrolSession');
     _isRunning = false;
     _currentTestFile = null;


### PR DESCRIPTION
MCP stdio clients (e.g. Claude Code) disconnect by closing the server's
stdin (EOF), but `patrol_mcp` only waited on `SIGTERM`/`SIGINT`. So on a
normal disconnect the VM blocked forever, got reparented to PID 1, and
piled up orphaned processes — and with a live develop session it leaked
the whole subtree (Flutter tool, frontend_server, DDS, headless Chrome)
plus their ports.

Changes:
- Also wake `_runStdio` on transport close (`onclose`), not just OS
  signals, and cancel the signal subscriptions on the EOF path so a
  lingering `ProcessSignal.watch()` can't keep the VM alive.
- Dispose the active develop session on shutdown so its children are
  reaped before we exit.

Also hardens the server while here: tools now return `structuredContent`
(with `outputSchema` on `run`/`status`), and `quit` with no active
session returns a tool error instead of throwing.

Tests for that will be added in separate PR with MCP workflows
