### PR TITLE
docs: align macOS Configure Runner UITests step with iOS setup

### DIFF
--- a/docs/documentation/index.mdx
+++ b/docs/documentation/index.mdx
@@ -549,22 +549,45 @@ Check out our video version of this tutorial on YouTube!
           @import patrol;
           @import ObjectiveC.runtime;
 
+          #if !defined(PATROL_INTEGRATION_TEST_MACOS_RUNNER)
+          #import "PatrolIntegrationTestMacosRunner.h"
+          #endif
+
           PATROL_INTEGRATION_TEST_MACOS_RUNNER(RunnerUITests)
           ```
 
-          Add the newly created target to `macos/Podfile` by embedding in the existing
-          `Runner` target.
+          <Tabs
+            defaultIndex={0}
+            items={['CocoaPods', 'Swift Package Manager']}
+          >
+            <Tab value="CocoaPods">
+              Add the newly created target to `macos/Podfile` by embedding in the existing
+              `Runner` target.
 
-          ```ruby title="macos/Podfile"
-          target 'Runner' do
-            # Do not change existing lines.
-            ...
+              ```ruby title="macos/Podfile"
+              target 'Runner' do
+                # Do not change existing lines.
+                ...
 
-            target 'RunnerUITests' do
-              inherit! :complete
-            end
-          end
-          ```
+                target 'RunnerUITests' do
+                  inherit! :complete
+                end
+              end
+              ```
+            </Tab>
+            <Tab value="Swift Package Manager">
+              If you haven't yet migrated your project to Swift Package Manager, follow the Flutter docs for
+              [integrating SPM with your app](https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers).
+
+              <Info>Following the Flutter docs will allow you to run or build the app itself (Runner target) but we still need to do some configuration for Patrol tests (RunnerUITests target).</Info>
+
+              To add the `FlutterGeneratedPluginSwiftPackage` to the **RunnerUITests**
+              target, in Xcode go to **RunnerUITests > General > Frameworks and Libraries**,
+              click **+**, and select `FlutterGeneratedPluginSwiftPackage`.
+
+              ![Xcode RunnerUITests Frameworks and Libraries](/assets/ios_spm_frameworks.png)
+            </Tab>
+          </Tabs>
         </Step>
 
         <Step id="build-macos-config">
@@ -576,7 +599,7 @@ Check out our video version of this tutorial on YouTube!
         </Step>
 
         <Step id="pod-install">
-          Go to your `macos` directory and run:
+           **(CocoaPods only)** Go to your `macos` directory and run:
 
           ```
           pod install --repo-update

--- a/docs/spm-announcement.mdx
+++ b/docs/spm-announcement.mdx
@@ -8,6 +8,7 @@ Starting with Patrol 4.7.0 and Patrol CLI 4.5.0, Patrol supports Swift Package M
 If you switch your project to SPM, a few small changes to the Patrol setup are needed — most notably adding `FlutterGeneratedPluginSwiftPackage` to the `RunnerUITests` target. Everything is described in the updated setup guide:
 
  - [SPM configuration step in the iOS setup](/documentation#ios-setup-configure-runner-uitests)
+ - [SPM configuration step in the macOS setup](/documentation#macos-setup-configure-runner-uitests)
  - [Swift Package Manager support PR on GitHub](https://github.com/leancodepl/patrol/pull/2976)
 
 If you have any questions or want to submit feedback, head on to [GitHub](https://github.com/leancodepl/patrol) or [our Discord server](https://discord.gg/ukBK5t4EZg).


### PR DESCRIPTION
## Summary

Makes the macOS setup's **Configure Runner UITests** step match the iOS one (https://patrol.leancode.co/documentation#ios-setup-configure-runner-uitests):

- Add the `#if !defined(PATROL_INTEGRATION_TEST_MACOS_RUNNER)` / `#import "PatrolIntegrationTestMacosRunner.h"` fallback to the `RunnerUITests.m` snippet, mirroring the iOS guard (the header exists in the patrol package alongside the iOS one).
- Move the Podfile instructions into a **CocoaPods** tab and add a **Swift Package Manager** tab, same as iOS — SPM on macOS is supported since Patrol 4.7.0.
- Mark the subsequent `pod install` step as **(CocoaPods only)**, consistent with the iOS section.

Note: the SPM tab reuses the iOS screenshot (`ios_spm_frameworks.png`) since the Xcode UI is identical and no macOS-specific asset exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)