### PR TITLE
fix(patrol_finders): stop in-progress fling so scrollTo works with no…

### DIFF
--- a/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart
@@ -970,6 +970,30 @@ class PatrolTester {
       await pumpAndSettle(timeout: timeout);
     } else {
       await tester.pump();
+      // A single pump is not enough for the ballistic fling started by the
+      // drag's pointer-up to finish. While a scrollable is mid-fling it wraps
+      // its contents in an IgnorePointer, so the target is never reported as
+      // hit-testable (visible) - the scroll loop then drags forever and times
+      // out. Halt any in-progress fling so the next visibility check is
+      // reliable, without advancing the clock (which noSettle deliberately
+      // avoids, e.g. to not progress unrelated infinite animations).
+      // See https://github.com/leancodepl/patrol/issues/3115.
+      _stopInProgressScrolling();
+    }
+  }
+
+  /// Stops any scrollable that is currently mid-fling by pinning it to its
+  /// current offset. This makes it idle, which releases the [IgnorePointer]
+  /// that a scrolling [Scrollable] keeps over its contents.
+  void _stopInProgressScrolling() {
+    for (final element in find.byType(Scrollable).evaluate()) {
+      final state = (element as StatefulElement).state;
+      if (state is ScrollableState) {
+        final position = state.position;
+        if (position.isScrollingNotifier.value && position.hasPixels) {
+          position.jumpTo(position.pixels);
+        }
+      }
     }
   }
 }

--- a/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart
@@ -987,11 +987,19 @@ class PatrolTester {
   /// that a scrolling [Scrollable] keeps over its contents.
   void _stopInProgressScrolling() {
     for (final element in find.byType(Scrollable).evaluate()) {
-      final state = (element as StatefulElement).state;
+      if (element is! StatefulElement) {
+        continue;
+      }
+      final state = element.state;
       if (state is ScrollableState) {
-        final position = state.position;
-        if (position.isScrollingNotifier.value && position.hasPixels) {
-          position.jumpTo(position.pixels);
+        try {
+          final position = state.position;
+          if (position.isScrollingNotifier.value && position.hasPixels) {
+            position.jumpTo(position.pixels);
+          }
+        } catch (_) {
+          // A scrollable whose position is not yet established can't be
+          // mid-fling, so skipping it is safe.
         }
       }
     }

--- a/packages/patrol_finders/test/patrol_finder_test.dart
+++ b/packages/patrol_finders/test/patrol_finder_test.dart
@@ -955,6 +955,48 @@ void main() {
         expect($('bottom text').visible, true);
       });
 
+      // Regression test for https://github.com/leancodepl/patrol/issues/3115.
+      //
+      // With SettlePolicy.noSettle a single frame is pumped after each drag.
+      // The pointer-up from the drag starts a ballistic fling, and while a
+      // scrollable is mid-fling it wraps its contents in an IgnorePointer, so
+      // the target is never reported as hit-testable (visible) even though it
+      // scrolls into view - the loop drags until maxScrolls and throws.
+      //
+      // The target sits in the middle of a long scrollable (large trailing
+      // space below it) so the scroll never reaches its end - otherwise the
+      // boundary would stop the fling and mask the bug.
+      patrolWidgetTest(
+        'scrolls to widget in CustomScrollView with SettlePolicy.noSettle',
+        ($) async {
+          await $.pumpWidget(
+            const MaterialApp(
+              home: Scaffold(
+                body: CustomScrollView(
+                  slivers: [
+                    SliverList(
+                      delegate: SliverChildListDelegate.fixed([
+                        Text('top text'),
+                        SizedBox(height: 700),
+                        Text('bottom text'),
+                        SizedBox(height: 2000),
+                      ]),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+
+          expect($('top text').visible, true);
+          expect($('bottom text').visible, false);
+
+          await $('bottom text').scrollTo(settlePolicy: SettlePolicy.noSettle);
+
+          expect($('bottom text').visible, true);
+        },
+      );
+
       final app = MaterialApp(
         home: Scaffold(
           body: Column(


### PR DESCRIPTION
…Settle

With SettlePolicy.noSettle the scroll loop pumps a single frame after each drag. The drag's pointer-up starts a ballistic fling that the single pump never finishes, and while a Scrollable is mid-fling it wraps its contents in an IgnorePointer - so the hitTestable() visibility check never matches and scrollTo drags until maxScrolls and throws.

Halt any in-progress fling between drags by pinning the scrollable to its current offset (making it idle, which releases the IgnorePointer), without advancing the clock so noSettle keeps its meaning for unrelated infinite animations.

Closes #3115