### PR TITLE
chore: remove @fylyppo from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 #
 
 # Owners of the patrol repo.
-* @pdenert @piotruela @gogolon @fylyppo @Kendru98 @zoskar @PiotrRogulski @jBorkowska
+* @pdenert @piotruela @gogolon @Kendru98 @zoskar @PiotrRogulski @jBorkowska


### PR DESCRIPTION
Removes `@fylyppo` from the `*` owner rule in `.github/CODEOWNERS` so I'm no longer auto-requested as a reviewer on all PRs.