### PR TITLE
chore(patrol_finders): bump patrol_log to ^0.10.0

### DIFF
--- a/packages/patrol_finders/CHANGELOG.md
+++ b/packages/patrol_finders/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.0
+
+- Bump `patrol_log` to `^0.10.0`.
+
 ## 3.5.0
 
 - Fix issues with `enterText()`. (#2202, #2111)

--- a/packages/patrol_finders/pubspec.yaml
+++ b/packages/patrol_finders/pubspec.yaml
@@ -1,6 +1,6 @@
 name: patrol_finders
 description: Streamlined, high-level API on top of flutter_test.
-version: 3.5.0
+version: 3.6.0
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol_finders
 issue_tracker: https://github.com/leancodepl/patrol/issues?q=is%3Aopen+is%3Aissue+label%3Apackage%3Apatrol_finders
@@ -28,7 +28,7 @@ dependencies:
   flutter_test:
     sdk: flutter
   meta: ^1.10.0
-  patrol_log: ^0.9.0
+  patrol_log: ^0.10.0
 
 dev_dependencies:
   leancode_lint: ^17.0.0


### PR DESCRIPTION
## What changed

- Bumped the `patrol_log` dependency in `patrol_finders` from `^0.9.0` to `^0.10.0`.
- Released `patrol_finders` 3.6.0 with a corresponding CHANGELOG entry.

## Why

`patrol_log` 0.10.0 was recently released. This pulls the new version into `patrol_finders`.

## Notes for reviewers

- Version bumped as a minor (`3.5.0` → `3.6.0`), consistent with how previous `patrol_log` bumps were versioned in this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)