### PR TITLE
Stop downloading unused browsers in web_runner

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Download only Chromium instead of all default Playwright browsers during web runner setup. (#3156)
+
 ## 4.5.0
 
 - Add `-weak_framework XCTest` linker flags to iOS and macOS `build-for-testing` to support Swift Package Manager integration.

--- a/packages/patrol_cli/lib/src/web/web_test_backend.dart
+++ b/packages/patrol_cli/lib/src/web/web_test_backend.dart
@@ -727,7 +727,7 @@ class WebTestBackend {
       ..info('Node.js dependencies installed successfully.')
       ..info('Installing Playwright dependencies...');
     final result = await _processManager.run(
-      ['npx', 'playwright', 'install'],
+      ['npx', 'playwright', 'install', 'chromium'],
       workingDirectory: webRunnerPath,
       runInShell: true,
     );
@@ -735,7 +735,7 @@ class WebTestBackend {
     if (result.exitCode != 0) {
       throw ProcessException(
         'npx',
-        ['playwright', 'install'],
+        ['playwright', 'install', 'chromium'],
         'Failed to install Playwright dependencies:\n'
             'STDOUT: ${result.stdout}\n'
             'STDERR: ${result.stderr}',


### PR DESCRIPTION
Installing only `chromium` saves around 650 MB of spaces taken by unsed `firefox` and `webkit`