### PR TITLE
docs(skills): scope skills install to skills/ subdir

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -3,7 +3,8 @@
 Skills for **developing Patrol itself** — the framework, the CLI, native automation, and docs.
 They're consumed by contributors working in this repository and are **not** published to Patrol
 users. (User-facing skills for *writing tests* live in [`../../skills/`](../../skills/) and ship via
-`npx skills add leancodepl/patrol`.)
+`npx skills add leancodepl/patrol/skills` — scoped to that subdirectory, so the contributor skills
+here are never pulled into a consumer's project.)
 
 This directory (`.agents/skills/`) is the canonical location, read by Codex, GitHub Copilot, and
 Antigravity. `.claude/skills` is a symlink to it, so Claude Code and Cursor read the same source —

--- a/skills/README.md
+++ b/skills/README.md
@@ -16,13 +16,13 @@ Copilot, Antigravity, Gemini CLI and most others share `.agents/skills/` (the `u
 
 ```bash
 # Claude Code
-npx skills add leancodepl/patrol -s '*' -a claude-code -y
+npx skills add leancodepl/patrol/skills -s '*' -a claude-code -y
 
 # Cursor, Codex, GitHub Copilot, Antigravity, Gemini CLI, … (the "universal" location)
-npx skills add leancodepl/patrol -s '*' -a universal -y
+npx skills add leancodepl/patrol/skills -s '*' -a universal -y
 
 # …or cover both at once
-npx skills add leancodepl/patrol -s '*' -a claude-code universal -y
+npx skills add leancodepl/patrol/skills -s '*' -a claude-code universal -y
 ```
 
 To update later:
@@ -35,7 +35,7 @@ npx skills update
 > (where Claude Code reads them), due to
 > [vercel-labs/skills#744](https://github.com/vercel-labs/skills/issues/744). If your skills stop
 > being picked up, regenerate them with
-> `npx skills add leancodepl/patrol -s '*' -a claude-code -y`.
+> `npx skills add leancodepl/patrol/skills -s '*' -a claude-code -y`.
 
 ## Available skills
 


### PR DESCRIPTION
## Problem

The install command in `skills/README.md` targets the whole repo:

```bash
npx skills add leancodepl/patrol -s '*' ...
```

The `skills` CLI discovers `SKILL.md` files across a fixed set of locations that includes `.agents/skills/` (its canonical "universal" skills dir), not just `skills/`. So `-s '*'` reports **Found 3 skills** and installs the contributor-only **`fix-issue`** skill into the consumer's project alongside the two user-facing ones. `fix-issue` is meant for developing Patrol itself (references `packages/`, `dev/e2e_app`, `CONTRIBUTING.md`, and conventions like branching off `master` / `Closes #` in PRs) and has no place in a consumer project.

## Fix

Scope the documented install source to the `skills/` subdirectory using the CLI's supported `owner/repo/subpath` source syntax:

```bash
npx skills add leancodepl/patrol/skills -s '*' ...
```

Verified against the live repo: this reports **Found 2 skills** (`patrol-write-test`, `patrol-test-architecture`) and never surfaces `fix-issue`. `-s '*'` is kept, so any future user-facing skill added under `skills/` is still picked up automatically. Contributor skills stay where they are in `.agents/skills/`.

Also corrected the cross-reference in `.agents/skills/README.md` to the scoped path.
