### PR TITLE
Skip device discovery for chrome in `patrol test`

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Download only Chromium instead of all default Playwright browsers during web runner setup. (#3156)
+- Fix `patrol test -d chrome` failing with `No devices attached` on machines without a system Chrome installation. (#3172)
 
 ## 4.5.1
 

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -153,10 +153,16 @@ class TestCommand extends PatrolCommand {
       _logger.detail('Received build number: $buildNumber');
     }
 
-    final devices = await _deviceFinder.find(
-      stringsArg('device'),
-      flutterCommand: flutterCommand,
-    );
+    final wantDevices = stringsArg('device');
+    final bundledDevice = switch (wantDevices) {
+      [final name] => Device.bundledForTest(name),
+      _ => null,
+    };
+
+    final devices = bundledDevice != null
+        ? [bundledDevice]
+        : await _deviceFinder.find(wantDevices, flutterCommand: flutterCommand);
+
     _logger.detail('Received ${devices.length} device(s) to run on');
     for (final device in devices) {
       _logger.detail('Received device: ${device.name} (${device.id})');

--- a/packages/patrol_cli/lib/src/devices.dart
+++ b/packages/patrol_cli/lib/src/devices.dart
@@ -224,6 +224,12 @@ class Device {
     required this.real,
   });
 
+  /// The [Device] that `patrol test` bundles for [name], letting the caller
+  /// skip looking up a matching real device. Returns null if [name] isn't
+  /// bundled for `patrol test`.
+  static Device? bundledForTest(String name) =>
+      _testBundledDevices[name.trim().toLowerCase()];
+
   final String name;
   final String id;
   final TargetPlatform targetPlatform;
@@ -259,6 +265,15 @@ class Device {
     }
   }
 }
+
+const _testBundledDevices = {
+  'chrome': Device(
+    name: 'Chrome',
+    id: 'chrome',
+    targetPlatform: TargetPlatform.web,
+    real: true,
+  ),
+};
 
 enum TargetPlatform { iOS, android, macOS, web }
 

--- a/packages/patrol_cli/test/general/devices_test.dart
+++ b/packages/patrol_cli/test/general/devices_test.dart
@@ -151,10 +151,18 @@ void main() {
     test('returns a synthetic web device for chrome', () {
       final device = Device.bundledForTest('chrome');
 
-      expect(device, isNotNull);
-      expect(device!.targetPlatform, TargetPlatform.web);
-      expect(device.id, 'chrome');
-      expect(device.real, true);
+      expect(
+        device,
+        isA<Device>()
+            .having((d) => d.name, 'name', 'Chrome')
+            .having((d) => d.id, 'id', 'chrome')
+            .having(
+              (d) => d.targetPlatform,
+              'targetPlatform',
+              TargetPlatform.web,
+            )
+            .having((d) => d.real, 'real', true),
+      );
     });
 
     test('is case-insensitive and trims whitespace', () {

--- a/packages/patrol_cli/test/general/devices_test.dart
+++ b/packages/patrol_cli/test/general/devices_test.dart
@@ -146,4 +146,23 @@ void main() {
       expect(devicesToUse, [iosDevice]);
     });
   });
+
+  group('Device.bundledForTest()', () {
+    test('returns a synthetic web device for chrome', () {
+      final device = Device.bundledForTest('chrome');
+
+      expect(device, isNotNull);
+      expect(device!.targetPlatform, TargetPlatform.web);
+      expect(device.id, 'chrome');
+      expect(device.real, true);
+    });
+
+    test('is case-insensitive and trims whitespace', () {
+      expect(Device.bundledForTest(' Chrome '), isNotNull);
+    });
+
+    test('returns null for a device that is not bundled', () {
+      expect(Device.bundledForTest('emulator-5554'), isNull);
+    });
+  });
 }


### PR DESCRIPTION
Fixes #3172 by skipping the device finder in `patrol test` when the selected device is `chrome`. The web runner provides its own Chromium installation, which is invisible to the `flutter devices`. `patrol develop` wasn't touched