### PR TITLE
Multi-device support in patrol_mcp

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -44,7 +44,7 @@ This document describes all GitHub Actions workflows used in the Patrol project.
 | [adb prepare][adb-prepare] | PR (on adb package changes), manual | Dart 3.8 | Runs CI checks for `adb` package: tests, analyzer, formatter, and pub publish dry-run. |
 | [prepare e2e_app][prepare-e2e_app] | PR (on all changes except docs), manual | Flutter 3.38.x (stable) | Runs CI checks for E2E test app: Android builds (Windows/Linux) with ktlint, iOS builds with swift-format/clang-format and unit tests, Flutter tests, analyzer, and formatter. |
 | [patrol_gen prepare][patrol_gen-prepare] | PR (on patrol_gen changes), manual | Dart 3.8 | Runs CI checks for patrol contracts generator: analyzer and formatter. |
-| [patrol_mcp prepare][patrol_mcp-prepare] | PR (on patrol_mcp changes), manual | Dart (stable) | Smoke-tests the MCP server on Ubuntu and Windows against the newest and floor `patrol_cli` (from pub.dev): verifies it starts, handshakes, and shuts down on stdin EOF. The floor run guards against a stale `patrol_cli` constraint. |
+| [patrol_mcp prepare][patrol_mcp-prepare] | PR (on patrol_mcp changes), manual | Dart (stable) | Runs the MCP server checks on Ubuntu and Windows against the newest and floor `patrol_cli` (from pub.dev): a smoke test (starts, handshakes, shuts down on stdin EOF) and unit tests (`dart test`). The floor run guards against a stale `patrol_cli` constraint. |
 | [patrol_mcp cli-compat][patrol_mcp-cli-compat] | PR (on patrol_cli `lib/` or pubspec changes), manual | Flutter 3.38.x (stable) | Non-blocking: builds `patrol_mcp` against the PR's local `patrol_cli` and warns (annotation + job summary, never fails CI) if the barrel API it consumes broke. |
 
 ## Publishing Workflows

--- a/.github/workflows/patrol_mcp-prepare.yaml
+++ b/.github/workflows/patrol_mcp-prepare.yaml
@@ -42,3 +42,6 @@ jobs:
 
       - name: Smoke test — server starts, handshakes, and shuts down on EOF
         run: dart run tool/smoke_test.dart
+
+      - name: Unit tests
+        run: dart test

--- a/packages/patrol_mcp/.gitignore
+++ b/packages/patrol_mcp/.gitignore
@@ -1,0 +1,3 @@
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/patrol_mcp/CHANGELOG.md
+++ b/packages/patrol_mcp/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Simplified setup: the `run-patrol` wrapper script is no longer needed — point your MCP config directly at `dart run patrol_mcp`. FVM-pinned projects run develop sessions with the pinned Flutter automatically. See the README for the updated setup.
 - Run develop sessions from `PROJECT_ROOT`, so `run` works when the server's working directory differs from the project (e.g. an app in a subdirectory).
+- Multi-device support: `run` auto-selects a device (Android device > Android emulator > iOS device > iOS simulator) or accepts an optional `device` to target one, and a new `devices` tool lists attached Android/iOS devices. `PATROL_FLAGS --device` still takes precedence.
 - Fix `screenshot` and `native-tree` MCP tools failing with `error: more than one device/emulator` (Android) or capturing the wrong simulator (iOS) when multiple devices are attached. Both now target the active session's device explicitly.
 - Exit on client disconnect (stdin EOF), not just `SIGTERM`/`SIGINT`, and tear down the active develop session on shutdown so it doesn't orphan.
 - Return structured output (`structuredContent`) from `run`/`status`/`native-tree`, and reply with a clear error instead of crashing when `quit` has no active session.

--- a/packages/patrol_mcp/README.md
+++ b/packages/patrol_mcp/README.md
@@ -154,7 +154,10 @@ See [VS Code's MCP docs][vscode_mcp] for starting the server.
 
 ## Tools
 
-- `run`: Runs a test file and waits for completion.
+- `run`: Runs a test file and waits for completion. Auto-selects a device
+  (Android device > Android emulator > iOS device > iOS simulator), or pass
+  `device` to target one; `PATROL_FLAGS --device` wins.
+- `devices`: Lists attached Android/iOS devices to pass as `run`'s `device`.
 - `quit`: Gracefully stops the active session.
 - `status`: Returns session state and recent output.
 - `screenshot`: Captures screenshot from active session device.

--- a/packages/patrol_mcp/bin/patrol_mcp.dart
+++ b/packages/patrol_mcp/bin/patrol_mcp.dart
@@ -6,6 +6,10 @@ import 'package:args/args.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:mcp_dart/mcp_dart.dart';
 import 'package:path/path.dart' as p;
+import 'package:patrol_cli/patrol_cli.dart' show FlutterCommand;
+import 'package:patrol_mcp/src/device_lister.dart';
+import 'package:patrol_mcp/src/device_selection.dart';
+import 'package:patrol_mcp/src/flutter_command_resolver.dart';
 import 'package:patrol_mcp/src/native_tree_service.dart';
 import 'package:patrol_mcp/src/patrol_session.dart';
 import 'package:patrol_mcp/src/screenshot_service.dart';
@@ -53,10 +57,16 @@ Duration _parseTimeout(num? timeoutMinutes) {
 class _PatrolRunArgs {
   _PatrolRunArgs.fromJson(Map<String, dynamic> json)
     : testFile = json['testFile'] as String,
-      timeout = _parseTimeout(json['timeoutMinutes'] as num?);
+      timeout = _parseTimeout(json['timeoutMinutes'] as num?),
+      device = (json['device'] as String?)?.trim().nullIfEmpty;
 
   final String testFile;
   final Duration timeout;
+  final String? device;
+}
+
+extension on String {
+  String? get nullIfEmpty => isEmpty ? null : this;
 }
 
 /// Output schema for `run` and `status` -- a serialized [PatrolStatus].
@@ -69,6 +79,7 @@ const _sessionStatusSchema = JsonObject(
     ),
     'currentTestFile': JsonString(),
     'warning': JsonString(),
+    'deviceSelectionNote': JsonString(),
     'deviceName': JsonString(),
     'deviceId': JsonString(),
     'devicePlatform': JsonString(),
@@ -136,6 +147,7 @@ Future<int> main(List<String> args) async {
                   '- run waits for test completion.\n'
                   '- If no session is running, run starts a new session.\n'
                   '- If a session is already running, run triggers a restart for the requested test.\n'
+                  '- run auto-selects a device; to target a specific one, call devices and pass its id as run\'s "device".\n'
                   '- status is optional and mainly useful for debugging session state and recent output.\n'
                   '- native-tree is intended for native interactions and cross-app/native context inspection.',
             ),
@@ -155,6 +167,13 @@ Future<int> main(List<String> args) async {
                 ),
                 'timeoutMinutes': JsonNumber(
                   description: 'Optional timeout in minutes (default: 5)',
+                ),
+                'device': JsonString(
+                  description:
+                      'Optional device id or name to run on (from the '
+                      '`devices` tool). Omit to auto-select (Android device '
+                      '> Android emulator > iOS device > iOS simulator). A '
+                      '`--device` in PATROL_FLAGS takes precedence.',
                 ),
               },
               required: ['testFile'],
@@ -180,12 +199,55 @@ Future<int> main(List<String> args) async {
               final result = await patrolSession.startAndWait(
                 runArgs.testFile,
                 timeout: runArgs.timeout,
+                device: runArgs.device,
               );
               final status = result.toMap();
               return CallToolResult(
                 content: [TextContent(text: jsonEncode(status))],
                 structuredContent: status,
               );
+            },
+          )
+          ..registerTool(
+            'devices',
+            description:
+                'List attached devices patrol can run on (Android, iOS). Use '
+                'to resolve a device name/id to pass as `device` to run.',
+            annotations: const ToolAnnotations(title: 'List Devices'),
+            callback: (args, extra) async {
+              // Resolve Flutter the same way `run` does (FVM autodetect,
+              // `PATROL_FLUTTER_COMMAND` escape hatch) so device enumeration
+              // works in FVM projects without a global `flutter` on PATH.
+              final flutterCommand = FlutterCommandResolver()
+                  .resolve(projectRoot: projectRoot)
+                  .command;
+              try {
+                final attached = await listAttachedDevices(
+                  flutterCommand:
+                      flutterCommand ?? const FlutterCommand('flutter'),
+                );
+                final devices = [
+                  for (final d in supportedDevices(attached))
+                    {
+                      'id': d.id,
+                      'name': d.name,
+                      'platform': d.targetPlatform.name,
+                      'isEmulator': !d.real,
+                    },
+                ];
+                final payload = {'devices': devices};
+                return CallToolResult(
+                  content: [TextContent(text: jsonEncode(payload))],
+                  structuredContent: payload,
+                );
+              } catch (e) {
+                return CallToolResult(
+                  content: [
+                    TextContent(text: 'Failed to list attached devices: $e'),
+                  ],
+                  isError: true,
+                );
+              }
             },
           )
           ..registerTool(

--- a/packages/patrol_mcp/lib/src/device_lister.dart
+++ b/packages/patrol_mcp/lib/src/device_lister.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:patrol_cli/patrol_cli.dart'
+    show Device, FlutterCommand, TargetPlatform;
+
+/// Lists the devices Flutter reports as attached, by running
+/// `flutter devices --machine` as a subprocess and parsing its output.
+///
+/// Runs Flutter as a subprocess (rather than patrol_cli's in-process
+/// `DeviceFinder`) so nothing is written to this process's `stdout` — the MCP's
+/// JSON-RPC channel stays clean.
+Future<List<Device>> listAttachedDevices({
+  required FlutterCommand flutterCommand,
+}) async {
+  final result = await Process.run(flutterCommand.executable, [
+    ...flutterCommand.arguments,
+    'devices',
+    '--machine',
+  ]);
+  if (result.exitCode != 0) {
+    throw Exception(
+      'flutter devices exited with code ${result.exitCode}: ${result.stderr}',
+    );
+  }
+  return parseFlutterDevices(result.stdout as String);
+}
+
+/// Parses `flutter devices --machine` JSON into [Device]s, mirroring the
+/// mapping patrol_cli's `DeviceFinder` uses (unsupported platforms are skipped).
+List<Device> parseFlutterDevices(String machineJson) {
+  final entries = jsonDecode(machineJson) as List<dynamic>;
+  final devices = <Device>[];
+  for (final entry in entries) {
+    entry as Map<String, dynamic>;
+    final platform = _targetPlatform(entry['targetPlatform'] as String);
+    if (platform == null) {
+      continue;
+    }
+    devices.add(
+      Device(
+        name: entry['name'] as String,
+        id: entry['id'] as String,
+        targetPlatform: platform,
+        real: !(entry['emulator'] as bool),
+      ),
+    );
+  }
+  return devices;
+}
+
+/// Mirrors patrol_cli's `TargetPlatformX.fromString`, returning `null` for
+/// platforms patrol doesn't handle (instead of throwing).
+TargetPlatform? _targetPlatform(String platform) {
+  if (platform == 'ios') {
+    return TargetPlatform.iOS;
+  } else if (platform.startsWith('android-')) {
+    return TargetPlatform.android;
+  } else if (platform == 'darwin') {
+    return TargetPlatform.macOS;
+  } else if (platform == 'web-javascript') {
+    return TargetPlatform.web;
+  }
+  return null;
+}

--- a/packages/patrol_mcp/lib/src/device_selection.dart
+++ b/packages/patrol_mcp/lib/src/device_selection.dart
@@ -1,0 +1,38 @@
+import 'package:patrol_cli/patrol_cli.dart' show Device, TargetPlatform;
+
+/// Platforms `patrol develop` can run. Add [TargetPlatform.web] once web
+/// develop lands (feat/patrol-web-develop); macOS is unsupported.
+const developSupportedPlatforms = {TargetPlatform.android, TargetPlatform.iOS};
+
+/// Attached devices the MCP can run on (returned by the `devices` tool).
+List<Device> supportedDevices(List<Device> attached) => attached
+    .where((d) => developSupportedPlatforms.contains(d.targetPlatform))
+    .toList();
+
+/// The best device to run on when none is specified (see [_rank] for the
+/// order), or `null` if nothing auto-selectable is attached. Web is never
+/// auto-selected.
+Device? autoSelectDevice(List<Device> attached) {
+  final ranked =
+      attached
+          .map((d) => (device: d, rank: _rank(d)))
+          .where((e) => e.rank < _notSelectable)
+          .toList()
+        ..sort((a, b) => a.rank.compareTo(b.rank));
+
+  return ranked.isEmpty ? null : ranked.first.device;
+}
+
+const _notSelectable = 99;
+
+int _rank(Device d) {
+  // Android before iOS, physical devices before emulators/simulators.
+  // Device.real is true for physical devices, false for emulators/simulators.
+  return switch ((d.targetPlatform, d.real)) {
+    (TargetPlatform.android, true) => 0, // Android device
+    (TargetPlatform.android, false) => 1, // Android emulator
+    (TargetPlatform.iOS, true) => 2, // iOS device
+    (TargetPlatform.iOS, false) => 3, // iOS simulator
+    _ => _notSelectable, // web / macOS
+  };
+}

--- a/packages/patrol_mcp/lib/src/patrol_session.dart
+++ b/packages/patrol_mcp/lib/src/patrol_session.dart
@@ -7,6 +7,8 @@ import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:patrol_cli/patrol_cli.dart';
 
+import 'device_lister.dart';
+import 'device_selection.dart';
 import 'flutter_command_resolver.dart';
 import 'log_streaming.dart';
 
@@ -152,6 +154,7 @@ class PatrolStatus {
     required this.output,
     this.currentTestFile,
     this.warning,
+    this.deviceSelectionNote,
     this.deviceName,
     this.deviceId,
     this.devicePlatform,
@@ -162,6 +165,7 @@ class PatrolStatus {
   final String output;
   final String? currentTestFile;
   final String? warning;
+  final String? deviceSelectionNote;
   final String? deviceName;
   final String? deviceId;
   final String? devicePlatform;
@@ -173,6 +177,7 @@ class PatrolStatus {
     'testState': testState.name,
     'currentTestFile': ?currentTestFile,
     'warning': ?warning,
+    'deviceSelectionNote': ?deviceSelectionNote,
     'deviceName': ?deviceName,
     'deviceId': ?deviceId,
     'devicePlatform': ?devicePlatform,
@@ -205,6 +210,10 @@ final class PatrolSession {
   DevelopService? _developService;
   int? _testServerPort;
 
+  /// A note about device selection surfaced in the next status (e.g. which
+  /// device was auto-selected, or that a `device` argument was overridden).
+  String? _deviceSelectionNote;
+
   final _logStreaming = LogStreaming.instance;
 
   /// The device discovered by the last [startAndWait] call.
@@ -212,14 +221,21 @@ final class PatrolSession {
   int? get testServerPort => _testServerPort;
 
   /// Returns null if started successfully, or a warning message if blocked
-  Future<String?> _start(String testFile) async {
+  Future<String?> _start(String testFile, {String? device}) async {
+    _deviceSelectionNote = null;
     if (_isRunning) {
       if (_currentTestFile != testFile) {
         return 'Patrol session is already running "$_currentTestFile". '
             'Cannot start different test "$testFile". '
             'Use patrol-quit first or run the same test file.';
       }
-      // Same test file - hot restart
+      // Same test file - hot restart. The device can't change on hot restart.
+      if (device != null) {
+        _deviceSelectionNote =
+            'Device "$device" ignored: hot-restarting the running session on '
+            '${this.device?.name ?? 'the current device'}. Use patrol-quit '
+            'first to switch devices.';
+      }
       sendCommand(PatrolCommand.hotRestart);
       return null;
     }
@@ -244,11 +260,53 @@ final class PatrolSession {
     final flutterResolution = FlutterCommandResolver().resolve(
       projectRoot: resolvedCwd,
     );
+    final flutterCommand = flutterResolution.command;
 
-    final (options, globalResults) = DevelopOptions.parseArgs(
+    // First parse: see what PATROL_FLAGS already specifies.
+    final (flagOptions, globalResults) = DevelopOptions.parseArgs(
       flagParts,
       target: testFile,
-      flutterCommand: flutterResolution.command,
+      flutterCommand: flutterCommand,
+    );
+    final verbose = globalResults['verbose'] as bool? ?? false;
+
+    // Resolve the device. Precedence: PATROL_FLAGS `--device` > `device`
+    // argument > auto-selection.
+    if (flagOptions.devices.isNotEmpty) {
+      if (device != null) {
+        _deviceSelectionNote =
+            'Ignored device "$device": PATROL_FLAGS already pins '
+            '--device ${flagOptions.devices.join(', ')}.';
+      }
+    } else if (device != null) {
+      flagParts.addAll(['--device', device]);
+    } else {
+      final List<Device> attached;
+      try {
+        attached = await listAttachedDevices(
+          flutterCommand: flutterCommand ?? const FlutterCommand('flutter'),
+        );
+      } catch (e) {
+        return 'Failed to detect attached devices: $e';
+      }
+      final selected = autoSelectDevice(attached);
+      if (selected == null) {
+        return 'No Android or iOS device detected. Start an emulator or '
+            'simulator (or connect a device) and try again.';
+      }
+      flagParts.addAll(['--device', selected.id]);
+      if (supportedDevices(attached).length > 1) {
+        _deviceSelectionNote =
+            'Auto-selected ${selected.name} (${selected.id}); '
+            'pass "device" to run on a different one.';
+      }
+    }
+
+    // Final parse, now including the resolved `--device` (if any).
+    final (options, _) = DevelopOptions.parseArgs(
+      flagParts,
+      target: testFile,
+      flutterCommand: flutterCommand,
     );
 
     // Log the effective Flutter command once (to stderr via the logging sink).
@@ -272,7 +330,6 @@ final class PatrolSession {
       );
     }
     _testServerPort = options.testServerPort;
-    final verbose = globalResults['verbose'] as bool? ?? false;
 
     // Create a DisposeScope for the session lifecycle
     final disposeScope = DisposeScope();
@@ -388,6 +445,7 @@ final class PatrolSession {
     _isRunning = false;
     _currentTestFile = null;
     _testServerPort = null;
+    _deviceSelectionNote = null;
 
     await _logStreaming.stopLogging();
 
@@ -500,6 +558,7 @@ final class PatrolSession {
       testState: _testState,
       output: _formatLogs(_outputs),
       currentTestFile: _currentTestFile,
+      deviceSelectionNote: _deviceSelectionNote,
       deviceName: dev?.name,
       deviceId: dev?.id,
       devicePlatform: dev?.targetPlatform.name,
@@ -547,8 +606,9 @@ final class PatrolSession {
   Future<PatrolStatus> startAndWait(
     String testFile, {
     Duration? timeout,
+    String? device,
   }) async {
-    final warning = await _start(testFile);
+    final warning = await _start(testFile, device: device);
     if (warning != null) {
       // Return current status with warning (blocked by different test)
       final status = getStatus();
@@ -558,6 +618,7 @@ final class PatrolSession {
         output: status.output,
         currentTestFile: status.currentTestFile,
         warning: warning,
+        deviceSelectionNote: status.deviceSelectionNote,
         deviceName: status.deviceName,
         deviceId: status.deviceId,
         devicePlatform: status.devicePlatform,

--- a/packages/patrol_mcp/test/device_lister_test.dart
+++ b/packages/patrol_mcp/test/device_lister_test.dart
@@ -1,0 +1,56 @@
+import 'package:patrol_cli/patrol_cli.dart' show TargetPlatform;
+import 'package:patrol_mcp/src/device_lister.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('parseFlutterDevices', () {
+    test('maps platforms and the emulator flag, skips unsupported', () {
+      const json = '''
+[
+  {"name":"sdk gphone64 arm64","id":"emulator-5554","targetPlatform":"android-arm64","emulator":true},
+  {"name":"Pixel 7","id":"PX7","targetPlatform":"android-arm64","emulator":false},
+  {"name":"iPhone 17 Pro","id":"ABC-123","targetPlatform":"ios","emulator":true},
+  {"name":"macOS","id":"macos","targetPlatform":"darwin","emulator":false},
+  {"name":"Chrome","id":"chrome","targetPlatform":"web-javascript","emulator":false},
+  {"name":"Fuchsia","id":"fx","targetPlatform":"fuchsia-x64","emulator":false}
+]''';
+
+      final devices = parseFlutterDevices(json);
+
+      // Fuchsia is dropped; the other five are kept.
+      expect(devices.map((d) => d.id), [
+        'emulator-5554',
+        'PX7',
+        'ABC-123',
+        'macos',
+        'chrome',
+      ]);
+
+      final android = devices.firstWhere((d) => d.id == 'emulator-5554');
+      expect(android.name, 'sdk gphone64 arm64');
+      expect(android.targetPlatform, TargetPlatform.android);
+      expect(android.real, isFalse); // emulator -> not real
+
+      expect(
+        devices.firstWhere((d) => d.id == 'PX7').real,
+        isTrue, // physical device
+      );
+      expect(
+        devices.firstWhere((d) => d.id == 'ABC-123').targetPlatform,
+        TargetPlatform.iOS,
+      );
+      expect(
+        devices.firstWhere((d) => d.id == 'macos').targetPlatform,
+        TargetPlatform.macOS,
+      );
+      expect(
+        devices.firstWhere((d) => d.id == 'chrome').targetPlatform,
+        TargetPlatform.web,
+      );
+    });
+
+    test('empty list in, empty list out', () {
+      expect(parseFlutterDevices('[]'), isEmpty);
+    });
+  });
+}

--- a/packages/patrol_mcp/test/device_selection_test.dart
+++ b/packages/patrol_mcp/test/device_selection_test.dart
@@ -1,0 +1,61 @@
+import 'package:patrol_cli/patrol_cli.dart' show Device, TargetPlatform;
+import 'package:patrol_mcp/src/device_selection.dart';
+import 'package:test/test.dart';
+
+Device _device(String id, TargetPlatform platform, {required bool emulator}) =>
+    Device(name: id, id: id, targetPlatform: platform, real: !emulator);
+
+void main() {
+  final androidEmu = _device(
+    'android-emu',
+    TargetPlatform.android,
+    emulator: true,
+  );
+  final androidReal = _device(
+    'android-real',
+    TargetPlatform.android,
+    emulator: false,
+  );
+  final iosSim = _device('ios-sim', TargetPlatform.iOS, emulator: true);
+  final iosReal = _device('ios-real', TargetPlatform.iOS, emulator: false);
+  final web = _device('chrome', TargetPlatform.web, emulator: false);
+  final macos = _device('macos', TargetPlatform.macOS, emulator: false);
+
+  group('supportedDevices', () {
+    test('keeps Android and iOS, drops web and macOS', () {
+      final result = supportedDevices([androidEmu, iosSim, web, macos]);
+      expect(result, [androidEmu, iosSim]);
+    });
+
+    test('empty in, empty out', () {
+      expect(supportedDevices([]), isEmpty);
+    });
+  });
+
+  group('autoSelectDevice', () {
+    test('ranks Android device > Android emu > iOS device > iOS sim', () {
+      // Shuffled input; expect the ranking order regardless.
+      expect(
+        autoSelectDevice([iosSim, iosReal, androidEmu, androidReal]),
+        androidReal,
+      );
+      expect(autoSelectDevice([iosSim, iosReal, androidEmu]), androidEmu);
+      expect(autoSelectDevice([iosSim, iosReal]), iosReal);
+      expect(autoSelectDevice([iosSim]), iosSim);
+    });
+
+    test('picks the only attached device', () {
+      expect(autoSelectDevice([iosSim]), iosSim);
+    });
+
+    test('never auto-selects web or macOS', () {
+      expect(autoSelectDevice([web, macos]), isNull);
+      // With a mobile device present, web/macOS are ignored.
+      expect(autoSelectDevice([web, iosSim, macos]), iosSim);
+    });
+
+    test('returns null when nothing is attached', () {
+      expect(autoSelectDevice([]), isNull);
+    });
+  });
+}

--- a/packages/patrol_mcp/test/flutter_command_resolver_test.dart
+++ b/packages/patrol_mcp/test/flutter_command_resolver_test.dart
@@ -21,7 +21,10 @@ void main() {
     String join(String dir, String a, [String? b]) =>
         b == null ? p.join(dir, a) : p.join(dir, a, b);
 
-    const root = '/repo/app';
+    // Canonicalized so the literals match what the resolver computes: it
+    // canonicalizes projectRoot, which on Windows also prepends a drive letter.
+    final root = p.canonicalize('/repo/app');
+    final repo = p.canonicalize('/repo');
 
     test('PATROL_FLUTTER_COMMAND takes precedence over FVM detection', () {
       final r = resolver(
@@ -82,11 +85,11 @@ void main() {
 
     test('detects a pin in an ancestor directory', () {
       final r = resolver(
-        existing: {join('/repo', '.fvmrc')},
+        existing: {join(repo, '.fvmrc')},
       ).resolve(projectRoot: root);
 
       expect(r.command!.executable, 'fvm');
-      expect(r.reason, contains('/repo'));
+      expect(r.reason, contains(repo));
     });
 
     test(
@@ -132,7 +135,7 @@ void main() {
       // .git marks /repo/app as the repo root; the pin one level up must not
       // be picked up.
       final r = resolver(
-        existing: {join(root, '.git'), join('/repo', '.fvmrc')},
+        existing: {join(root, '.git'), join(repo, '.fvmrc')},
       ).resolve(projectRoot: root);
 
       expect(r.command, isNull);


### PR DESCRIPTION
Multi-device support for `patrol_mcp`: `run` auto-selects a device (Android device > Android emulator > iOS device > iOS simulator) or accepts an optional `device` to target one, and a new `devices` tool lists attached Android/iOS devices. `PATROL_FLAGS --device` still takes precedence. Web is intentionally excluded for now (one line to enable once web develop lands).

Devices are listed by running `flutter devices --machine` as a subprocess and parsing its output, so this needs **no new `patrol_cli` API** and nothing leaks to the MCP's JSON-RPC stdout channel.

**No `patrol_cli` release or constraint bump required** — it resolves against the currently published `patrol_cli` (uses only the already-exported `Device`/`TargetPlatform`). Standalone MCP PR.
