### PR TITLE
Announce Swift Package Manager support in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can find out more below:
 
 > [!NOTE] 
 > **Patrol 4.7.0 adds Swift Package Manager support for iOS and macOS!** 
-> If you migrate your project to SPM, a few small setup changes are needed — see the [iOS setup][docs_ios_setup_spm] guides for details.
+> If you migrate your project to SPM, a few small setup changes are needed — see the [iOS setup][docs_ios_setup_spm] guide for details.
 
 ## Patrol custom finders
 
@@ -235,7 +235,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 [github_workflows]: https://github.com/leancodepl/patrol/blob/master/.github/WORKFLOWS.md
 [docs]: https://patrol.leancode.co/?utm_source=github.com&utm_medium=referral&utm_campaign=patrol-readme
 [docs_finders]: https://patrol.leancode.co/finders/overview
-[docs_ios_setup_spm]: https://patrol.leancode.co/documentation#ios-setup-configure-runner-uitests?utm_source=github.com&utm_medium=referral&utm_campaign=patrol-readme#ios-setup
+[docs_ios_setup_spm]: https://patrol.leancode.co/documentation?utm_source=github.com&utm_medium=referral&utm_campaign=patrol-readme#ios-setup-configure-runner-uitests
 [promo_graphics]: assets/promo_banner.png
 [article_web]: https://leancode.co/blog/patrol-web-support?utm_source=github.com&utm_medium=referral&utm_campaign=patrol-readme
 [article_4x]: https://leancode.co/blog/patrol-4-0-release?utm_source=github.com&utm_medium=referral&utm_campaign=patrol-readme

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ You can find out more below:
 - 🚀  [Automate Flutter app testing with Patrol][automate_flutter_app_testing_with_patrol]
 - 🚀  [Patrol Setup & Patrol Training][patrol_setup_and_training]
 
+> [!NOTE] 
+> **Patrol 4.7.0 adds Swift Package Manager support for iOS and macOS!** 
+> If you migrate your project to SPM, a few small setup changes are needed — see the [iOS setup][docs_ios_setup_spm] guides for details.
+
 ## Patrol custom finders
 
 Flutter's finders are powerful, but not very intuitive to use.
@@ -231,6 +235,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 [github_workflows]: https://github.com/leancodepl/patrol/blob/master/.github/WORKFLOWS.md
 [docs]: https://patrol.leancode.co/?utm_source=github.com&utm_medium=referral&utm_campaign=patrol-readme
 [docs_finders]: https://patrol.leancode.co/finders/overview
+[docs_ios_setup_spm]: https://patrol.leancode.co/documentation#ios-setup-configure-runner-uitests?utm_source=github.com&utm_medium=referral&utm_campaign=patrol-readme#ios-setup
 [promo_graphics]: assets/promo_banner.png
 [article_web]: https://leancode.co/blog/patrol-web-support?utm_source=github.com&utm_medium=referral&utm_campaign=patrol-readme
 [article_4x]: https://leancode.co/blog/patrol-4-0-release?utm_source=github.com&utm_medium=referral&utm_campaign=patrol-readme

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -6,6 +6,7 @@
     "overview/getting-started",
     "external:[LeanCode](https://leancode.co)",
     "---Announcements---",
+    "spm-announcement",
     "patrol-mcp-announcement",
     "v4",
     "native-to-platform-migration",

--- a/docs/spm-announcement.mdx
+++ b/docs/spm-announcement.mdx
@@ -1,0 +1,13 @@
+---
+title: Swift Package Manager support is here!
+hidePrevious: true
+---
+
+Starting with Patrol 4.7.0 and Patrol CLI 4.5.0, Patrol supports Swift Package Manager (SPM) on iOS and macOS, integrating with [Flutter's native SPM support](https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers). CocoaPods remains fully supported for projects that haven't migrated yet.
+
+If you switch your project to SPM, a few small changes to the Patrol setup are needed — most notably adding `FlutterGeneratedPluginSwiftPackage` to the `RunnerUITests` target. Everything is described in the updated setup guide:
+
+ - [SPM configuration step in the iOS setup](/documentation#ios-setup-configure-runner-uitests)
+ - [Swift Package Manager support PR on GitHub](https://github.com/leancodepl/patrol/pull/2976)
+
+If you have any questions or want to submit feedback, head on to [GitHub](https://github.com/leancodepl/patrol) or [our Discord server](https://discord.gg/ukBK5t4EZg).

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.7.1
+
+- Add a Swift Package Manager support note to the README.
+
 ## 4.7.0
 
 - Add Swift Package Manager (SPM) support for iOS and macOS. CocoaPods remains supported for projects that have not migrated to SPM.

--- a/packages/patrol/README.md
+++ b/packages/patrol/README.md
@@ -33,6 +33,9 @@ You can find out more below:
 - 🚀  [Automate Flutter app testing with Patrol][automate_flutter_app_testing_with_patrol]
 - 🚀  [Patrol Setup & Patrol Training][patrol_setup_and_training]
 
+> **Patrol 4.7.0 adds Swift Package Manager support for iOS and macOS!**
+> If you migrate your project to SPM, a few small setup changes are needed — see the [iOS setup][docs_ios_setup_spm] guide for details.
+
 ## Patrol
 
 `patrol` package builds on top of `flutter_test` and `integration_test` to make
@@ -176,6 +179,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 [patrol_github_link]: https://github.com/leancodepl/patrol
 [patrol_discord_link]: https://discord.gg/ukBK5t4EZg
 [docs]: https://patrol.leancode.co/?utm_source=github.com&utm_medium=referral&utm_campaign=patrol-readme
+[docs_ios_setup_spm]: https://patrol.leancode.co/documentation?utm_source=github.com&utm_medium=referral&utm_campaign=patrol-readme#ios-setup-configure-runner-uitests
 [docs_setup]: https://patrol.leancode.co/documentation?utm_source=github.com&utm_medium=referral&utm_campaign=patrol-readme
 [docs_finders]: https://patrol.leancode.co/finders/overview
 [promo_graphics]: ../../assets/promo_banner.png

--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -2,7 +2,7 @@ name: patrol
 description: >
   A powerful, multiplatform E2E UI testing framework for Flutter apps that
   overcomes the limitations of integration_test by handling native interactions.
-version: 4.7.0
+version: 4.7.1
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.5.1
+
+- Add a Swift Package Manager support note to the README.
+
 ## 4.5.0
 
 - Add `-weak_framework XCTest` linker flags to iOS and macOS `build-for-testing` to support Swift Package Manager integration.

--- a/packages/patrol_cli/README.md
+++ b/packages/patrol_cli/README.md
@@ -126,7 +126,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 [patrol_github_link]: https://github.com/leancodepl/patrol
 [patrol_discord_link]: https://discord.gg/ukBK5t4EZg
 [docs]: https://patrol.leancode.co
-[docs_ios_setup_spm]: https://patrol.leancode.co/documentation#ios-setup-configure-runner-uitests
+[docs_ios_setup_spm]: https://patrol.leancode.co/documentation?utm_source=github.com&utm_medium=referral&utm_campaign=patrol-readme#ios-setup-configure-runner-uitests
 [docs_finders]: https://patrol.leancode.co/finders/overview
 [promo_graphics]: ../../assets/promo_banner.png
 [article_web]: https://leancode.co/blog/patrol-web-support

--- a/packages/patrol_cli/README.md
+++ b/packages/patrol_cli/README.md
@@ -22,6 +22,9 @@ Learn more about Patrol:
 - [Simplifying Flutter Web Testing: Patrol Web][article_web]
 - [Patrol VS Code Extension - A Better Way to Run and Debug Flutter UI Tests][article_vscode]
 
+> **Patrol 4.7.0 adds Swift Package Manager support for iOS and macOS!**
+> If you migrate your project to SPM, a few small setup changes are needed — see the [iOS setup][docs_ios_setup_spm] guide for details.
+
 ## Patrol CLI
 
 Command-line tool to run and debug tests written with [`patrol`][patrol_link] framework.
@@ -123,6 +126,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 [patrol_github_link]: https://github.com/leancodepl/patrol
 [patrol_discord_link]: https://discord.gg/ukBK5t4EZg
 [docs]: https://patrol.leancode.co
+[docs_ios_setup_spm]: https://patrol.leancode.co/documentation#ios-setup-configure-runner-uitests
 [docs_finders]: https://patrol.leancode.co/finders/overview
 [promo_graphics]: ../../assets/promo_banner.png
 [article_web]: https://leancode.co/blog/patrol-web-support

--- a/packages/patrol_cli/lib/src/base/constants.dart
+++ b/packages/patrol_cli/lib/src/base/constants.dart
@@ -1,3 +1,3 @@
 /// Version of Patrol CLI. Must be kept in sync with pubspec.yaml.
 /// If you update this, make sure that compatibility-table.mdx is updated (if needed)
-const version = '4.5.0';
+const version = '4.5.1';

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: patrol_cli
 description: >
   Command-line tool for Patrol, a powerful Flutter-native UI testing framework.
-version: 4.5.0  # Must be kept in sync with constants.dart
+version: 4.5.1  # Must be kept in sync with constants.dart
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol_cli
 issue_tracker: https://github.com/leancodepl/patrol/issues?q=is%3Aopen+is%3Aissue+label%3A%22package%3A+patrol_cli%22


### PR DESCRIPTION
## What changed

Announces the Swift Package Manager support that shipped in patrol 4.7.0 / patrol_cli 4.5.0 (#2976):

- **README**: a note near the top highlighting SPM support, linking directly to the SPM configuration step in the iOS setup guide.
- **Docs**: a new announcement page `docs/spm-announcement.mdx` ("Swift Package Manager support is here!"), modeled on the Patrol MCP announcement, added at the top of the Announcements section in `docs/meta.json`.

## Notes for reviewers

- The links use the deep-link anchors added in #3161 (`#ios-setup-configure-runner-uitests`), which auto-expand the accordion and scroll to the step.
- The README link keeps the repo's UTM-parameter convention; query string before the `#fragment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)