### PR TITLE
Prepare patrol 4.7.0 and patrol_cli 4.5.0 for release

### DIFF
--- a/docs/documentation/compatibility-table.mdx
+++ b/docs/documentation/compatibility-table.mdx
@@ -13,7 +13,8 @@ This table shows the compatible versions between patrol_cli and patrol packages.
 
 | patrol_cli version | patrol version | Minimum Flutter version |
 |-------------------|----------------|------------------------|
-| 4.4.0+ | 4.6.0+ | 3.32.0 |
+| 4.5.0+ | 4.7.0+ | 3.32.0 |
+| 4.4.0 | 4.6.0 - 4.6.1 | 3.32.0 |
 | 4.3.0 - 4.3.1 | 4.5.0 | 3.32.0 |
 | 4.2.0 | 4.2.0 - 4.4.0 | 3.32.0 |
 | 4.0.2 - 4.1.0 | 4.1.0 - 4.1.1 | 3.32.0 |

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 4.7.0
 
 - Bump `patrol_finders` to `^3.6.0`.
 - Bump `patrol_log` to `^0.10.0`.

--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -2,7 +2,7 @@ name: patrol
 description: >
   A powerful, multiplatform E2E UI testing framework for Flutter apps that
   overcomes the limitations of integration_test by handling native interactions.
-version: 4.6.1
+version: 4.7.0
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 4.5.0
 
 - Bump `patrol_log` to `^0.10.0`.
 

--- a/packages/patrol_cli/lib/src/base/constants.dart
+++ b/packages/patrol_cli/lib/src/base/constants.dart
@@ -1,3 +1,3 @@
 /// Version of Patrol CLI. Must be kept in sync with pubspec.yaml.
 /// If you update this, make sure that compatibility-table.mdx is updated (if needed)
-const version = '4.4.0';
+const version = '4.5.0';

--- a/packages/patrol_cli/lib/src/compatibility_checker/version_compatibility.dart
+++ b/packages/patrol_cli/lib/src/compatibility_checker/version_compatibility.dart
@@ -89,8 +89,13 @@ class VersionCompatibility {
 final versionCompatibilityList =
     <VersionCompatibility>[
       VersionCompatibility.fromRangeString(
-        patrolCliVersion: '4.4.0+',
-        patrolVersion: '4.6.0+',
+        patrolCliVersion: '4.5.0+',
+        patrolVersion: '4.7.0+',
+        minFlutterVersion: '3.32.0',
+      ),
+      VersionCompatibility.fromRangeString(
+        patrolCliVersion: '4.4.0',
+        patrolVersion: '4.6.0 - 4.6.1',
         minFlutterVersion: '3.32.0',
       ),
       VersionCompatibility.fromRangeString(

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: patrol_cli
 description: >
   Command-line tool for Patrol, a powerful Flutter-native UI testing framework.
-version: 4.4.0  # Must be kept in sync with constants.dart
+version: 4.5.0  # Must be kept in sync with constants.dart
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol_cli
 issue_tracker: https://github.com/leancodepl/patrol/issues?q=is%3Aopen+is%3Aissue+label%3A%22package%3A+patrol_cli%22


### PR DESCRIPTION
## Description

Prepares the stable releases of **patrol 4.7.0** and **patrol_cli 4.5.0** (stabilizing the `4.7.0-dev.x` / `4.5.0-dev.x` prerelease line, plus the Windows gradle-hang fix #3094 that landed after `dev.3` was cut).

Changes:
- Bump `patrol` to `4.7.0` and `patrol_cli` to `4.5.0` (pubspec + `constants.dart`).
- Rename the `Unreleased` changelog sections to the release versions.
- Split the compatibility table: `patrol_cli` 4.5.0+ pairs with `patrol` 4.7.0+, since `patrol_log` was bumped to `^0.10.0`, which (semver <1.0.0) is incompatible with `^0.9.0`. The previous open-ended row is closed at `4.4.0` / `4.6.0 - 4.6.1`. Applied to both `version_compatibility.dart` and `compatibility-table.mdx`.

`patrol_cli` compatibility tests pass locally.

After merge, tag `patrol-v4.7.0` and `patrol_cli-v4.5.0` to trigger the publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)