### PR TITLE
Organize changelogs for patrol 4.7.0 and patrol_cli 4.5.0

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fix iOS/macOS regular app builds failing with undefined XCTest symbols when using SPM.
 - Add multi-tab browser support for web tests: `openNewPage`, `closePage`, `switchToPage`, `switchToInitialPage`, `getPages`, `getCurrentPage`, `getCurrentPageUrl`, `waitForPopup`. (#2871)
 - Fix `patrol develop` on iOS Simulator timing out after ~6 minutes with "Test runner never began executing tests after launching". Requires a matching `patrol_cli` version that sets `PATROL_DEVELOP`. (#3139)
-- Fix iOS tests failing on devices whose name contains a comma 
+- Fix iOS tests failing on devices whose name contains a comma.
 - Fix a crash when an `IOSSelector` has no arguments needed for creating `NSPredicate` for textfield. (#3053)
 - Fix macOS build by implementing `sendKeyboardEnter` in `MacOSAutomator`. (#3105)
 - Add `sendKeyboardEnter` method for `MobileAutomator`. (#2748)

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,21 +1,22 @@
 ## 4.7.0
 
+- Add Swift Package Manager (SPM) support for iOS and macOS. CocoaPods remains supported for projects that have not migrated to SPM.
+- Fix iOS/macOS regular app builds failing with undefined XCTest symbols when using SPM.
+- Add multi-tab browser support for web tests: `openNewPage`, `closePage`, `switchToPage`, `switchToInitialPage`, `getPages`, `getCurrentPage`, `getCurrentPageUrl`, `waitForPopup`. (#2871)
+- Fix `patrol develop` on iOS Simulator timing out after ~6 minutes with "Test runner never began executing tests after launching". Requires a matching `patrol_cli` version that sets `PATROL_DEVELOP`. (#3139)
+- Fix iOS tests failing on devices whose name contains a comma 
+- Fix a crash when an `IOSSelector` has no arguments needed for creating `NSPredicate` for textfield. (#3053)
+- Fix macOS build by implementing `sendKeyboardEnter` in `MacOSAutomator`. (#3105)
+- Add `sendKeyboardEnter` method for `MobileAutomator`. (#2748)
+- Add Japanese (ja) language support for native OS interactions.
+- Migrate Japanese text resources to SPM (#3128)
+- Use HttpMultiServer and Ktor for handling raw HTTP requests. (#2645)
+- Migrate to built-in Kotlin (#3084).
+- Bump `equatable` to `^2.1.0` and migrate generated platform contracts from deprecated `EquatableMixin` to `with Equatable`.
 - Bump `patrol_finders` to `^3.6.0`.
 - Bump `patrol_log` to `^0.10.0`.
 
-- Fix `patrol develop` on iOS Simulator timing out after ~6 minutes with "Test runner never began executing tests after launching". Requires a matching `patrol_cli` version that sets `PATROL_DEVELOP`. (#3139)
-- Bump `equatable` to `^2.1.0` and migrate generated platform contracts from deprecated `EquatableMixin` to `with Equatable`.
-- Add Swift Package Manager (SPM) support for iOS and macOS. CocoaPods remains supported for projects that have not migrated to SPM.
-- Fix iOS/macOS regular app builds failing with undefined XCTest symbols when using SPM.
-- Use HttpMultiServer and Ktor for handling raw HTTP requests. (#2645)
-- Add `sendKeyboardEnter` method for `MobileAutomator`. (#2748)
-- Fix a crash when an `IOSSelector` has no arguments needed for creating `NSPredicate` for textfield. (#3053)
-- Add Japanese (ja) language support for native OS interactions.
-- Fix macOS build by implementing `sendKeyboardEnter` in `MacOSAutomator`. (#3105)
-- Migrate to built-in Kotlin (#3084).
-- Fix iOS tests failing on devices whose name contains a comma 
-- Migrate Japanese text resources to SPM (#3128)
-- Add multi-tab browser support for web tests: `openNewPage`, `closePage`, `switchToPage`, `switchToInitialPage`, `getPages`, `getCurrentPage`, `getCurrentPageUrl`, `waitForPopup`. (#2871)
+This version requires version `4.5.0` of `patrol_cli` package.
 
 ## 4.6.1
 

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fix `patrol test`/`patrol develop` hanging on Windows at `gradlew :app:dependencies` by also draining the gradle process stderr stream during orchestrator-version detection. (#2565)
 - Fix `--exclude` not working. (#2990)
 - Fix `--clear-permissions` being ignored by `patrol build ios`. The flag was wired into `patrol test` but dropped from `build ios`, so prebuilt iOS test bundles (e.g. for BrowserStack/Firebase Test Lab) never had `CLEAR_PERMISSIONS` enabled.
-- Fix wrong import generated string on Windows commands like `patrol test -t .\patrol_test\example_test.dart` now generate correct import path;
+- Fix wrong import path being generated on Windows for commands like `patrol test -t .\patrol_test\example_test.dart`.
 - Fix `test_bundle.dart` generating a broken absolute import (and an invalid import alias containing characters such as `-`) when the test target lives outside the configured `test_directory`. The import is now computed relative to the bundle and the alias is sanitized. (#3104)
 - Don't listen for `SIGTERM` on Windows, where it is not supported and throws an unhandled `SignalException`. (#3035)
 - Bump `equatable` to `^2.1.0` and migrate `PatrolPubspecConfig` and related config classes from deprecated `EquatableMixin` to `with Equatable`.

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,16 +1,17 @@
 ## 4.5.0
 
+- Add `-weak_framework XCTest` linker flags to iOS and macOS `build-for-testing` to support Swift Package Manager integration.
+- Fix `patrol develop` on iOS Simulator timing out after ~6 minutes with "Test runner never began executing tests after launching". Requires a matching `patrol` version that enables the develop-specific native test runner path. (#3139)
+- Fix `patrol test`/`patrol develop` hanging on Windows at `gradlew :app:dependencies` by also draining the gradle process stderr stream during orchestrator-version detection. (#2565)
+- Fix `--exclude` not working. (#2990)
+- Fix `--clear-permissions` being ignored by `patrol build ios`. The flag was wired into `patrol test` but dropped from `build ios`, so prebuilt iOS test bundles (e.g. for BrowserStack/Firebase Test Lab) never had `CLEAR_PERMISSIONS` enabled.
+- Fix wrong import generated string on Windows commands like `patrol test -t .\patrol_test\example_test.dart` now generate correct import path;
+- Fix `test_bundle.dart` generating a broken absolute import (and an invalid import alias containing characters such as `-`) when the test target lives outside the configured `test_directory`. The import is now computed relative to the bundle and the alias is sanitized. (#3104)
+- Don't listen for `SIGTERM` on Windows, where it is not supported and throws an unhandled `SignalException`. (#3035)
+- Bump `equatable` to `^2.1.0` and migrate `PatrolPubspecConfig` and related config classes from deprecated `EquatableMixin` to `with Equatable`.
 - Bump `patrol_log` to `^0.10.0`.
 
-- Fix `patrol develop` on iOS Simulator timing out after ~6 minutes with "Test runner never began executing tests after launching". Requires a matching `patrol` version that enables the develop-specific native test runner path. (#3139)
-- Bump `equatable` to `^2.1.0` and migrate `PatrolPubspecConfig` and related config classes from deprecated `EquatableMixin` to `with Equatable`.
-- Fix wrong import generated string on Windows commands like `patrol test -t .\patrol_test\example_test.dart` now generate correct import path;
-- Add `-weak_framework XCTest` linker flags to iOS and macOS `build-for-testing` to support Swift Package Manager integration.
-- Fix `--clear-permissions` being ignored by `patrol build ios`. The flag was wired into `patrol test` but dropped from `build ios`, so prebuilt iOS test bundles (e.g. for BrowserStack/Firebase Test Lab) never had `CLEAR_PERMISSIONS` enabled.
-- Don't listen for `SIGTERM` on Windows, where it is not supported and throws an unhandled `SignalException`. (#3035)
-- Fix `--exclude` not working. (#2990)
-- Fix `test_bundle.dart` generating a broken absolute import (and an invalid import alias containing characters such as `-`) when the test target lives outside the configured `test_directory`. The import is now computed relative to the bundle and the alias is sanitized. (#3104)
-- Fix `patrol test`/`patrol develop` hanging on Windows at `gradlew :app:dependencies` by also draining the gradle process stderr stream during orchestrator-version detection. (#2565)
+This version requires version `4.7.0` of `patrol` package.
 
 ## 4.4.0
 


### PR DESCRIPTION
## What changed

Reorganizes the changelog entries for the `patrol 4.7.0` / `patrol_cli 4.5.0` release:

- **Sorted entries by importance** in both `packages/patrol/CHANGELOG.md` (4.7.0) and `packages/patrol_cli/CHANGELOG.md` (4.5.0): headline features first (SPM support, multi-tab web testing), then high-impact fixes (`patrol develop` iOS Simulator timeout, Windows Gradle hang, broken `--exclude`/`--clear-permissions` flags), then smaller fixes and new capabilities, with internal work and dependency bumps last.
- **Added cross-version requirement notes** in the established format: patrol 4.7.0 requires `patrol_cli` `4.5.0`, and patrol_cli 4.5.0 requires `patrol` `4.7.0`. This matters for the `patrol develop` iOS Simulator fix (#3139), which only works when both packages are upgraded together.
- Removed the stray blank line that split the dependency-bump entries from the rest of the list in both sections.

## Why

Makes the release notes easier to scan (most important items first) and makes the mutual version requirement explicit, as done for previous releases (e.g. 4.0.0).

No code changes — changelog files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)