### PR TITLE
fix(patrol): stop web tests hanging between bundled tests

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Migrate to built-in Kotlin (#3084).
 - Fix iOS tests failing on devices whose name contains a comma 
 - Migrate Japanese text resources to SPM (#3128)
+- Fix web tests hanging between bundled tests by using time-based polling instead of `requestAnimationFrame` polling in the Playwright runner, which is paused while the page is not visible in headed runs. (#3133)
 
 ## 4.6.1
 

--- a/packages/patrol/web_runner/tests/initialise.ts
+++ b/packages/patrol/web_runner/tests/initialise.ts
@@ -13,6 +13,10 @@ export async function initialise(page: Page) {
 
       return true
     },
-    { timeout: 60000 },
+    // Time-based polling instead of the default `requestAnimationFrame`
+    // polling, which is paused while the page/tab is not visible and can hang
+    // this wait in headed runs. See
+    // https://github.com/leancodepl/patrol/issues/3132.
+    { timeout: 60000, polling: 100 },
   )
 }

--- a/packages/patrol/web_runner/tests/setup.ts
+++ b/packages/patrol/web_runner/tests/setup.ts
@@ -41,7 +41,11 @@ async function setup(config: FullConfig) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             return window.__patrol__getTests?.()!
           },
-          { timeout: 120000 },
+          // Time-based polling instead of the default `requestAnimationFrame`
+          // polling, which is paused while the page/tab is not visible and can
+          // hang this wait in headed runs. See
+          // https://github.com/leancodepl/patrol/issues/3132.
+          { timeout: 120000, polling: 100 },
         )
         .then(v => v.jsonValue()),
       setupPageErrorPromise,

--- a/packages/patrol/web_runner/tests/test.spec.ts
+++ b/packages/patrol/web_runner/tests/test.spec.ts
@@ -39,6 +39,13 @@ for (const { name, skip, tags } of tests) {
 
     await page.waitForFunction(() => window.__patrol__runTest, {
       timeout: 300000,
+      // Use time-based polling instead of the default `requestAnimationFrame`
+      // polling. `rAF` is paused by the browser while the page/tab is not
+      // visible (e.g. an occluded or unfocused window in a headed run), which
+      // can make this wait hang between tests even though the Dart side has
+      // already exposed `__patrol__runTest`. See
+      // https://github.com/leancodepl/patrol/issues/3132.
+      polling: 100,
     })
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
## Problem

Closes #3132.

Running a multi-scenario Patrol **web** suite hangs between tests: after one scenario passes, the runner stalls before the next one starts and eventually times out. It reproduces in **headed** runs (the reporter's `patrol test --device chrome` on macOS) while headless CI is unaffected.

## Root cause

The Playwright runner (shipped inside the `patrol` package under `web_runner/`) waits for the freshly-loaded Flutter app to expose its JS hooks using `page.waitForFunction(...)`. `waitForFunction` **defaults to `requestAnimationFrame` polling**, and the browser pauses `rAF` while the page/tab is not visible (an occluded or unfocused window — common in a headed run).

Each web test runs in a fresh browser context/page, so between bundled tests the tab briefly loses foreground during teardown + re-creation. That latches the `rAF`-based poll into a paused state, so the wait for `window.__patrol__runTest` (and the setup/initialise hooks) never re-evaluates — even though the Dart side has already exposed them (test discovery and `runAppService` complete via timers/microtasks, not frames). The result is a hang between tests. Headless CI never hides the page, so `rAF` keeps firing and the suite passes — which also explains why CI (which additionally passes `--web-headless true`) is green.

## Fix

Switch the three `waitForFunction` calls in the runner (`setup.ts`, `initialise.ts`, `test.spec.ts`) to **time-based polling** (`polling: 100`). Timer-based polling keeps re-evaluating regardless of tab visibility (Playwright already launches Chromium with `--disable-background-timer-throttling`), so the waits no longer stall when the window is occluded/unfocused. Timeouts and predicates are unchanged.

## Verification

- `tsc --noEmit`, `eslint`, and `prettier --check` all pass on `web_runner`.
- End-to-end: ran two web tests from `dev/e2e_app` (`web_example_navigation_test` → `web_example_dark_mode_test`) with the local CLI. Both pass and the **inter-test transition** — the exact point that hangs in the report — is clean:

  ```
  ✅ navigation (/web/web_example_navigation_test.dart) (9s)
  🧪 web.web_example_dark_mode_test dark mode
  ✅ dark mode (/web/web_example_dark_mode_test.dart) (5s)
  Total: 2  Successful: 2  Failed: 0
  ```

The original hang is timing/environment-specific (flaky, headed-macOS), so it can't be reproduced deterministically; this change targets the mechanism that makes the wait stall and is a strictly more robust poll. Running headless (`--web-headless true`, as CI does) remains a reliable workaround.