### PR TITLE
chore: bump patrol_finders/patrol_log in patrol and patrol_log in patrol_cli

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Bump `patrol_finders` to `^3.6.0`.
+- Bump `patrol_log` to `^0.10.0`.
+
 - Fix `patrol develop` on iOS Simulator timing out after ~6 minutes with "Test runner never began executing tests after launching". Requires a matching `patrol_cli` version that sets `PATROL_DEVELOP`. (#3139)
 - Bump `equatable` to `^2.1.0` and migrate generated platform contracts from deprecated `EquatableMixin` to `with Equatable`.
 - Add Swift Package Manager (SPM) support for iOS and macOS. CocoaPods remains supported for projects that have not migrated to SPM.

--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -32,8 +32,8 @@ dependencies:
   http_multi_server: ^3.2.2
   json_annotation: ^4.9.0
   meta: ^1.10.0
-  patrol_finders: ^3.4.0
-  patrol_log: ^0.9.0
+  patrol_finders: ^3.6.0
+  patrol_log: ^0.10.0
   shelf: ^1.4.1
   test_api: '^0.7.0'
   web: ^1.0.0

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Bump `patrol_log` to `^0.10.0`.
+
 - Fix `patrol develop` on iOS Simulator timing out after ~6 minutes with "Test runner never began executing tests after launching". Requires a matching `patrol` version that enables the develop-specific native test runner path. (#3139)
 - Bump `equatable` to `^2.1.0` and migrate `PatrolPubspecConfig` and related config classes from deprecated `EquatableMixin` to `with Equatable`.
 - Fix wrong import generated string on Windows commands like `patrol test -t .\patrol_test\example_test.dart` now generate correct import path;

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   meta: ^1.10.0
   package_config: ^2.1.1
   path: ^1.8.3
-  patrol_log: ^0.9.0
+  patrol_log: ^0.10.0
   platform: ^3.1.3
   process: ^5.0.1
   pub_updater: ^0.5.0


### PR DESCRIPTION
## What changed

- **patrol**: bump `patrol_finders` to `^3.6.0` and `patrol_log` to `^0.10.0`
- **patrol_cli**: bump `patrol_log` to `^0.10.0`
- CHANGELOG entries added under `## Unreleased` in both packages

## Why

`patrol_finders` 3.6.0 and `patrol_log` 0.10.0 are published on pub.dev; this pulls them into the consumer packages.

## Notes for reviewers

- Bumping `patrol_finders` alone would break version solving: `patrol_finders` 3.6.0 requires `patrol_log ^0.10.0`, so `patrol`'s own `patrol_log` constraint must move in lockstep (verified with pana).
- pana confirms dependency resolution, dartdoc, and up-to-date dependency checks pass after the change. Remaining local pana failures were caused by a broken `custom_lint` snapshot in the local pub cache (environmental), not by this change.
- `patrol_cli` has no `patrol_finders` dependency, so only `patrol_log` was bumped there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)