### PR TITLE
Add CI workflows for patrol_mcp

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -44,6 +44,8 @@ This document describes all GitHub Actions workflows used in the Patrol project.
 | [adb prepare][adb-prepare] | PR (on adb package changes), manual | Dart 3.8 | Runs CI checks for `adb` package: tests, analyzer, formatter, and pub publish dry-run. |
 | [prepare e2e_app][prepare-e2e_app] | PR (on all changes except docs), manual | Flutter 3.38.x (stable) | Runs CI checks for E2E test app: Android builds (Windows/Linux) with ktlint, iOS builds with swift-format/clang-format and unit tests, Flutter tests, analyzer, and formatter. |
 | [patrol_gen prepare][patrol_gen-prepare] | PR (on patrol_gen changes), manual | Dart 3.8 | Runs CI checks for patrol contracts generator: analyzer and formatter. |
+| [patrol_mcp prepare][patrol_mcp-prepare] | PR (on patrol_mcp changes), manual | Dart (stable) | Smoke-tests the MCP server on Ubuntu and Windows against the newest and floor `patrol_cli` (from pub.dev): verifies it starts, handshakes, and shuts down on stdin EOF. The floor run guards against a stale `patrol_cli` constraint. |
+| [patrol_mcp cli-compat][patrol_mcp-cli-compat] | PR (on patrol_cli `lib/` or pubspec changes), manual | Flutter 3.38.x (stable) | Non-blocking: builds `patrol_mcp` against the PR's local `patrol_cli` and warns (annotation + job summary, never fails CI) if the barrel API it consumes broke. |
 
 ## Publishing Workflows
 
@@ -166,6 +168,8 @@ A test is selected if it matches ALL conditions in the boolean expression (AND o
 [adb-prepare]: workflows/adb-prepare.yaml
 [prepare-e2e_app]: workflows/prepare-e2e_app.yaml
 [patrol_gen-prepare]: workflows/patrol_gen-prepare.yaml
+[patrol_mcp-prepare]: workflows/patrol_mcp-prepare.yaml
+[patrol_mcp-cli-compat]: workflows/patrol_mcp-cli-compat.yaml
 [patrol-publish]: workflows/patrol-publish.yaml
 [patrol_cli-publish]: workflows/patrol_cli-publish.yaml
 [patrol_finders-publish]: workflows/patrol_finders-publish.yaml

--- a/.github/workflows/patrol_mcp-cli-compat.yaml
+++ b/.github/workflows/patrol_mcp-cli-compat.yaml
@@ -1,14 +1,8 @@
 name: patrol_mcp cli-compat
 
-# Non-blocking heads-up for patrol_cli authors.
-#
-# patrol_cli exposes a public API barrel (lib/patrol_cli.dart) specifically for
-# patrol_mcp. A breaking change to it does NOT break released patrol_mcp users
-# (patrol_mcp is pinned to a *published* patrol_cli), so this must never fail CI.
-# But the author may not realize they broke patrol_mcp against the current source
-# — this job builds patrol_mcp against THIS PR's patrol_cli (local, via melos)
-# and, if it breaks, surfaces a warning annotation + job summary. It always
-# exits green.
+# Non-blocking heads-up: does this patrol_cli change break patrol_mcp when built
+# against local source? Released users are safe (patrol_mcp pins a published
+# patrol_cli), so on a break we only warn — never fail CI.
 
 on:
   workflow_dispatch:
@@ -36,8 +30,7 @@ jobs:
           flutter-version: ${{ matrix.flutter-version }}
           channel: ${{ matrix.flutter-channel }}
 
-      # melos path-links the local packages so patrol_mcp builds against this
-      # PR's patrol_cli source rather than the published version.
+      # melos path-links local packages so patrol_mcp builds against this PR's cli.
       - name: Set up Melos and bootstrap workspace
         continue-on-error: true
         run: |

--- a/.github/workflows/patrol_mcp-cli-compat.yaml
+++ b/.github/workflows/patrol_mcp-cli-compat.yaml
@@ -1,0 +1,65 @@
+name: patrol_mcp cli-compat
+
+# Non-blocking heads-up for patrol_cli authors.
+#
+# patrol_cli exposes a public API barrel (lib/patrol_cli.dart) specifically for
+# patrol_mcp. A breaking change to it does NOT break released patrol_mcp users
+# (patrol_mcp is pinned to a *published* patrol_cli), so this must never fail CI.
+# But the author may not realize they broke patrol_mcp against the current source
+# — this job builds patrol_mcp against THIS PR's patrol_cli (local, via melos)
+# and, if it breaks, surfaces a warning annotation + job summary. It always
+# exits green.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'packages/patrol_cli/**'
+
+jobs:
+  mcp_compat:
+    name: patrol_mcp builds against local patrol_cli
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        flutter-version: ['3.38.x']
+        flutter-channel: ['stable']
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ matrix.flutter-version }}
+          channel: ${{ matrix.flutter-channel }}
+
+      # melos path-links the local packages so patrol_mcp builds against this
+      # PR's patrol_cli source rather than the published version.
+      - name: Set up Melos and bootstrap workspace
+        continue-on-error: true
+        run: |
+          dart pub global activate melos
+          melos bootstrap
+
+      - name: Build and start patrol_mcp against local patrol_cli
+        id: smoke
+        continue-on-error: true
+        working-directory: packages/patrol_mcp
+        run: dart run tool/smoke_test.dart
+
+      - name: Report incompatibility (non-blocking)
+        if: steps.smoke.outcome != 'success'
+        run: |
+          echo "::warning title=patrol_mcp may need updating::This patrol_cli change breaks patrol_mcp when built against your local changes. Released users are unaffected (patrol_mcp is pinned to a published patrol_cli), but you likely need to update patrol_mcp and bump its patrol_cli constraint alongside this change."
+          {
+            echo "### ⚠️ patrol_mcp compatibility"
+            echo ""
+            echo "\`patrol_mcp\` failed to build/start against **this PR's** \`patrol_cli\`."
+            echo ""
+            echo "This does **not** break released users — \`patrol_mcp\` depends on a *published* \`patrol_cli\`, not this branch. But you have likely changed the public API barrel (\`packages/patrol_cli/lib/patrol_cli.dart\`) that \`patrol_mcp\` consumes."
+            echo ""
+            echo "Consider updating \`patrol_mcp\` (and bumping its \`patrol_cli\` constraint) in the same release cycle."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/patrol_mcp-cli-compat.yaml
+++ b/.github/workflows/patrol_mcp-cli-compat.yaml
@@ -1,14 +1,11 @@
 name: patrol_mcp cli-compat
 
-# Non-blocking heads-up: does this patrol_cli change break patrol_mcp when built
-# against local source? Released users are safe (patrol_mcp pins a published
-# patrol_cli), so on a break we only warn — never fail CI.
-
 on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'packages/patrol_cli/**'
+      - 'packages/patrol_cli/lib/**'
+      - 'packages/patrol_cli/pubspec.yaml'
 
 jobs:
   mcp_compat:

--- a/.github/workflows/patrol_mcp-prepare.yaml
+++ b/.github/workflows/patrol_mcp-prepare.yaml
@@ -14,15 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Windows matters because the server's only OS-specific code is the
-        # SIGTERM path that broke startup there (#3035); ubuntu covers POSIX.
+        # Windows: the SIGTERM startup path that broke there (#3035); ubuntu = POSIX.
         os: [ubuntu-latest, windows-latest]
-        # Resolve from pub.dev at both ends of patrol_mcp's patrol_cli range:
-        #  - latest: newest patrol_cli allowed (what a fresh `pub get` gives).
-        #  - floor:  lowest allowed (^4.3.0 -> 4.3.0). If patrol_mcp starts using
-        #    a newer patrol_cli API without bumping its constraint, the floor
-        #    build fails HERE instead of shipping broken to users who resolve
-        #    patrol_cli to an older version the loose constraint still permits.
+        # floor = lowest patrol_cli the constraint allows; fails here if patrol_mcp
+        # outgrew its constraint, rather than shipping broken to users.
         resolution: [latest, floor]
 
     defaults:
@@ -33,20 +28,15 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      # patrol_mcp is a pure-Dart package with only pub.dev dependencies, so the
-      # Dart SDK alone resolves it — no Flutter toolchain or melos needed here.
-      # Testing against pub.dev (not local melos paths) is deliberate: local
-      # resolution would mask a stale patrol_cli constraint.
+      # pub.dev, not melos: local resolution would mask a stale patrol_cli constraint.
       - name: Set up Dart
         uses: dart-lang/setup-dart@v1
 
       - name: Resolve dependencies (from pub.dev)
         run: dart pub get
 
-      # Pin ONLY patrol_cli to the floor of its constraint, leaving other deps at
-      # their latest resolved versions. A full `dart pub downgrade` would drag in
-      # unfixable ancient transitive floors (e.g. win32) that patrol_mcp can't
-      # control and that have nothing to do with the patrol_cli constraint.
+      # Only patrol_cli, not a full downgrade (that drags in unfixable old
+      # transitive floors like win32).
       - name: Downgrade patrol_cli to its constraint floor
         if: matrix.resolution == 'floor'
         run: dart pub downgrade patrol_cli

--- a/.github/workflows/patrol_mcp-prepare.yaml
+++ b/.github/workflows/patrol_mcp-prepare.yaml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Windows: the SIGTERM startup path that broke there (#3035); ubuntu = POSIX.
         os: [ubuntu-latest, windows-latest]
         # floor = lowest patrol_cli the constraint allows; fails here if patrol_mcp
         # outgrew its constraint, rather than shipping broken to users.

--- a/.github/workflows/patrol_mcp-prepare.yaml
+++ b/.github/workflows/patrol_mcp-prepare.yaml
@@ -1,0 +1,55 @@
+name: patrol_mcp prepare
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'packages/patrol_mcp/**'
+
+jobs:
+  smoke_test:
+    name: Smoke (${{ matrix.resolution }} patrol_cli) on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Windows matters because the server's only OS-specific code is the
+        # SIGTERM path that broke startup there (#3035); ubuntu covers POSIX.
+        os: [ubuntu-latest, windows-latest]
+        # Resolve from pub.dev at both ends of patrol_mcp's patrol_cli range:
+        #  - latest: newest patrol_cli allowed (what a fresh `pub get` gives).
+        #  - floor:  lowest allowed (^4.3.0 -> 4.3.0). If patrol_mcp starts using
+        #    a newer patrol_cli API without bumping its constraint, the floor
+        #    build fails HERE instead of shipping broken to users who resolve
+        #    patrol_cli to an older version the loose constraint still permits.
+        resolution: [latest, floor]
+
+    defaults:
+      run:
+        working-directory: packages/patrol_mcp
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      # patrol_mcp is a pure-Dart package with only pub.dev dependencies, so the
+      # Dart SDK alone resolves it — no Flutter toolchain or melos needed here.
+      # Testing against pub.dev (not local melos paths) is deliberate: local
+      # resolution would mask a stale patrol_cli constraint.
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
+
+      - name: Resolve dependencies (from pub.dev)
+        run: dart pub get
+
+      # Pin ONLY patrol_cli to the floor of its constraint, leaving other deps at
+      # their latest resolved versions. A full `dart pub downgrade` would drag in
+      # unfixable ancient transitive floors (e.g. win32) that patrol_mcp can't
+      # control and that have nothing to do with the patrol_cli constraint.
+      - name: Downgrade patrol_cli to its constraint floor
+        if: matrix.resolution == 'floor'
+        run: dart pub downgrade patrol_cli
+
+      - name: Smoke test — server starts, handshakes, and shuts down on EOF
+        run: dart run tool/smoke_test.dart

--- a/docs/documentation/other/patrol-mcp.mdx
+++ b/docs/documentation/other/patrol-mcp.mdx
@@ -27,11 +27,15 @@ built and tested against.
 
 | patrol_mcp | patrol_cli | patrol_log |
 |------------|------------|------------|
-| 0.1.4      | 4.3.0+     | >=0.8.0    |
+| 0.1.4      | 4.4.x      | ^0.9.0     |
+| 0.1.4      | 4.3.x      | ^0.8.0     |
 | 0.1.3      | 4.3.1      | ^0.8.0     |
 | 0.1.2      | 4.3.0      | ^0.8.0     |
 | 0.1.1      | 4.3.0      | ^0.8.0     |
 | 0.1.0      | 4.3.0      | ^0.8.0     |
+
+The `patrol_log` version is determined by which `patrol_cli` minor you end
+up with — it is transitive, not a constraint you set directly.
 
 
 

--- a/packages/patrol_mcp/tool/smoke_test.dart
+++ b/packages/patrol_mcp/tool/smoke_test.dart
@@ -1,30 +1,10 @@
-// Startup smoke test for the patrol_mcp server.
+// Smoke test: spawn the MCP server, complete the `initialize` handshake over
+// stdio, then close stdin and assert it exits cleanly. Guards startup (#3035)
+// and shutdown-on-EOF (#3122). Dart, not shell, so it runs identically on every
+// OS. Run from the package root: dart run tool/smoke_test.dart
 //
-// Dependency-resolution checks (`dart pub get`) prove the package *resolves*,
-// but not that the server *runs*. Recent releases fixed runtime bugs that a
-// `pub get` sails straight past. This guards the two that bookend a session's
-// lifecycle:
-//   - Startup: the Windows SIGTERM crash that stopped the server from starting
-//     at all (#3035).
-//   - Shutdown: MCP clients disconnect by closing stdin (EOF), not via a
-//     signal; the server used to block forever on EOF and orphan its process
-//     subtree (#3122). It must now exit cleanly on EOF.
-//
-// So this test spawns the real server, completes the MCP `initialize` handshake
-// over stdio, then closes stdin and asserts the server exits with code 0. It
-// needs no device or Patrol session — the handshake happens before any tool is
-// invoked — so it is safe to run on a bare CI runner on every OS.
-//
-// Dependency resolution is the caller's choice — this script only spawns and
-// drives the server, so it is agnostic to how deps were resolved:
-//   - patrol_mcp-prepare runs it against pub.dev (newest, and constraint-floor).
-//   - patrol_mcp-cli-compat runs it under melos against the local patrol_cli.
-//
-// It is written in Dart (not shell) on purpose: it must behave identically on
-// ubuntu, macOS, and Windows, and pure-Dart process handling avoids the
-// portability traps of `timeout`, background jobs, and PowerShell-vs-bash.
-//
-// Run from the package root:  dart run tool/smoke_test.dart
+// Resolution is the caller's choice (pub.dev in prepare, melos in cli-compat);
+// this script only drives the server.
 
 import 'dart:async';
 import 'dart:convert';
@@ -78,11 +58,8 @@ Future<void> main() async {
   process.stdin.writeln(jsonEncode(initializeRequest));
   await process.stdin.flush();
 
-  // Race the handshake against the process dying, so a server that crashes on
-  // startup fails fast with a clear message instead of hanging until timeout.
-  // The exit branch resolves to a sentinel (rather than calling _fail directly)
-  // so it stays side-effect-free if the handshake wins — otherwise it would
-  // still fire later, during the normal EOF shutdown below.
+  // Race the handshake against early exit so a startup crash fails fast. The
+  // exit branch yields a sentinel (not _fail) so it's a no-op if handshake wins.
   const exitedSentinel = ' process-exited';
   final line =
       await Future.any([
@@ -127,9 +104,8 @@ Future<void> main() async {
     'v${serverInfo?['version']} responded to initialize',
   );
 
-  // Closing stdin sends EOF — the disconnect signal an MCP client uses. The
-  // server must exit cleanly instead of blocking and orphaning its process
-  // subtree (#3122). This is the shutdown regression guard.
+  // Closing stdin sends EOF — how MCP clients disconnect. Server must exit
+  // cleanly, not hang and orphan its process subtree (#3122).
   await process.stdin.close();
 
   final exitCode = await process.exitCode.timeout(

--- a/packages/patrol_mcp/tool/smoke_test.dart
+++ b/packages/patrol_mcp/tool/smoke_test.dart
@@ -1,0 +1,178 @@
+// Startup smoke test for the patrol_mcp server.
+//
+// Dependency-resolution checks (`dart pub get`) prove the package *resolves*,
+// but not that the server *runs*. Recent releases fixed runtime bugs that a
+// `pub get` sails straight past. This guards the two that bookend a session's
+// lifecycle:
+//   - Startup: the Windows SIGTERM crash that stopped the server from starting
+//     at all (#3035).
+//   - Shutdown: MCP clients disconnect by closing stdin (EOF), not via a
+//     signal; the server used to block forever on EOF and orphan its process
+//     subtree (#3122). It must now exit cleanly on EOF.
+//
+// So this test spawns the real server, completes the MCP `initialize` handshake
+// over stdio, then closes stdin and asserts the server exits with code 0. It
+// needs no device or Patrol session — the handshake happens before any tool is
+// invoked — so it is safe to run on a bare CI runner on every OS.
+//
+// Dependency resolution is the caller's choice — this script only spawns and
+// drives the server, so it is agnostic to how deps were resolved:
+//   - patrol_mcp-prepare runs it against pub.dev (newest, and constraint-floor).
+//   - patrol_mcp-cli-compat runs it under melos against the local patrol_cli.
+//
+// It is written in Dart (not shell) on purpose: it must behave identically on
+// ubuntu, macOS, and Windows, and pure-Dart process handling avoids the
+// portability traps of `timeout`, background jobs, and PowerShell-vs-bash.
+//
+// Run from the package root:  dart run tool/smoke_test.dart
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+const _handshakeTimeout = Duration(seconds: 60);
+const _shutdownTimeout = Duration(seconds: 15);
+
+Future<void> main() async {
+  stdout.writeln('[smoke] starting patrol_mcp server...');
+
+  final process = await Process.start(
+    Platform.resolvedExecutable, // the `dart` running this script
+    ['run', 'bin/patrol_mcp.dart'],
+    workingDirectory: Directory.current.path,
+  );
+
+  // The server logs to stderr; mirror it so CI shows what happened on failure.
+  final stderrBuffer = StringBuffer();
+  process.stderr.transform(utf8.decoder).listen((chunk) {
+    stderrBuffer.write(chunk);
+    stderr.write(chunk);
+  });
+
+  // MCP stdio transport is newline-delimited JSON-RPC. Complete on the first
+  // line that is a JSON-RPC response to our initialize request (id == 1).
+  final handshake = Completer<String>();
+  final stdoutSub = process.stdout
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .listen((line) {
+        final message = _tryDecode(line);
+        if (!handshake.isCompleted &&
+            message != null &&
+            message['id'] == 1 &&
+            message['result'] != null) {
+          handshake.complete(line);
+        }
+      });
+
+  const initializeRequest = {
+    'jsonrpc': '2.0',
+    'id': 1,
+    'method': 'initialize',
+    'params': {
+      'protocolVersion': '2024-11-05',
+      'capabilities': <String, dynamic>{},
+      'clientInfo': {'name': 'patrol_mcp_smoke', 'version': '1.0.0'},
+    },
+  };
+  process.stdin.writeln(jsonEncode(initializeRequest));
+  await process.stdin.flush();
+
+  // Race the handshake against the process dying, so a server that crashes on
+  // startup fails fast with a clear message instead of hanging until timeout.
+  // The exit branch resolves to a sentinel (rather than calling _fail directly)
+  // so it stays side-effect-free if the handshake wins — otherwise it would
+  // still fire later, during the normal EOF shutdown below.
+  const exitedSentinel = ' process-exited';
+  final line =
+      await Future.any([
+        handshake.future,
+        process.exitCode.then((_) => exitedSentinel),
+      ]).timeout(
+        _handshakeTimeout,
+        onTimeout: () => _fail(
+          process,
+          'timed out after ${_handshakeTimeout.inSeconds}s waiting for the '
+          'initialize response',
+          stderrBuffer,
+        ),
+      );
+  await stdoutSub.cancel();
+
+  if (identical(line, exitedSentinel)) {
+    _fail(
+      process,
+      'server exited early (code ${await process.exitCode}) before answering '
+      'initialize',
+      stderrBuffer,
+    );
+  }
+
+  final result =
+      (jsonDecode(line) as Map<String, dynamic>)['result']
+          as Map<String, dynamic>;
+  final serverInfo = result['serverInfo'] as Map<String, dynamic>?;
+  final serverName = serverInfo?['name'];
+  if (serverName != 'patrol_mcp') {
+    _fail(
+      process,
+      "handshake returned unexpected serverInfo.name: '$serverName' "
+      "(expected 'patrol_mcp'). Full result: $result",
+      stderrBuffer,
+    );
+  }
+
+  stdout.writeln(
+    '[smoke] handshake OK — server "$serverName" '
+    'v${serverInfo?['version']} responded to initialize',
+  );
+
+  // Closing stdin sends EOF — the disconnect signal an MCP client uses. The
+  // server must exit cleanly instead of blocking and orphaning its process
+  // subtree (#3122). This is the shutdown regression guard.
+  await process.stdin.close();
+
+  final exitCode = await process.exitCode.timeout(
+    _shutdownTimeout,
+    onTimeout: () => _fail(
+      process,
+      'server did not exit within ${_shutdownTimeout.inSeconds}s of stdin '
+      'closing (EOF) — it is blocking on shutdown and would orphan its '
+      'process subtree (#3122)',
+      stderrBuffer,
+    ),
+  );
+
+  if (exitCode != 0) {
+    _fail(
+      process,
+      'server exited with code $exitCode after stdin EOF (expected 0)',
+      stderrBuffer,
+    );
+  }
+
+  stdout
+    ..writeln('[smoke] shutdown OK — server exited 0 on stdin EOF')
+    ..writeln('[smoke] PASS');
+}
+
+Map<String, dynamic>? _tryDecode(String line) {
+  if (line.trim().isEmpty) {
+    return null;
+  }
+  try {
+    final decoded = jsonDecode(line);
+    return decoded is Map<String, dynamic> ? decoded : null;
+  } on FormatException {
+    return null; // non-JSON log line on stdout — ignore
+  }
+}
+
+Never _fail(Process process, String message, StringBuffer serverStderr) {
+  process.kill();
+  stderr
+    ..writeln('[smoke] FAIL: $message')
+    ..writeln('[smoke] --- server stderr ---')
+    ..writeln(serverStderr.toString().trim());
+  exit(1);
+}

--- a/packages/patrol_mcp/tool/smoke_test.dart
+++ b/packages/patrol_mcp/tool/smoke_test.dart
@@ -22,9 +22,16 @@ Future<void> main() async {
     workingDirectory: Directory.current.path,
   );
 
+  // If the server exits early, writes to its stdin break; swallow that so the
+  // exitCode race below reports the real failure instead of an unhandled error.
+  unawaited(process.stdin.done.catchError((Object _) {}));
+
   // The server logs to stderr; mirror it so CI shows what happened on failure.
+  // allowMalformed: a non-UTF-8 console code page (Windows) must not crash us.
   final stderrBuffer = StringBuffer();
-  process.stderr.transform(utf8.decoder).listen((chunk) {
+  process.stderr.transform(const Utf8Decoder(allowMalformed: true)).listen((
+    chunk,
+  ) {
     stderrBuffer.write(chunk);
     stderr.write(chunk);
   });
@@ -33,7 +40,7 @@ Future<void> main() async {
   // line that is a JSON-RPC response to our initialize request (id == 1).
   final handshake = Completer<String>();
   final stdoutSub = process.stdout
-      .transform(utf8.decoder)
+      .transform(const Utf8Decoder(allowMalformed: true))
       .transform(const LineSplitter())
       .listen((line) {
         final message = _tryDecode(line);
@@ -55,8 +62,13 @@ Future<void> main() async {
       'clientInfo': {'name': 'patrol_mcp_smoke', 'version': '1.0.0'},
     },
   };
-  process.stdin.writeln(jsonEncode(initializeRequest));
-  await process.stdin.flush();
+  // A broken pipe here just means the server already exited; the race reports it.
+  try {
+    process.stdin.writeln(jsonEncode(initializeRequest));
+    await process.stdin.flush();
+  } on Object {
+    /* ignored — surfaced via the exit branch below */
+  }
 
   // Race the handshake against early exit so a startup crash fails fast. The
   // exit branch yields a sentinel (not _fail) so it's a no-op if handshake wins.
@@ -105,8 +117,13 @@ Future<void> main() async {
   );
 
   // Closing stdin sends EOF — how MCP clients disconnect. Server must exit
-  // cleanly, not hang and orphan its process subtree (#3122).
-  await process.stdin.close();
+  // cleanly, not hang and orphan its process subtree (#3122). A throw here means
+  // it already exited — fine, the exitCode check below still runs.
+  try {
+    await process.stdin.close();
+  } on Object {
+    /* ignored */
+  }
 
   final exitCode = await process.exitCode.timeout(
     _shutdownTimeout,


### PR DESCRIPTION
## What

`patrol_mcp` had no CI coverage. This adds workflows that actually test the MCP server, not just that it resolves.

## Cases covered

**Server lifecycle** — blocking, on `patrol_mcp` changes
- The MCP server starts and completes the `initialize` handshake.
- It shuts down cleanly on client disconnect (stdin EOF) without orphaning its process subtree.
- Verified on Linux and Windows.

**Dependency-constraint honesty** — blocking, on `patrol_mcp` changes
- `patrol_mcp` builds and starts against both the newest and the lowest `patrol_cli` its constraint allows.
- Catches the case where `patrol_mcp` starts using a newer `patrol_cli` API without bumping its constraint — which would otherwise ship broken to users on an older `patrol_cli`.

**`patrol_cli` compatibility heads-up** — non-blocking, on `patrol_cli` changes
- When a `patrol_cli` change breaks `patrol_mcp` against local source, the author gets a warning + job summary. Never fails CI — released users are unaffected because `patrol_mcp` is pinned to a published `patrol_cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)