### PR TITLE
chore: remove @gogolon from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 #
 
 # Owners of the patrol repo.
-* @pdenert @piotruela @gogolon @Kendru98 @zoskar @PiotrRogulski @jBorkowska
+* @pdenert @piotruela @Kendru98 @zoskar @PiotrRogulski @jBorkowska


### PR DESCRIPTION
Removes `@gogolon` from the `*` owner rule in `.github/CODEOWNERS` so they're no longer auto-requested as a reviewer on all PRs.