### PR TITLE
Add findAttachedDevices to DevelopSessionFactory

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Download only Chromium instead of all default Playwright browsers during web runner setup. (#3156)
+- Add `DevelopSessionFactory.findAttachedDevices` to enumerate attached devices, so non-CLI callers (e.g. `patrol_mcp`) can list devices without building a `DeviceFinder` themselves.
 
 ## 4.5.1
 

--- a/packages/patrol_cli/lib/src/commands/develop_session_factory.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_session_factory.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' as io;
 
 import 'package:adb/adb.dart';
 import 'package:dispose_scope/dispose_scope.dart';
@@ -13,6 +14,7 @@ import 'package:patrol_cli/src/devices.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
 import 'package:patrol_cli/src/macos/macos_test_backend.dart' hide BuildMode;
 import 'package:patrol_cli/src/pubspec_reader.dart';
+import 'package:patrol_cli/src/runner/flutter_command.dart';
 import 'package:patrol_cli/src/test_bundler.dart';
 import 'package:patrol_cli/src/test_finder.dart';
 import 'package:patrol_cli/src/web/web_test_backend.dart';
@@ -113,5 +115,28 @@ class DevelopSessionFactory {
       onTestsCompleted: onTestsCompleted,
       onLogEntry: onLogEntry,
     );
+  }
+
+  /// Devices Flutter reports as attached (Android, iOS, macOS, web), unfiltered.
+  ///
+  /// Exposed for non-CLI callers (e.g. the MCP). Logger output is redirected to
+  /// stderr because [Logger] writes to `stdout` — the MCP's JSON-RPC channel.
+  static Future<List<Device>> findAttachedDevices({
+    required FlutterCommand flutterCommand,
+    bool verbose = false,
+  }) async {
+    final disposeScope = DisposeScope();
+    try {
+      return await io.IOOverrides.runZoned(() {
+        final deviceFinder = DeviceFinder(
+          processManager: const LocalProcessManager(),
+          parentDisposeScope: disposeScope,
+          logger: Logger(level: verbose ? Level.verbose : Level.info),
+        );
+        return deviceFinder.getAttachedDevices(flutterCommand: flutterCommand);
+      }, stdout: () => io.stderr);
+    } finally {
+      await disposeScope.dispose();
+    }
   }
 }

--- a/packages/patrol_cli/lib/src/commands/develop_session_factory.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_session_factory.dart
@@ -119,22 +119,34 @@ class DevelopSessionFactory {
 
   /// Devices Flutter reports as attached (Android, iOS, macOS, web), unfiltered.
   ///
-  /// Exposed for non-CLI callers (e.g. the MCP). Logger output is redirected to
-  /// stderr because [Logger] writes to `stdout` — the MCP's JSON-RPC channel.
+  /// Exposed for non-CLI callers (e.g. the MCP). All console output is redirected
+  /// to stderr so nothing leaks to `stdout` — the MCP's JSON-RPC channel: the
+  /// [Logger] writes to `io.stdout` (covered by [io.IOOverrides]), and any stray
+  /// `print` is redirected via the zone's `print` handler.
   static Future<List<Device>> findAttachedDevices({
     required FlutterCommand flutterCommand,
     bool verbose = false,
   }) async {
     final disposeScope = DisposeScope();
     try {
-      return await io.IOOverrides.runZoned(() {
-        final deviceFinder = DeviceFinder(
-          processManager: const LocalProcessManager(),
-          parentDisposeScope: disposeScope,
-          logger: Logger(level: verbose ? Level.verbose : Level.info),
-        );
-        return deviceFinder.getAttachedDevices(flutterCommand: flutterCommand);
-      }, stdout: () => io.stderr);
+      return await io.IOOverrides.runZoned(
+        () => runZoned(
+          () {
+            final deviceFinder = DeviceFinder(
+              processManager: const LocalProcessManager(),
+              parentDisposeScope: disposeScope,
+              logger: Logger(level: verbose ? Level.verbose : Level.info),
+            );
+            return deviceFinder.getAttachedDevices(
+              flutterCommand: flutterCommand,
+            );
+          },
+          zoneSpecification: ZoneSpecification(
+            print: (_, _, _, line) => io.stderr.writeln(line),
+          ),
+        ),
+        stdout: () => io.stderr,
+      );
     } finally {
       await disposeScope.dispose();
     }


### PR DESCRIPTION
Adds `DevelopSessionFactory.findAttachedDevices`, a static helper that lists the devices Flutter reports as attached (Android, iOS, macOS, web) for non-CLI callers, redirecting `Logger` output to `stderr`. Pure additive change — no effect on existing `patrol` commands.

Groundwork for multi-device support in `patrol_mcp` (#3162), which lands in a separate PR. Split out so `patrol_cli` can be released with this API first, then `patrol_mcp` bumps its constraint to it.
