### PR TITLE
Fix patrol develop hang when app shuts down early

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Download only Chromium instead of all default Playwright browsers during web runner setup. (#3156)
+- Fix `patrol develop` not reporting completion when the app shuts down before the tests finish, causing `patrol_mcp` to hang until its timeout. The backend exit is now detected independently of `flutter attach`.
 
 ## 4.5.1
 

--- a/packages/patrol_cli/lib/src/commands/develop_service.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_service.dart
@@ -426,6 +426,28 @@ class DevelopService {
     try {
       final future = action();
 
+      // If the backend settles before attach returns, the app shut down early.
+      // Report it now instead of after attach (which blocks for the whole
+      // session), so callers waiting on [onTestsCompleted] don't hang.
+      var testsReported = false;
+      void reportTestsCompleted(TestCompletionResult result) {
+        if (testsReported) {
+          return;
+        }
+        testsReported = true;
+        onTestsCompleted?.call(result);
+      }
+
+      unawaited(
+        future.then(
+          (_) =>
+              reportTestsCompleted(const TestCompletionResult(success: true)),
+          onError: (Object err, StackTrace st) => reportTestsCompleted(
+            TestCompletionResult(success: false, error: err),
+          ),
+        ),
+      );
+
       if (device.targetPlatform != TargetPlatform.web) {
         await _flutterTool.attachForHotRestart(
           flutterCommand: flutterOpts.command,
@@ -441,11 +463,9 @@ class DevelopService {
 
       try {
         await future;
-        onTestsCompleted?.call(const TestCompletionResult(success: true));
+        reportTestsCompleted(const TestCompletionResult(success: true));
       } catch (err) {
-        onTestsCompleted?.call(
-          TestCompletionResult(success: false, error: err),
-        );
+        reportTestsCompleted(TestCompletionResult(success: false, error: err));
         rethrow;
       }
     } catch (err, st) {

--- a/packages/patrol_cli/test/commands/develop_service_test.dart
+++ b/packages/patrol_cli/test/commands/develop_service_test.dart
@@ -1,0 +1,262 @@
+import 'dart:async';
+
+import 'package:file/memory.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:patrol_cli/src/commands/develop_options.dart';
+import 'package:patrol_cli/src/commands/develop_service.dart';
+import 'package:patrol_cli/src/crossplatform/app_options.dart';
+import 'package:patrol_cli/src/devices.dart';
+import 'package:patrol_cli/src/ios/ios_test_backend.dart' show BuildMode;
+import 'package:patrol_cli/src/pubspec_reader.dart';
+import 'package:patrol_cli/src/runner/flutter_command.dart';
+import 'package:test/test.dart';
+
+import '../src/mocks.dart';
+
+void main() {
+  group('DevelopService', () {
+    late MockDeviceFinder deviceFinder;
+    late MockTestFinderFactory testFinderFactory;
+    late MockTestFinder testFinder;
+    late MockTestBundler testBundler;
+    late MockDartDefinesReader dartDefinesReader;
+    late MockCompatibilityChecker compatibilityChecker;
+    late MockPubspecReader pubspecReader;
+    late MockAndroidTestBackend androidTestBackend;
+    late MockIOSTestBackend iosTestBackend;
+    late MockMacOSTestBackend macosTestBackend;
+    late MockWebTestBackend webTestBackend;
+    late MockFlutterTool flutterTool;
+    late MockLogger logger;
+
+    const androidDevice = Device(
+      name: 'emulator-5554',
+      id: 'emulator-5554',
+      targetPlatform: TargetPlatform.android,
+      real: false,
+    );
+
+    setUpAll(() {
+      registerFallbackValue(
+        const AndroidAppOptions(
+          flutter: FlutterAppOptions(
+            command: FlutterCommand('flutter'),
+            target: 'patrol_test/test_bundle.dart',
+            flavor: null,
+            buildMode: BuildMode.debug,
+            dartDefines: <String, String>{},
+            dartDefineFromFilePaths: <String>[],
+            buildName: null,
+            buildNumber: null,
+          ),
+          packageName: 'com.example.app',
+          appServerPort: 8080,
+          testServerPort: 8081,
+          uninstall: false,
+        ),
+      );
+      registerFallbackValue(androidDevice);
+      registerFallbackValue(const FlutterCommand('flutter'));
+      registerFallbackValue(<String, String>{});
+    });
+
+    setUp(() {
+      deviceFinder = MockDeviceFinder();
+      testFinderFactory = MockTestFinderFactory();
+      testFinder = MockTestFinder();
+      testBundler = MockTestBundler();
+      dartDefinesReader = MockDartDefinesReader();
+      compatibilityChecker = MockCompatibilityChecker();
+      pubspecReader = MockPubspecReader();
+      androidTestBackend = MockAndroidTestBackend();
+      iosTestBackend = MockIOSTestBackend();
+      macosTestBackend = MockMacOSTestBackend();
+      webTestBackend = MockWebTestBackend();
+      flutterTool = MockFlutterTool();
+      logger = MockLogger();
+
+      when(() => logger.detail(any())).thenReturn(null);
+      when(() => logger.info(any())).thenReturn(null);
+      when(() => logger.err(any())).thenReturn(null);
+
+      when(
+        pubspecReader.read,
+      ).thenReturn(PatrolPubspecConfig.empty(flutterPackageName: 'test_app'));
+
+      when(() => testFinderFactory.create(any())).thenReturn(testFinder);
+      when(
+        () => testFinder.findTest(any(), any()),
+      ).thenReturn('patrol_test/onboarding_test.dart');
+
+      when(() => testBundler.ensureEntrypoint(any())).thenReturn(null);
+      when(
+        () => testBundler.getEntrypointFile(any()),
+      ).thenReturn(MemoryFileSystem().file('patrol_test/test_bundle.dart'));
+      when(() => testBundler.deleteEntrypointProxy(any())).thenReturn(null);
+
+      when(() => dartDefinesReader.fromFile()).thenReturn(<String, String>{});
+      when(
+        () => dartDefinesReader.fromCli(args: any(named: 'args')),
+      ).thenReturn(<String, String>{});
+      when(
+        () => dartDefinesReader.extractDartDefineConfigJsonMap(any()),
+      ).thenReturn(<String, Object?>{});
+
+      when(
+        () => deviceFinder.find(
+          any(),
+          flutterCommand: any(named: 'flutterCommand'),
+        ),
+      ).thenAnswer((_) async => [androidDevice]);
+
+      when(() => androidTestBackend.build(any())).thenAnswer((_) async {});
+    });
+
+    DevelopService buildService() => DevelopService(
+      deviceFinder: deviceFinder,
+      testFinderFactory: testFinderFactory,
+      testBundler: testBundler,
+      dartDefinesReader: dartDefinesReader,
+      compatibilityChecker: compatibilityChecker,
+      pubspecReader: pubspecReader,
+      androidTestBackend: androidTestBackend,
+      iosTestBackend: iosTestBackend,
+      macosTestBackend: macosTestBackend,
+      webTestBackend: webTestBackend,
+      flutterTool: flutterTool,
+      logger: logger,
+      stdin: const Stream.empty(),
+      onTestsCompleted: (result) => _lastResult = result,
+    );
+
+    const options = DevelopOptions(
+      target: 'onboarding_test.dart',
+      flutterCommand: FlutterCommand('flutter'),
+      buildMode: BuildMode.debug,
+      testServerPort: 8081,
+      appServerPort: 8080,
+      generateBundle: false,
+      uninstall: false,
+      checkCompatibility: false,
+    );
+
+    test(
+      'reports test completion when the app shuts down before attach returns',
+      () async {
+        // The backend process exits early (e.g. "App shut down on request")
+        // while `flutter attach` stays alive for the whole session.
+        final backendExit = Completer<void>();
+        when(
+          () => androidTestBackend.execute(
+            any(),
+            any(),
+            interruptible: any(named: 'interruptible'),
+            showFlutterLogs: any(named: 'showFlutterLogs'),
+            hideTestSteps: any(named: 'hideTestSteps'),
+            flavor: any(named: 'flavor'),
+            clearTestSteps: any(named: 'clearTestSteps'),
+            onLogEntry: any(named: 'onLogEntry'),
+          ),
+        ).thenAnswer((_) => backendExit.future);
+
+        // attach never completes -- it blocks for the whole develop session.
+        final attachNeverCompletes = Completer<void>();
+        when(
+          () => flutterTool.attachForHotRestart(
+            flutterCommand: any(named: 'flutterCommand'),
+            deviceId: any(named: 'deviceId'),
+            target: any(named: 'target'),
+            appId: any(named: 'appId'),
+            dartDefines: any(named: 'dartDefines'),
+            openDevtools: any(named: 'openDevtools'),
+            attachUsingUrl: any(named: 'attachUsingUrl'),
+            onQuit: any(named: 'onQuit'),
+          ),
+        ).thenAnswer((_) => attachNeverCompletes.future);
+
+        _lastResult = null;
+
+        // `run()` never returns (attach is still pending), so don't await it.
+        unawaited(buildService().run(options));
+
+        // Simulate the app shutting down after the test started.
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        backendExit.complete();
+
+        // onTestsCompleted must fire promptly -- BEFORE attach returns.
+        // Before the fix this only happened after attach, so it never fired
+        // and MCP callers hung until their global timeout.
+        await _waitFor(() => _lastResult != null);
+
+        expect(_lastResult, isNotNull);
+        expect(_lastResult!.success, isTrue);
+        expect(attachNeverCompletes.isCompleted, isFalse);
+      },
+    );
+
+    test(
+      'reports failure when the backend fails before attach returns',
+      () async {
+        final backendExit = Completer<void>();
+        when(
+          () => androidTestBackend.execute(
+            any(),
+            any(),
+            interruptible: any(named: 'interruptible'),
+            showFlutterLogs: any(named: 'showFlutterLogs'),
+            hideTestSteps: any(named: 'hideTestSteps'),
+            flavor: any(named: 'flavor'),
+            clearTestSteps: any(named: 'clearTestSteps'),
+            onLogEntry: any(named: 'onLogEntry'),
+          ),
+        ).thenAnswer((_) => backendExit.future);
+
+        final attachNeverCompletes = Completer<void>();
+        when(
+          () => flutterTool.attachForHotRestart(
+            flutterCommand: any(named: 'flutterCommand'),
+            deviceId: any(named: 'deviceId'),
+            target: any(named: 'target'),
+            appId: any(named: 'appId'),
+            dartDefines: any(named: 'dartDefines'),
+            openDevtools: any(named: 'openDevtools'),
+            attachUsingUrl: any(named: 'attachUsingUrl'),
+            onQuit: any(named: 'onQuit'),
+          ),
+        ).thenAnswer((_) => attachNeverCompletes.future);
+
+        _lastResult = null;
+
+        unawaited(
+          buildService().run(options).catchError((Object _) {
+            // The failure is rethrown by run(); swallow it here since the
+            // assertion is on the reported result, not on run()'s error.
+          }),
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        backendExit.completeError(Exception('boom'));
+
+        await _waitFor(() => _lastResult != null);
+
+        expect(_lastResult, isNotNull);
+        expect(_lastResult!.success, isFalse);
+        expect(_lastResult!.error, isA<Exception>());
+      },
+    );
+  });
+}
+
+TestCompletionResult? _lastResult;
+
+/// Polls [condition] until it becomes true or a generous deadline elapses,
+/// failing the test on timeout instead of hanging forever.
+Future<void> _waitFor(bool Function() condition) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 5));
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('Condition was not met within the timeout');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+}

--- a/packages/patrol_cli/test/src/mocks.dart
+++ b/packages/patrol_cli/test/src/mocks.dart
@@ -7,6 +7,7 @@ import 'package:patrol_cli/src/analytics/analytics.dart';
 import 'package:patrol_cli/src/android/android_test_backend.dart';
 import 'package:patrol_cli/src/base/logger.dart' as logger;
 import 'package:patrol_cli/src/compatibility_checker/compatibility_checker.dart';
+import 'package:patrol_cli/src/crossplatform/flutter_tool.dart';
 import 'package:patrol_cli/src/dart_defines_reader.dart';
 import 'package:patrol_cli/src/devices.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
@@ -14,6 +15,7 @@ import 'package:patrol_cli/src/macos/macos_test_backend.dart';
 import 'package:patrol_cli/src/pubspec_reader.dart';
 import 'package:patrol_cli/src/test_bundler.dart';
 import 'package:patrol_cli/src/test_finder.dart';
+import 'package:patrol_cli/src/web/web_test_backend.dart';
 import 'package:process/process.dart' as process;
 import 'package:pub_updater/pub_updater.dart' as pub;
 
@@ -38,6 +40,10 @@ class MockAndroidTestBackend extends Mock implements AndroidTestBackend {}
 class MockIOSTestBackend extends Mock implements IOSTestBackend {}
 
 class MockMacOSTestBackend extends Mock implements MacOSTestBackend {}
+
+class MockWebTestBackend extends Mock implements WebTestBackend {}
+
+class MockFlutterTool extends Mock implements FlutterTool {}
 
 class MockTestFinderFactory extends Mock implements TestFinderFactory {}
 

--- a/packages/patrol_mcp/CHANGELOG.md
+++ b/packages/patrol_mcp/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Simplified setup: the `run-patrol` wrapper script is no longer needed — point your MCP config directly at `dart run patrol_mcp`. FVM-pinned projects run develop sessions with the pinned Flutter automatically. See the README for the updated setup.
 - Run develop sessions from `PROJECT_ROOT`, so `run` works when the server's working directory differs from the project (e.g. an app in a subdirectory).
+- Fix the `run` tool hanging until its timeout when the app shuts down before the test reports completion; it now returns promptly as a failed run with a warning, and a `quit` isn't misreported as a crash.
 - Fix `screenshot` and `native-tree` MCP tools failing with `error: more than one device/emulator` (Android) or capturing the wrong simulator (iOS) when multiple devices are attached. Both now target the active session's device explicitly.
 - Exit on client disconnect (stdin EOF), not just `SIGTERM`/`SIGINT`, and tear down the active develop session on shutdown so it doesn't orphan.
 - Return structured output (`structuredContent`) from `run`/`status`/`native-tree`, and reply with a clear error instead of crashing when `quit` has no active session.

--- a/packages/patrol_mcp/CHANGELOG.md
+++ b/packages/patrol_mcp/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Simplified setup: the `run-patrol` wrapper script is no longer needed — point your MCP config directly at `dart run patrol_mcp`. FVM-pinned projects run develop sessions with the pinned Flutter automatically. See the README for the updated setup.
 - Run develop sessions from `PROJECT_ROOT`, so `run` works when the server's working directory differs from the project (e.g. an app in a subdirectory).
-- Fix the `run` tool hanging until its timeout when the app shuts down before the test reports completion; it now returns promptly as a failed run with a warning, and a `quit` isn't misreported as a crash.
+- Fix the `run` tool hanging until its timeout when the app shuts down before the test reports completion; it now returns promptly as a failed run with a warning, and a `quit` isn't misreported as a crash. Requires the first `patrol_cli` release after 4.5.1, which reports the backend exit independently of `flutter attach`.
 - Fix `screenshot` and `native-tree` MCP tools failing with `error: more than one device/emulator` (Android) or capturing the wrong simulator (iOS) when multiple devices are attached. Both now target the active session's device explicitly.
 - Exit on client disconnect (stdin EOF), not just `SIGTERM`/`SIGINT`, and tear down the active develop session on shutdown so it doesn't orphan.
 - Return structured output (`structuredContent`) from `run`/`status`/`native-tree`, and reply with a clear error instead of crashing when `quit` has no active session.

--- a/packages/patrol_mcp/lib/src/patrol_session.dart
+++ b/packages/patrol_mcp/lib/src/patrol_session.dart
@@ -199,6 +199,12 @@ final class PatrolSession {
   final _outputs = <String>[];
   TestState _testState = TestState.idle;
 
+  /// Set while quitting so a backend exit we caused isn't reported as a crash.
+  var _quitRequested = false;
+
+  /// Warning attached to the next returned status (e.g. unexpected app exit).
+  String? _finishWarning;
+
   Completer<void>? _finishCompleter;
   DisposeScope? _disposeScope;
   StreamController<List<int>>? _stdinController;
@@ -304,6 +310,8 @@ final class PatrolSession {
     _cleanupFuture = null;
     _currentTestFile = testFile;
     _testState = TestState.running;
+    _quitRequested = false;
+    _finishWarning = null;
     _outputs.clear();
     // Create the completer eagerly so callbacks can signal it even if
     // test completion happens before _waitForFinish is called.
@@ -435,14 +443,20 @@ final class PatrolSession {
 
   /// Backend exit signal from [DevelopService].
   ///
-  /// In develop mode, successful runs stay alive for hot restart and don't exit.
-  /// So if the backend exits while we're still running, treat it as failure.
-  /// (Quit path sets state to idle before this callback can affect it.)
+  /// In develop mode runs stay alive for hot restart, so a backend exit while
+  /// running means the app shut down early -- report it as a failure. Our own
+  /// quit also exits it but flips to idle first; [_quitRequested] covers the race.
   void _handleTestsCompleted(TestCompletionResult result) {
-    if (_testState == TestState.running) {
-      _testState = TestState.finishedFailed;
-      _completeFinish();
+    if (_quitRequested || _testState != TestState.running) {
+      return;
     }
+
+    _testState = TestState.finishedFailed;
+    _finishWarning =
+        'The app shut down before the test reported completion. This usually '
+        'means the app crashed or exited early rather than a test assertion '
+        'failing. Check the output/logs above for the underlying error.';
+    _completeFinish();
   }
 
   String _normalizeLine(String line) {
@@ -458,6 +472,7 @@ final class PatrolSession {
         throw StateError('No active patrol session');
       }
 
+      _quitRequested = true;
       controller.add('Q'.codeUnits);
       _testState = TestState.idle;
       _completeFinish();
@@ -481,6 +496,7 @@ final class PatrolSession {
 
       _outputs.clear();
       _testState = TestState.running;
+      _finishWarning = null;
       // Complete the old completer so any previous waiters are unblocked, then
       // immediately create a fresh one. This avoids a race where callbacks
       // could fire between null-ing and lazy re-creation in _waitForFinish.
@@ -500,6 +516,7 @@ final class PatrolSession {
       testState: _testState,
       output: _formatLogs(_outputs),
       currentTestFile: _currentTestFile,
+      warning: _finishWarning,
       deviceName: dev?.name,
       deviceId: dev?.id,
       devicePlatform: dev?.targetPlatform.name,

--- a/packages/patrol_mcp/lib/src/patrol_session.dart
+++ b/packages/patrol_mcp/lib/src/patrol_session.dart
@@ -452,6 +452,13 @@ final class PatrolSession {
     }
 
     _testState = TestState.finishedFailed;
+    // Surface the underlying error (backend threw rather than exiting cleanly)
+    // so it isn't swallowed by the generic warning below.
+    final error = result.error;
+    if (error != null) {
+      _pushOutput('ERROR: $error');
+      Logger('PatrolSession').severe('Backend exit error: $error');
+    }
     _finishWarning =
         'The app shut down before the test reported completion. This usually '
         'means the app crashed or exited early rather than a test assertion '


### PR DESCRIPTION
In develop mode `onTestsCompleted` was only fired after `attachForHotRestart` returned. When the app shut down before the tests reported completion (e.g. a crash, or "App shut down on request"), the backend exited but attach kept blocking, so MCP callers hung until their global timeout.

Now the backend future is observed independently of attach, so completion is reported as soon as it settles. On the MCP side an early shutdown is surfaced as a failed run with a warning, and the quit path is guarded so a user quit isn't misreported as a crash.

Adds a `DevelopService` regression test.