### PR TITLE
Quote PROJECT_ROOT in README run-patrol example

### DIFF
--- a/packages/patrol_mcp/README.md
+++ b/packages/patrol_mcp/README.md
@@ -74,7 +74,7 @@ accordingly (for example `./app`).
    set -e
 
    cd "${PROJECT_ROOT:-.}"
-   export PROJECT_ROOT=$PWD
+   export PROJECT_ROOT="$PWD"
 
    if command -v fvm >/dev/null 2>&1; then
      export PATROL_FLUTTER_COMMAND="${PATROL_FLUTTER_COMMAND:-fvm flutter}"


### PR DESCRIPTION
Quote `$PWD` in the `run-patrol` launcher template documented in `packages/patrol_mcp/README.md`, so the documented script is conventionally quoted / shellcheck-clean.

Note: this is a style/consistency fix, not a bug fix — an assignment's RHS isn't word-split, so the unquoted form already handles paths with spaces correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
