### PR TITLE
Workflows/clean up not needed test

### DIFF
--- a/dev/e2e_app/patrol_test/selector_test.dart
+++ b/dev/e2e_app/patrol_test/selector_test.dart
@@ -1,40 +1,18 @@
 import 'common.dart';
 
 void main() {
-  patrol(
-    'PlatformSelector allows different selectors per platform',
-    ($) async {
-      await createApp($);
+  patrol('PlatformSelector allows different selectors per platform', ($) async {
+    await createApp($);
 
-      await $('Open webview (Hacker News)').scrollTo().tap();
-      await $.pump(Duration(seconds: 5));
+    await $('Open webview (Hacker News)').scrollTo().tap();
+    await $.pump(Duration(seconds: 5));
 
-      await $.platform.tap(
-        PlatformSelector(
-          android: AndroidSelector(text: 'login'),
-          ios: IOSSelector(label: 'login'),
-          web: WebSelector(text: 'login'),
-        ),
-      );
-    },
-    tags: ['android', 'emulator', 'ios', 'simulator'],
-  );
-
-  patrol(
-    'MobileSelector allows different selectors for mobile platforms',
-    ($) async {
-      await createApp($);
-
-      await $('Open webview (Hacker News)').scrollTo().tap();
-      await $.pump(Duration(seconds: 5));
-
-      await $.platform.mobile.tap(
-        MobileSelector(
-          android: AndroidSelector(text: 'login'),
-          ios: IOSSelector(label: 'login'),
-        ),
-      );
-    },
-    tags: ['android', 'emulator', 'ios', 'simulator'],
-  );
+    await $.platform.tap(
+      PlatformSelector(
+        android: AndroidSelector(text: 'login'),
+        ios: IOSSelector(label: 'login'),
+        web: WebSelector(text: 'login'),
+      ),
+    );
+  });
 }

--- a/dev/e2e_app/patrol_test/selector_test.dart
+++ b/dev/e2e_app/patrol_test/selector_test.dart
@@ -1,15 +1,15 @@
 import 'common.dart';
 
 void main() {
+  // TODO: Add this test to Ci/CD to test PlatformSelector on web
+  // https://leancode.atlassian.net/browse/PAT-304
   patrol('PlatformSelector allows different selectors per platform', ($) async {
     await createApp($);
 
     await $('Open webview (Patrol docs)').scrollTo().tap();
     await $.pump(const Duration(seconds: 5));
 
-    // Dismiss the cookie consent popup if it appears. The exact button label
-    // can vary, so try the common variants and ignore if none are present.
-
+    // Dismiss the cookie consent popup if it appears
     try {
       await $.platform.tap(
         Selector(text: 'ACCEPT ALL COOKIES'),

--- a/dev/e2e_app/patrol_test/selector_test.dart
+++ b/dev/e2e_app/patrol_test/selector_test.dart
@@ -11,7 +11,7 @@ void main() {
     // can vary, so try the common variants and ignore if none are present.
 
     try {
-      await $.platform.mobile.tap(
+      await $.platform.tap(
         Selector(text: 'ACCEPT ALL COOKIES'),
         timeout: const Duration(seconds: 10),
       );

--- a/dev/e2e_app/patrol_test/selector_test.dart
+++ b/dev/e2e_app/patrol_test/selector_test.dart
@@ -4,14 +4,27 @@ void main() {
   patrol('PlatformSelector allows different selectors per platform', ($) async {
     await createApp($);
 
-    await $('Open webview (Hacker News)').scrollTo().tap();
-    await $.pump(Duration(seconds: 5));
+    await $('Open webview (Patrol docs)').scrollTo().tap();
+    await $.pump(const Duration(seconds: 5));
 
-    await $.platform.tap(
+    // Dismiss the cookie consent popup if it appears. The exact button label
+    // can vary, so try the common variants and ignore if none are present.
+
+    try {
+      await $.platform.mobile.tap(
+        Selector(text: 'ACCEPT ALL COOKIES'),
+        timeout: const Duration(seconds: 10),
+      );
+    } on PatrolActionException catch (_) {
+      // nothing
+    }
+    await Future<void>.delayed(const Duration(seconds: 5));
+    // Open the search modal and type a query into its input field.
+    await $.platform.mobile.tap(
       PlatformSelector(
-        android: AndroidSelector(text: 'login'),
-        ios: IOSSelector(label: 'login'),
-        web: WebSelector(text: 'login'),
+        android: AndroidSelector(text: 'Open Search'),
+        ios: IOSSelector(label: 'Open Search'),
+        web: WebSelector(text: 'Search'),
       ),
     );
   });

--- a/dev/e2e_app/patrol_test/selector_test.dart
+++ b/dev/e2e_app/patrol_test/selector_test.dart
@@ -19,7 +19,6 @@ void main() {
       // nothing
     }
     await Future<void>.delayed(const Duration(seconds: 5));
-    // Open the search modal and type a query into its input field.
     await $.platform.mobile.tap(
       PlatformSelector(
         android: AndroidSelector(text: 'Open Search'),

--- a/dev/e2e_app/patrol_test/webview_patrol_docs_test.dart
+++ b/dev/e2e_app/patrol_test/webview_patrol_docs_test.dart
@@ -9,9 +9,7 @@ void main() {
       await $('Open webview (Patrol docs)').scrollTo().tap();
       await $.pump(const Duration(seconds: 5));
 
-      // Dismiss the cookie consent popup if it appears. The exact button label
-      // can vary, so try the common variants and ignore if none are present.
-
+      // Dismiss the cookie consent popup if it appears
       try {
         await $.platform.mobile.tap(
           Selector(text: 'ACCEPT ALL COOKIES'),


### PR DESCRIPTION
These tests are not supposed to be run on Ci/CD I accidentialy add tags last time to them. But currently we dont have any test to be run with PlatformSelector so this can be considered as something to be add. The second test is removed, because test that open patrol docs, and interacte with it in webview, already cover this. 