### PR TITLE
ci(potential-duplicates): pin action to SHA, lower threshold to 0.5

### DIFF
--- a/.github/workflows/potential-duplicates.yaml
+++ b/.github/workflows/potential-duplicates.yaml
@@ -7,7 +7,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: wow-actions/potential-duplicates@v1
+      - uses: wow-actions/potential-duplicates@4d4ea0352e0383859279938e255179dd1dbb67b5 # v1.1.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           filter: ''
@@ -15,7 +15,7 @@ jobs:
           exclude: ''
           label: potential-duplicate
           state: open
-          threshold: 0.6
+          threshold: 0.5
           reactions: 'eyes, confused'
           # Comment to post when potential duplicates are detected.
           comment: >


### PR DESCRIPTION
## What

- Pin `wow-actions/potential-duplicates` to the v1.1.0 commit SHA (`4d4ea0352e0383859279938e255179dd1dbb67b5`) instead of the mutable `v1` tag.
- Lower the duplicate-detection `threshold` from `0.6` to `0.5`.

## Why

- **Pinning to SHA** follows supply-chain best practice for third-party actions. `v1` already resolved to v1.1.0 (the latest release), so this is not a functional change — just a safer reference.
- **Lower threshold** so more potential duplicates are surfaced. The action only labels/comments/reacts when it finds an existing open issue with a title similarity ≥ threshold; at `0.6` recent issues weren't matching anything.

## Notes

- The Node.js 20 → 24 deprecation warning in the action's runs is harmless; the action is already at its latest release (v1.1.0, Oct 2022) so there is no newer version to upgrade to.