### PR TITLE
Add web coverage support

### DIFF
--- a/docs/cli-commands/test.mdx
+++ b/docs/cli-commands/test.mdx
@@ -113,6 +113,12 @@ patrol test --exclude-tags='(android||ios)'
         Coverage collection is currently not supported on macOS.
 </Warning>
 
+<Warning>
+    A debug build is required. Coverage relies on the Dart VM Service (mobile)
+    or DDC source maps (web), which are only available in debug builds, so
+    `--profile` and `--release` are not supported with `--coverage`.
+</Warning>
+
 To collect coverage from patrol tests, use `--coverage`.
 
 ```
@@ -138,10 +144,6 @@ Web coverage is collected differently from other platforms, so a couple of thing
 - The covered-line set may differ slightly from the same code measured on mobile.
 
 The report format is otherwise identical.
-
-<Warning>
-    A debug build is required. `--profile` and `--release` are not supported with `--coverage` on the web.
-</Warning>
 
 ### Build versioning
 

--- a/docs/cli-commands/test.mdx
+++ b/docs/cli-commands/test.mdx
@@ -130,6 +130,19 @@ patrol test --coverage --coverage-ignore="**/*.g.dart"
 
 excludes all files ending with `.g.dart`.
 
+#### Coverage on the web
+
+Web coverage is collected differently from other platforms, so a couple of things differ:
+
+- Lines are reported as covered or uncovered only, without the per-line hit counts available on other platforms.
+- The covered-line set may differ slightly from the same code measured on mobile.
+
+The report format is otherwise identical.
+
+<Warning>
+    A debug build is required. `--profile` and `--release` are not supported with `--coverage` on the web.
+</Warning>
+
 ### Build versioning
 
 You can specify custom build number and build name using the `--build-name` and `--build-number` flags. These work

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fix `AndroidNativeView.visibleBounds` always having zero height. (#3202)
+- Collect Chrome JavaScript coverage in the web runner when `patrol test --coverage` runs on the web platform.
 
 ## 4.8.0
 

--- a/packages/patrol/web_runner/tests/coverage.ts
+++ b/packages/patrol/web_runner/tests/coverage.ts
@@ -1,0 +1,88 @@
+import * as fs from "node:fs/promises"
+import * as path from "path"
+import { Page, TestInfo } from "@playwright/test"
+import { logger } from "./logger"
+
+// Set by patrol_cli for `patrol test --coverage` on web. When present, raw V8
+// coverage (plus source maps) is written here as one JSON file per test, which
+// the CLI later converts into an LCOV report.
+const coverageDir = process.env.PATROL_COVERAGE_DIR
+
+export async function startCoverage(page: Page): Promise<void> {
+  if (!coverageDir) {
+    return
+  }
+
+  try {
+    // resetOnNavigation: false keeps initial-load coverage across navigation.
+    await page.coverage.startJSCoverage({ resetOnNavigation: false })
+  } catch (error) {
+    logger.error(`Failed to start JS coverage collection: ${error}`)
+  }
+}
+
+export async function stopAndSaveCoverage(page: Page, testInfo: TestInfo): Promise<void> {
+  if (!coverageDir) {
+    return
+  }
+
+  try {
+    const entries = await page.coverage.stopJSCoverage()
+
+    const scripts: CoverageScriptEntry[] = (
+      await Promise.all(
+        entries.map(async ({ url, scriptId, source, functions }) => {
+          if (!url || !source) {
+            return null
+          }
+
+          const sourceMap = await fetchSourceMap(page, url, source)
+
+          return sourceMap ? { url, scriptId, source, sourceMap, functions } : null
+        }),
+      )
+    ).filter(s => !!s)
+
+    if (scripts.length === 0) {
+      logger.warn(`No source-mapped scripts in JS coverage for test "${testInfo.title}"`)
+      return
+    }
+
+    await fs.mkdir(coverageDir, { recursive: true })
+    // testId is stable across retries, so a retry overwrites the failed
+    // attempt instead of double-counting.
+    await fs.writeFile(path.join(coverageDir, `${testInfo.testId}.json`), JSON.stringify({ entries: scripts }))
+  } catch (error) {
+    logger.error(`Failed to collect JS coverage: ${error}`)
+  }
+}
+
+type CoverageScriptEntry = {
+  url: string
+  scriptId: string
+  source: string
+  sourceMap: string
+  functions: unknown
+}
+
+async function fetchSourceMap(page: Page, scriptUrl: string, source: string): Promise<string | null> {
+  // The last sourceMappingURL comment wins, matching browser behavior. Anchored
+  // to the line so a `sourceMappingURL=` inside a string literal can't false-match.
+  const matches = [...source.matchAll(/^[ \t]*\/\/[#@][ \t]*sourceMappingURL=(\S+)[ \t]*$/gm)]
+  const mapUrl = matches.at(-1)?.[1]
+  if (!mapUrl) {
+    return null
+  }
+
+  try {
+    if (mapUrl.startsWith("data:")) {
+      const response = await fetch(mapUrl)
+      return response.ok ? await response.text() : null
+    }
+
+    const response = await page.request.get(new URL(mapUrl, scriptUrl).toString())
+    return response.ok() ? await response.text() : null
+  } catch {
+    return null
+  }
+}

--- a/packages/patrol/web_runner/tests/coverage.ts
+++ b/packages/patrol/web_runner/tests/coverage.ts
@@ -6,7 +6,7 @@ import { logger } from "./logger"
 // Set by patrol_cli for `patrol test --coverage` on web. When present, raw V8
 // coverage (plus source maps) is written here as one JSON file per test, which
 // the CLI later converts into an LCOV report.
-const coverageDir = process.env.PATROL_COVERAGE_DIR
+const coverageDir = process.env.PATROL_WEB_COVERAGE_DIR
 
 export async function startCoverage(page: Page): Promise<void> {
   if (!coverageDir) {

--- a/packages/patrol/web_runner/tests/test.spec.ts
+++ b/packages/patrol/web_runner/tests/test.spec.ts
@@ -1,4 +1,5 @@
 import { test as base } from "@playwright/test"
+import { startCoverage, stopAndSaveCoverage } from "./coverage"
 import { initialise } from "./initialise"
 import { logger } from "./logger"
 import { PageManager } from "./pageManager"
@@ -11,7 +12,7 @@ if (tests.length === 0) {
 }
 
 export const patrolTest = base.extend({
-  page: async ({ page, context }, use) => {
+  page: async ({ page, context }, use, testInfo) => {
     page.on("console", message => {
       const text = message.text()
       if (text.startsWith("PATROL_LOG")) {
@@ -24,6 +25,8 @@ export const patrolTest = base.extend({
       console.log(`Playwright: ${text}`)
     })
 
+    await startCoverage(page)
+
     await page.goto("/", { waitUntil: "load" })
 
     const pageManager = new PageManager(context, page)
@@ -32,6 +35,8 @@ export const patrolTest = base.extend({
     await initialise(page)
 
     await use(page)
+
+    await stopAndSaveCoverage(page, testInfo)
 
     // Teardown: close all secondary pages (not the initial one)
     for (const p of context.pages()) {

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -33,6 +33,7 @@
   - `--web-accept-downloads`
 - Convert `--web-headless` to a flag. Use `--web-headless`/`--no-web-headless` instead of `--web-headless true/false`. The old syntax still works, but is deprecated and will be removed in a future release. (#3155)
 - Fix `--web-*` options being silently overridden by a same-named variable already set in the host shell environment when running web tests. (#3155)
+- Add `patrol test --coverage` support for the web platform, producing the same `coverage/patrol_lcov.info` report as mobile. Requires a debug build (the default); Chromium only.
 
 ## 4.5.1
 

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -7,7 +7,9 @@ import 'package:patrol_cli/src/base/extensions/core.dart';
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/commands/dart_define_utils.dart';
 import 'package:patrol_cli/src/compatibility_checker/compatibility_checker.dart';
+import 'package:patrol_cli/src/coverage/coverage_mode.dart';
 import 'package:patrol_cli/src/coverage/coverage_tool.dart';
+import 'package:patrol_cli/src/coverage/web_coverage_tool.dart';
 import 'package:patrol_cli/src/crossplatform/app_options.dart';
 import 'package:patrol_cli/src/crossplatform/video_recording_config.dart';
 import 'package:patrol_cli/src/dart_defines_reader.dart';
@@ -33,6 +35,7 @@ class TestCommand extends PatrolCommand {
     required MacOSTestBackend macOSTestBackend,
     required WebTestBackend webTestBackend,
     required CoverageTool coverageTool,
+    required WebCoverageTool webCoverageTool,
     required Analytics analytics,
     required Logger logger,
   }) : _deviceFinder = deviceFinder,
@@ -46,6 +49,7 @@ class TestCommand extends PatrolCommand {
        _macosTestBackend = macOSTestBackend,
        _webTestBackend = webTestBackend,
        _coverageTool = coverageTool,
+       _webCoverageTool = webCoverageTool,
        _analytics = analytics,
        _logger = logger {
     usesTargetOption();
@@ -87,6 +91,7 @@ class TestCommand extends PatrolCommand {
   final MacOSTestBackend _macosTestBackend;
   final WebTestBackend _webTestBackend;
   final CoverageTool _coverageTool;
+  final WebCoverageTool _webCoverageTool;
 
   final Analytics _analytics;
   final Logger _logger;
@@ -222,9 +227,35 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
     final uninstall = boolArg('uninstall');
     final noTreeShakeIcons = boolArg('no-tree-shake-icons');
     final coverageEnabled = boolArg('coverage');
+
+    final coverageMode = switch ((coverageEnabled, isWeb)) {
+      (false, _) => CoverageMode.none,
+      (true, false) => CoverageMode.vm,
+      (true, true) => CoverageMode.web,
+    };
+
+    if (coverageMode == CoverageMode.web && buildMode.name != 'debug') {
+      _logger.err(
+        'Coverage on the web platform requires a debug build. '
+        'Please remove the --${buildMode.name} flag.',
+      );
+      return 1;
+    }
+
     final coverageWorkspace = boolArg('coverage-workspace');
     final ignoreGlobs = stringsArg('coverage-ignore').map(Glob.new).toSet();
     final coveragePackagesRegExps = stringsArg('coverage-package');
+    final coveragePackages = switch ((
+      coveragePackagesRegExps.length,
+      coverageWorkspace,
+    )) {
+      // No --coverage-package and no --coverage-workspace: fall back to
+      // the current package only.
+      (0, false) => {RegExp(config.flutterPackageName)},
+      // --coverage-workspace alone: rely entirely on workspace members.
+      (0, true) => const <RegExp>{},
+      _ => coveragePackagesRegExps.map(RegExp.new).toSet(),
+    };
 
     final customDartDefines = {
       ..._dartDefinesReader.fromFile(),
@@ -244,7 +275,7 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
         'PATROL_TEST_SERVER_PORT': super.testServerPort.toString(),
         'PATROL_APP_SERVER_PORT': super.appServerPort.toString(),
       },
-      'COVERAGE_ENABLED': coverageEnabled.toString(),
+      'COVERAGE_ENABLED': (coverageMode == CoverageMode.vm).toString(),
     }.withNullsRemoved();
 
     final dartDefines = {...customDartDefines, ...internalDartDefines};
@@ -318,6 +349,10 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
       testServerPort: super.testServerPort,
     );
 
+    final webCoverageDataDir = coverageMode == CoverageMode.web
+        ? (await _webCoverageTool.prepareDataDirectory()).path
+        : null;
+
     final webOpts = WebAppOptions(
       flutter: flutterOpts,
       resultsDir: stringArg('web-results-dir'),
@@ -358,6 +393,7 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
       trace: stringArg('web-trace'),
       storageState: stringArg('web-storage-state'),
       acceptDownloads: optionalBoolArg('web-accept-downloads'),
+      coverageDir: webCoverageDataDir,
     );
 
     // No need to build web app for testing. It's done in the execute method.
@@ -367,7 +403,7 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
 
     await _preExecute(androidOpts, iosOpts, macosOpts, device, uninstall);
 
-    if (coverageEnabled) {
+    if (coverageMode == CoverageMode.vm) {
       unawaited(
         _coverageTool.run(
           device: device,
@@ -376,17 +412,7 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
           ignoreGlobs: ignoreGlobs,
           flutterCommand: flutterCommand,
           includeWorkspacePackages: coverageWorkspace,
-          packagesRegExps: switch ((
-            coveragePackagesRegExps.length,
-            coverageWorkspace,
-          )) {
-            // No --coverage-package and no --coverage-workspace: fall back to
-            // the current package only.
-            (0, false) => {RegExp(config.flutterPackageName)},
-            // --coverage-workspace alone: rely entirely on workspace members.
-            (0, true) => const <RegExp>{},
-            _ => coveragePackagesRegExps.map(RegExp.new).toSet(),
-          },
+          packagesRegExps: coveragePackages,
         ),
       );
     }
@@ -404,6 +430,18 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
       clearTestSteps: boolArg('clear-test-steps'),
       testDirectory: testDirectory,
     );
+
+    // Converted after the run, once the runner has written the raw JS coverage.
+    // _execute signals failures via its return value, so failed runs still
+    // produce a report.
+    if (coverageMode == CoverageMode.web) {
+      await _webCoverageTool.run(
+        flutterPackageName: config.flutterPackageName,
+        packagesRegExps: coveragePackages,
+        includeWorkspacePackages: coverageWorkspace,
+        ignoreGlobs: ignoreGlobs,
+      );
+    }
 
     return allPassed ? 0 : 1;
   }
@@ -564,7 +602,13 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
 
   void useCoverageOptions() {
     argParser
-      ..addFlag('coverage', help: 'Generate coverage.')
+      ..addFlag(
+        'coverage',
+        help:
+            'Generate coverage. On the web, reports only covered/uncovered '
+            'lines, without the per-line hit counts available on other '
+            'platforms.',
+      )
       ..addFlag(
         'coverage-workspace',
         help:

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -234,9 +234,9 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
       (true, true) => CoverageMode.web,
     };
 
-    if (coverageMode == CoverageMode.web && buildMode.name != 'debug') {
+    if (coverageMode != CoverageMode.none && buildMode.name != 'debug') {
       _logger.err(
-        'Coverage on the web platform requires a debug build. '
+        'Coverage requires a debug build. '
         'Please remove the --${buildMode.name} flag.',
       );
       return 1;

--- a/packages/patrol_cli/lib/src/coverage/coverage_common.dart
+++ b/packages/patrol_cli/lib/src/coverage/coverage_common.dart
@@ -1,0 +1,154 @@
+import 'package:coverage/coverage.dart' as coverage;
+import 'package:file/file.dart';
+import 'package:glob/glob.dart';
+import 'package:meta/meta.dart';
+import 'package:package_config/package_config.dart';
+import 'package:patrol_cli/src/base/exceptions.dart';
+import 'package:patrol_cli/src/base/logger.dart';
+import 'package:yaml/yaml.dart';
+
+/// Writes [hitMap] as LCOV to `coverage/patrol_lcov.info`, resolving sources
+/// under [packagePath]. Shared by the VM and web coverage tools.
+Future<void> formatAndSaveLcovReport({
+  required FileSystem fs,
+  required Map<String, coverage.HitMap> hitMap,
+  required String packagePath,
+  required Set<Glob> ignoreGlobs,
+  required Logger logger,
+}) async {
+  logger.info('All coverage gathered, saving');
+  final report = hitMap.formatLcov(
+    await coverage.Resolver.create(packagePath: packagePath),
+    ignoreGlobs: ignoreGlobs,
+  );
+
+  final coverageDirectory = fs.directory('coverage');
+  await coverageDirectory.create(recursive: true);
+  await coverageDirectory.childFile('patrol_lcov.info').writeAsString(report);
+}
+
+/// Returns package names matching [packagesRegExps] in `package_config.json`,
+/// optionally plus the Pub workspace members of [rootDirectory].
+Future<Set<String>> getCoveragePackages({
+  required Directory rootDirectory,
+  required Set<RegExp> packagesRegExps,
+  required bool includeWorkspacePackages,
+  required Logger logger,
+}) async {
+  final packageConfigFile = findPackageConfigFile(rootDirectory);
+  if (packageConfigFile == null) {
+    throwToolExit(
+      "Couldn't find .dart_tool/package_config.json in "
+      '${rootDirectory.path} or any parent directory. '
+      'Run `flutter pub get` first.',
+    );
+  }
+  final packageConfig = await loadPackageConfig(packageConfigFile);
+
+  final packagesToInclude = {
+    for (final regExp in packagesRegExps)
+      ...packageConfig.packages.map((e) => e.name).where(regExp.hasMatch),
+  };
+
+  if (includeWorkspacePackages) {
+    // package_config.json lives in <workspace-root>/.dart_tool/.
+    final workspaceRoot = packageConfigFile.parent.parent;
+    final members = findWorkspaceMemberPackages(workspaceRoot);
+    if (members.isEmpty) {
+      logger.warn(
+        'No `workspace:` entries found in ${workspaceRoot.path}/pubspec.yaml; '
+        '--coverage-workspace had no effect.',
+      );
+    } else {
+      logger.detail('Workspace member packages: $members');
+      packagesToInclude.addAll(members);
+    }
+  }
+
+  logger.detail('Packages included in coverage: $packagesToInclude');
+
+  return packagesToInclude;
+}
+
+/// Returns the package names declared under the `workspace:` key of
+/// `<workspaceRoot>/pubspec.yaml`.
+///
+/// Each entry is a path relative to [workspaceRoot] whose `pubspec.yaml`
+/// `name:` is the package name. Members without a readable `pubspec.yaml` are
+/// skipped, as pub already reports that during `pub get`. Returns an empty set
+/// when the root `pubspec.yaml` is missing, has no `workspace:` key, or isn't
+/// a map.
+@visibleForTesting
+Set<String> findWorkspaceMemberPackages(Directory workspaceRoot) {
+  final root = _tryLoadYamlMap(workspaceRoot.childFile('pubspec.yaml'));
+  if (root == null) {
+    return const {};
+  }
+  final members = root['workspace'];
+  if (members is! Iterable) {
+    return const {};
+  }
+
+  final names = <String>{};
+  for (final entry in members) {
+    if (entry is! String) {
+      continue;
+    }
+    // `workspace:` entries are POSIX-style paths; split on `/` to stay
+    // platform-agnostic.
+    var memberDir = workspaceRoot;
+    for (final segment in entry.split('/')) {
+      if (segment.isEmpty || segment == '.') {
+        continue;
+      }
+      memberDir = memberDir.childDirectory(segment);
+    }
+    final memberYaml = _tryLoadYamlMap(memberDir.childFile('pubspec.yaml'));
+    if (memberYaml == null) {
+      continue;
+    }
+    final name = memberYaml['name'];
+    if (name is String && name.isNotEmpty) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
+/// Reads [file] as YAML and returns its top-level map, or `null` if the file
+/// is missing, fails to parse, or isn't a map.
+///
+/// A malformed file is treated as missing so coverage degrades gracefully
+/// instead of crashing; pub already surfaces the error during `pub get`.
+Map<dynamic, dynamic>? _tryLoadYamlMap(File file) {
+  if (!file.existsSync()) {
+    return null;
+  }
+  try {
+    final parsed = loadYaml(file.readAsStringSync());
+    return parsed is Map ? parsed : null;
+  } on YamlException {
+    return null;
+  }
+}
+
+/// Walks up from [directory] looking for `.dart_tool/package_config.json`,
+/// which in a Pub workspace lives at the workspace root. Returns `null` if
+/// none is found up to the filesystem root.
+@visibleForTesting
+File? findPackageConfigFile(Directory directory) {
+  var current = directory;
+  while (true) {
+    final candidate = current
+        .childDirectory('.dart_tool')
+        .childFile('package_config.json');
+    if (candidate.existsSync()) {
+      return candidate;
+    }
+    final parent = current.parent;
+    if (parent.path == current.path) {
+      return null;
+    }
+    current = parent;
+  }
+}

--- a/packages/patrol_cli/lib/src/coverage/coverage_mode.dart
+++ b/packages/patrol_cli/lib/src/coverage/coverage_mode.dart
@@ -1,0 +1,12 @@
+/// How coverage should be collected for a single `patrol test` run.
+enum CoverageMode {
+  /// Coverage is disabled for this run.
+  none,
+
+  /// Coverage collected from the Dart VM service (Android, iOS).
+  vm,
+
+  /// Coverage collected from the browser's native JavaScript coverage and
+  /// mapped back to Dart through source maps (web).
+  web,
+}

--- a/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
+++ b/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
@@ -7,9 +7,8 @@ import 'package:coverage/coverage.dart' as coverage;
 import 'package:dispose_scope/dispose_scope.dart';
 import 'package:file/file.dart';
 import 'package:glob/glob.dart';
-import 'package:package_config/package_config.dart';
-import 'package:patrol_cli/src/base/exceptions.dart';
 import 'package:patrol_cli/src/base/logger.dart';
+import 'package:patrol_cli/src/coverage/coverage_common.dart';
 import 'package:patrol_cli/src/coverage/device_to_host_port_transformer.dart';
 import 'package:patrol_cli/src/coverage/vm_connection_details.dart';
 import 'package:patrol_cli/src/devices.dart';
@@ -18,7 +17,6 @@ import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
-import 'package:yaml/yaml.dart';
 
 class CoverageTool {
   CoverageTool({
@@ -62,9 +60,11 @@ class CoverageTool {
 
     // Resolved once per run; the package_config.json contents do not change
     // mid-run and we'd otherwise re-walk + re-parse for every test isolate.
-    final packages = await _getCoveragePackages(
-      packagesRegExps,
+    final packages = await getCoveragePackages(
+      rootDirectory: _rootDirectory,
+      packagesRegExps: packagesRegExps,
       includeWorkspacePackages: includeWorkspacePackages,
+      logger: _logger,
     );
 
     await _disposeScope.run((scope) async {
@@ -120,12 +120,13 @@ class CoverageTool {
         ..disposedBy(scope);
       await coverageCollectionCompleter.future;
 
-      logger.info('All coverage gathered, saving');
-      final report = hitMap.formatLcov(
-        await coverage.Resolver.create(packagePath: _rootDirectory.path),
+      await formatAndSaveLcovReport(
+        fs: _fs,
+        hitMap: hitMap,
+        packagePath: _rootDirectory.path,
         ignoreGlobs: ignoreGlobs,
+        logger: logger,
       );
-      await _saveReport(report);
     });
   }
 
@@ -229,142 +230,6 @@ class CoverageTool {
     return coverage.HitMap.parseJson(
       data['coverage'] as List<Map<String, dynamic>>,
     );
-  }
-
-  Future<void> _saveReport(String report) async {
-    final coverageDirectory = _fs.directory('coverage');
-
-    if (!coverageDirectory.existsSync()) {
-      await coverageDirectory.create();
-    }
-
-    await coverageDirectory.childFile('patrol_lcov.info').writeAsString(report);
-  }
-
-  Future<Set<String>> _getCoveragePackages(
-    Set<RegExp> packagesRegExps, {
-    required bool includeWorkspacePackages,
-  }) async {
-    final packageConfigFile = findPackageConfigFile(_rootDirectory);
-    if (packageConfigFile == null) {
-      throwToolExit(
-        "Couldn't find .dart_tool/package_config.json in "
-        '${_rootDirectory.path} or any parent directory. '
-        'Run `flutter pub get` first.',
-      );
-    }
-    final packageConfig = await loadPackageConfig(packageConfigFile);
-
-    final packagesToInclude = {
-      for (final regExp in packagesRegExps)
-        ...packageConfig.packages.map((e) => e.name).where(regExp.hasMatch),
-    };
-
-    if (includeWorkspacePackages) {
-      // package_config.json lives in <workspace-root>/.dart_tool/, so the
-      // workspace root is two levels up.
-      final workspaceRoot = packageConfigFile.parent.parent;
-      final members = findWorkspaceMemberPackages(workspaceRoot);
-      if (members.isEmpty) {
-        _logger.warn(
-          'No `workspace:` entries found in ${workspaceRoot.path}/pubspec.yaml; '
-          '--coverage-workspace had no effect.',
-        );
-      } else {
-        _logger.detail('Workspace member packages: $members');
-        packagesToInclude.addAll(members);
-      }
-    }
-
-    _logger.detail('Packages included in coverage: $packagesToInclude');
-
-    return packagesToInclude;
-  }
-}
-
-/// Returns the names of every member package declared under the top-level
-/// `workspace:` key in `<workspaceRoot>/pubspec.yaml`.
-///
-/// Each entry in `workspace:` is a path relative to [workspaceRoot]; the
-/// `name:` field of that path's `pubspec.yaml` is the package name. Members
-/// without a readable `pubspec.yaml` are silently skipped, since pub itself
-/// will already have surfaced that error during `pub get`.
-///
-/// Returns an empty set when [workspaceRoot] has no `pubspec.yaml`, when its
-/// `workspace:` key is missing, or when the file isn't a YAML map.
-Set<String> findWorkspaceMemberPackages(Directory workspaceRoot) {
-  final root = _tryLoadYamlMap(workspaceRoot.childFile('pubspec.yaml'));
-  if (root == null) {
-    return const {};
-  }
-  final members = root['workspace'];
-  if (members is! Iterable) {
-    return const {};
-  }
-
-  final names = <String>{};
-  for (final entry in members) {
-    if (entry is! String) {
-      continue;
-    }
-    // pubspec.yaml `workspace:` entries are always POSIX-style relative paths,
-    // so split on `/` and walk children to stay platform-agnostic.
-    var memberDir = workspaceRoot;
-    for (final segment in entry.split('/')) {
-      if (segment.isEmpty || segment == '.') {
-        continue;
-      }
-      memberDir = memberDir.childDirectory(segment);
-    }
-    final memberYaml = _tryLoadYamlMap(memberDir.childFile('pubspec.yaml'));
-    if (memberYaml == null) {
-      continue;
-    }
-    final name = memberYaml['name'];
-    if (name is String && name.isNotEmpty) {
-      names.add(name);
-    }
-  }
-  return names;
-}
-
-/// Reads [file] as YAML and returns its top-level map, or `null` when the
-/// file is missing, the contents fail to parse, or the root is not a map.
-///
-/// We treat a malformed `pubspec.yaml` the same as a missing one because pub
-/// itself surfaces the underlying error during `pub get`; the coverage flow
-/// should degrade gracefully rather than crash mid-test.
-Map<dynamic, dynamic>? _tryLoadYamlMap(File file) {
-  if (!file.existsSync()) {
-    return null;
-  }
-  try {
-    final parsed = loadYaml(file.readAsStringSync());
-    return parsed is Map ? parsed : null;
-  } on YamlException {
-    return null;
-  }
-}
-
-/// Walks up from [directory] looking for `.dart_tool/package_config.json`.
-///
-/// In a Pub workspace the file lives at the workspace root, not in each
-/// member package. Returns `null` if no config is found up to the filesystem
-/// root.
-File? findPackageConfigFile(Directory directory) {
-  var current = directory;
-  while (true) {
-    final candidate = current
-        .childDirectory('.dart_tool')
-        .childFile('package_config.json');
-    if (candidate.existsSync()) {
-      return candidate;
-    }
-    final parent = current.parent;
-    if (parent.path == current.path) {
-      return null;
-    }
-    current = parent;
   }
 }
 

--- a/packages/patrol_cli/lib/src/coverage/web_coverage_tool.dart
+++ b/packages/patrol_cli/lib/src/coverage/web_coverage_tool.dart
@@ -1,0 +1,258 @@
+import 'dart:convert';
+
+import 'package:coverage/coverage.dart' as coverage;
+import 'package:file/file.dart';
+import 'package:glob/glob.dart';
+import 'package:patrol_cli/src/base/logger.dart';
+import 'package:patrol_cli/src/coverage/coverage_common.dart';
+
+/// Generates a Dart coverage report for web test runs.
+///
+/// The browser has no Dart VM, so instead of a VM service the Playwright runner
+/// records Chrome's JS coverage per test (with source maps) into
+/// [dataDirectory]. This tool maps it back to Dart and writes the same
+/// `coverage/patrol_lcov.info` report as the mobile flow.
+class WebCoverageTool {
+  WebCoverageTool({
+    required FileSystem fs,
+    required Directory rootDirectory,
+    required Logger logger,
+  }) : _fs = fs,
+       _rootDirectory = rootDirectory,
+       _logger = logger;
+
+  final FileSystem _fs;
+  final Directory _rootDirectory;
+  final Logger _logger;
+
+  /// Where the Playwright runner drops one JSON file per test with the raw V8
+  /// coverage entries.
+  Directory get dataDirectory => _rootDirectory
+      .childDirectory('.dart_tool')
+      .childDirectory('patrol')
+      .childDirectory('web_coverage');
+
+  /// Clears data from previous runs and returns the directory to write to.
+  Future<Directory> prepareDataDirectory() async {
+    final dir = dataDirectory;
+    if (dir.existsSync()) {
+      await dir.delete(recursive: true);
+    }
+    await dir.create(recursive: true);
+    return dir;
+  }
+
+  Future<void> run({
+    required String flutterPackageName,
+    required Set<RegExp> packagesRegExps,
+    required Set<Glob> ignoreGlobs,
+    bool includeWorkspacePackages = false,
+  }) async {
+    final dir = dataDirectory;
+    final files = dir.existsSync()
+        ? dir
+              .listSync()
+              .whereType<File>()
+              .where((file) => file.path.endsWith('.json'))
+              .toList()
+        : <File>[];
+
+    if (files.isEmpty) {
+      _logger.warn(
+        'No web coverage data was collected, skipping coverage report. '
+        'Make sure the tests are running on Chromium.',
+      );
+      return;
+    }
+
+    // Parse concurrently, recovering each future to null so one bad file
+    // doesn't reject the whole batch. Package resolution runs alongside the
+    // parse and is awaited directly so its `ToolExit` propagates unwrapped.
+    final testHitMapsFuture = Future.wait(
+      files.map(
+        (file) => _parseTestCoverage(file, flutterPackageName).catchError((
+          Object err,
+        ) {
+          _logger.warn('Skipping unreadable coverage file ${file.path}: $err');
+          return null;
+        }),
+      ),
+    );
+
+    final packages = await getCoveragePackages(
+      rootDirectory: _rootDirectory,
+      packagesRegExps: packagesRegExps,
+      includeWorkspacePackages: includeWorkspacePackages,
+      logger: _logger,
+    );
+    final testHitMaps = await testHitMapsFuture;
+
+    // Merge sequentially since `HitMap.merge` mutates the accumulator.
+    final parsed = testHitMaps
+        .whereType<Map<String, coverage.HitMap>>()
+        .toList();
+    final hitMap = <String, coverage.HitMap>{};
+    for (final testHitMap in parsed) {
+      hitMap.merge(_scopedTo(testHitMap, packages));
+    }
+    _logger.info('Converted ${parsed.length} / ${files.length} web coverages');
+
+    if (hitMap.isEmpty) {
+      _logger.warn(
+        'Web coverage data did not map back to any Dart sources, '
+        'skipping coverage report.',
+      );
+      return;
+    }
+
+    await formatAndSaveLcovReport(
+      fs: _fs,
+      hitMap: hitMap,
+      packagePath: _rootDirectory.path,
+      ignoreGlobs: ignoreGlobs,
+      logger: _logger,
+    );
+  }
+
+  /// Converts one test's V8 coverage into a Dart hit map, or null if the file
+  /// is unusable.
+  Future<Map<String, coverage.HitMap>?> _parseTestCoverage(
+    File file,
+    String flutterPackageName,
+  ) async {
+    final entries = await _readCoverageEntries(file);
+    if (entries == null) {
+      return null;
+    }
+    final byId = {for (final e in entries) e['scriptId'] as String: e};
+
+    // Source, source map and URL are supplied via these lookups by scriptId.
+    final parsed = await coverage.parseChromeCoverage(
+      entries,
+      (id) async => byId[id]?['source'] as String?,
+      (id) async => byId[id]?['sourceMap'] as String?,
+      (sourceUrl, id) async => resolveDartSourceUri(
+        sourceUrl: sourceUrl,
+        scriptUrl: byId[id]?['url'] as String?,
+        appPackageName: flutterPackageName,
+      ),
+    );
+
+    return coverage.HitMap.parseJson(
+      (parsed['coverage'] as List).cast<Map<String, dynamic>>(),
+    );
+  }
+
+  /// Returns the entries `parseChromeCoverage` can consume, or null if the file
+  /// is malformed. Written by a separate process, so a bad file is skipped
+  /// rather than fatal; only entries with a String `scriptId` are kept.
+  Future<List<Map<String, dynamic>>?> _readCoverageEntries(File file) async {
+    final Object? json;
+    try {
+      json = jsonDecode(await file.readAsString());
+    } on FormatException catch (err) {
+      _logger.warn('Skipping malformed coverage file ${file.path}: $err');
+      return null;
+    }
+    if (json is! Map<String, dynamic> || json['entries'] is! List) {
+      _logger.warn('Skipping malformed coverage file ${file.path}');
+      return null;
+    }
+    return (json['entries'] as List)
+        .whereType<Map<String, dynamic>>()
+        .where((e) => e['scriptId'] is String)
+        .toList();
+  }
+
+  /// Mirrors the VM collector: an empty [packages] set means no filtering.
+  Map<String, coverage.HitMap> _scopedTo(
+    Map<String, coverage.HitMap> hitMap,
+    Set<String> packages,
+  ) {
+    if (packages.isEmpty) {
+      return hitMap;
+    }
+    return {
+      for (final entry in hitMap.entries)
+        if (packages.contains(_packageNameOf(entry.key)))
+          entry.key: entry.value,
+    };
+  }
+}
+
+String? _packageNameOf(String source) {
+  final uri = Uri.tryParse(source);
+  if (uri == null || uri.scheme != 'package' || uri.pathSegments.isEmpty) {
+    return null;
+  }
+  return uri.pathSegments.first;
+}
+
+/// Maps a source map `sources` entry to a Dart URI the `package:coverage`
+/// Resolver understands, or null for unattributable sources (which are then
+/// excluded from the report). Handles the shapes the compilers emit:
+/// - `package:` and `file:` URIs are already usable;
+/// - DDC's `org-dartlang-app:///` for app-root sources;
+/// - otherwise the source is relative to the script's URL, where the dev
+///   server exposes dependencies under `/packages/<name>/`.
+///
+/// SDK sources (`org-dartlang-sdk:`) are already filtered by
+/// `parseChromeCoverage`.
+Uri? resolveDartSourceUri({
+  required String sourceUrl,
+  required String? scriptUrl,
+  required String appPackageName,
+}) {
+  final uri = Uri.tryParse(sourceUrl);
+  if (uri != null && uri.hasScheme) {
+    return switch (uri.scheme) {
+      'package' || 'file' => uri,
+      'org-dartlang-app' => _packageUriFromPath(
+        uri.pathSegments,
+        appPackageName,
+      ),
+      _ => null,
+    };
+  }
+
+  if (scriptUrl == null) {
+    return null;
+  }
+  final script = Uri.tryParse(scriptUrl);
+  if (script == null) {
+    return null;
+  }
+  final Uri resolved;
+  try {
+    resolved = script.resolve(sourceUrl);
+  } on FormatException {
+    return null;
+  }
+  return _packageUriFromPath(resolved.pathSegments, appPackageName);
+}
+
+/// Attributes a server/app-root path to a package: `packages/<name>/<path>`
+/// is a dependency, while a top-level `lib/` belongs to the app package.
+Uri? _packageUriFromPath(List<String> pathSegments, String appPackageName) {
+  final segments = pathSegments.where((s) => s.isNotEmpty).toList();
+  if (segments.isEmpty) {
+    return null;
+  }
+
+  if (segments.indexOf('packages') case final i
+      when i != -1 && i + 1 < segments.length) {
+    return Uri(
+      scheme: 'package',
+      pathSegments: segments.sublist(i + 1),
+    );
+  }
+
+  if (segments case ['lib', final first, ...final rest]) {
+    return Uri(
+      scheme: 'package',
+      pathSegments: [appPackageName, first, ...rest],
+    );
+  }
+
+  return null;
+}

--- a/packages/patrol_cli/lib/src/coverage/web_coverage_tool.dart
+++ b/packages/patrol_cli/lib/src/coverage/web_coverage_tool.dart
@@ -241,10 +241,7 @@ Uri? _packageUriFromPath(List<String> pathSegments, String appPackageName) {
 
   if (segments.indexOf('packages') case final i
       when i != -1 && i + 1 < segments.length) {
-    return Uri(
-      scheme: 'package',
-      pathSegments: segments.sublist(i + 1),
-    );
+    return Uri(scheme: 'package', pathSegments: segments.sublist(i + 1));
   }
 
   if (segments case ['lib', final first, ...final rest]) {

--- a/packages/patrol_cli/lib/src/coverage/web_coverage_tool.dart
+++ b/packages/patrol_cli/lib/src/coverage/web_coverage_tool.dart
@@ -8,10 +8,9 @@ import 'package:patrol_cli/src/coverage/coverage_common.dart';
 
 /// Generates a Dart coverage report for web test runs.
 ///
-/// The browser has no Dart VM, so instead of a VM service the Playwright runner
-/// records Chrome's JS coverage per test (with source maps) into
-/// [dataDirectory]. This tool maps it back to Dart and writes the same
-/// `coverage/patrol_lcov.info` report as the mobile flow.
+/// The browser has no Dart VM, so the Playwright runner records Chrome's JS
+/// coverage per test into [dataDirectory] instead. This tool maps it back to
+/// Dart via source maps and writes the same report as the mobile flow.
 class WebCoverageTool {
   WebCoverageTool({
     required FileSystem fs,
@@ -25,14 +24,11 @@ class WebCoverageTool {
   final Directory _rootDirectory;
   final Logger _logger;
 
-  /// Where the Playwright runner drops one JSON file per test with the raw V8
-  /// coverage entries.
   Directory get dataDirectory => _rootDirectory
       .childDirectory('.dart_tool')
       .childDirectory('patrol')
       .childDirectory('web_coverage');
 
-  /// Clears data from previous runs and returns the directory to write to.
   Future<Directory> prepareDataDirectory() async {
     final dir = dataDirectory;
     if (dir.existsSync()) {
@@ -65,9 +61,9 @@ class WebCoverageTool {
       return;
     }
 
-    // Parse concurrently, recovering each future to null so one bad file
-    // doesn't reject the whole batch. Package resolution runs alongside the
-    // parse and is awaited directly so its `ToolExit` propagates unwrapped.
+    // Recover each future to null so one bad file doesn't reject the batch.
+    // Package resolution runs alongside and is awaited directly, so its
+    // `ToolExit` propagates unwrapped.
     final testHitMapsFuture = Future.wait(
       files.map(
         (file) => _parseTestCoverage(file, flutterPackageName).catchError((
@@ -114,8 +110,6 @@ class WebCoverageTool {
     );
   }
 
-  /// Converts one test's V8 coverage into a Dart hit map, or null if the file
-  /// is unusable.
   Future<Map<String, coverage.HitMap>?> _parseTestCoverage(
     File file,
     String flutterPackageName,
@@ -126,7 +120,6 @@ class WebCoverageTool {
     }
     final byId = {for (final e in entries) e['scriptId'] as String: e};
 
-    // Source, source map and URL are supplied via these lookups by scriptId.
     final parsed = await coverage.parseChromeCoverage(
       entries,
       (id) async => byId[id]?['source'] as String?,
@@ -143,9 +136,8 @@ class WebCoverageTool {
     );
   }
 
-  /// Returns the entries `parseChromeCoverage` can consume, or null if the file
-  /// is malformed. Written by a separate process, so a bad file is skipped
-  /// rather than fatal; only entries with a String `scriptId` are kept.
+  /// The files come from a separate process, so a malformed one is skipped
+  /// rather than fatal.
   Future<List<Map<String, dynamic>>?> _readCoverageEntries(File file) async {
     final Object? json;
     try {
@@ -189,15 +181,11 @@ String? _packageNameOf(String source) {
 }
 
 /// Maps a source map `sources` entry to a Dart URI the `package:coverage`
-/// Resolver understands, or null for unattributable sources (which are then
-/// excluded from the report). Handles the shapes the compilers emit:
-/// - `package:` and `file:` URIs are already usable;
-/// - DDC's `org-dartlang-app:///` for app-root sources;
-/// - otherwise the source is relative to the script's URL, where the dev
-///   server exposes dependencies under `/packages/<name>/`.
+/// Resolver understands. Unattributable sources return null and are excluded
+/// from the report; SDK sources are already filtered by `parseChromeCoverage`.
 ///
-/// SDK sources (`org-dartlang-sdk:`) are already filtered by
-/// `parseChromeCoverage`.
+/// Relative sources are resolved against the script's URL, where the dev server
+/// exposes dependencies under `/packages/<name>/`.
 Uri? resolveDartSourceUri({
   required String sourceUrl,
   required String? scriptUrl,

--- a/packages/patrol_cli/lib/src/coverage/web_coverage_tool.dart
+++ b/packages/patrol_cli/lib/src/coverage/web_coverage_tool.dart
@@ -221,23 +221,22 @@ Uri? resolveDartSourceUri({
 
 /// Attributes a server/app-root path to a package: `packages/<name>/<path>`
 /// is a dependency, while a top-level `lib/` belongs to the app package.
+///
+/// Both prefixes are only recognized at the root, so an app source living under
+/// e.g. `lib/packages/widgets/button.dart` stays with the app package instead
+/// of being attributed to a `widgets` dependency.
 Uri? _packageUriFromPath(List<String> pathSegments, String appPackageName) {
   final segments = pathSegments.where((s) => s.isNotEmpty).toList();
-  if (segments.isEmpty) {
-    return null;
-  }
 
-  if (segments.indexOf('packages') case final i
-      when i != -1 && i + 1 < segments.length) {
-    return Uri(scheme: 'package', pathSegments: segments.sublist(i + 1));
-  }
-
-  if (segments case ['lib', final first, ...final rest]) {
-    return Uri(
+  return switch (segments) {
+    ['packages', final package, final first, ...final rest] => Uri(
+      scheme: 'package',
+      pathSegments: [package, first, ...rest],
+    ),
+    ['lib', final first, ...final rest] => Uri(
       scheme: 'package',
       pathSegments: [appPackageName, first, ...rest],
-    );
-  }
-
-  return null;
+    ),
+    _ => null,
+  };
 }

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -433,6 +433,7 @@ class WebAppOptions {
     this.trace,
     this.storageState,
     this.acceptDownloads,
+    this.coverageDir,
   });
 
   final FlutterAppOptions flutter;
@@ -477,6 +478,10 @@ class WebAppOptions {
   /// Timeout in seconds for the web server to start.
   /// Defaults to 120 seconds (2 minutes) if not specified.
   final int? serverTimeout;
+
+  /// Directory for the Playwright runner's raw JS coverage data; when set,
+  /// coverage collection is enabled.
+  final String? coverageDir;
 
   /// Translates these options into environment variables consumed by the
   /// Playwright web runner. Unset options are omitted.

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -521,6 +521,7 @@ class WebAppOptions {
       'PATROL_WEB_TRACE': trace,
       'PATROL_WEB_STORAGE_STATE': storageState,
       'PATROL_WEB_ACCEPT_DOWNLOADS': acceptDownloads,
+      'PATROL_WEB_COVERAGE_DIR': coverageDir,
     };
 
     return {

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -25,6 +25,7 @@ import 'package:patrol_cli/src/commands/update.dart';
 import 'package:patrol_cli/src/compatibility_checker/compatibility_checker.dart';
 import 'package:patrol_cli/src/compatibility_checker/version_compatibility.dart';
 import 'package:patrol_cli/src/coverage/coverage_tool.dart';
+import 'package:patrol_cli/src/coverage/web_coverage_tool.dart';
 import 'package:patrol_cli/src/crossplatform/flutter_tool.dart';
 import 'package:patrol_cli/src/dart_defines_reader.dart';
 import 'package:patrol_cli/src/devices.dart';
@@ -247,6 +248,11 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
           adb: adb,
           logger: _logger,
           parentDisposeScope: _disposeScope,
+        ),
+        webCoverageTool: WebCoverageTool(
+          fs: _fs,
+          rootDirectory: rootDirectory,
+          logger: _logger,
         ),
         analytics: _analytics,
         logger: _logger,

--- a/packages/patrol_cli/lib/src/web/web_test_backend.dart
+++ b/packages/patrol_cli/lib/src/web/web_test_backend.dart
@@ -455,6 +455,8 @@ class WebTestBackend {
                 'PATROL_TEST_RESULTS_DIR': testResultsDir,
                 'PATROL_TEST_REPORT_DIR': testReportDir,
                 ...options.toEnvironmentVariables(),
+                if (options.coverageDir != null)
+                  'PATROL_COVERAGE_DIR': options.coverageDir!,
               },
               runInShell: true,
             )

--- a/packages/patrol_cli/lib/src/web/web_test_backend.dart
+++ b/packages/patrol_cli/lib/src/web/web_test_backend.dart
@@ -455,8 +455,6 @@ class WebTestBackend {
                 'PATROL_TEST_RESULTS_DIR': testResultsDir,
                 'PATROL_TEST_REPORT_DIR': testReportDir,
                 ...options.toEnvironmentVariables(),
-                if (options.coverageDir != null)
-                  'PATROL_COVERAGE_DIR': options.coverageDir!,
               },
               runInShell: true,
             )

--- a/packages/patrol_cli/test/crossplatform/app_options_test.dart
+++ b/packages/patrol_cli/test/crossplatform/app_options_test.dart
@@ -878,6 +878,7 @@ void main() {
           trace: 'retain-on-failure',
           storageState: '/tmp/state.json',
           acceptDownloads: true,
+          coverageDir: '/tmp/coverage',
         );
 
         expect(
@@ -918,6 +919,7 @@ void main() {
             'PATROL_WEB_TRACE': 'retain-on-failure',
             'PATROL_WEB_STORAGE_STATE': '/tmp/state.json',
             'PATROL_WEB_ACCEPT_DOWNLOADS': 'true',
+            'PATROL_WEB_COVERAGE_DIR': '/tmp/coverage',
           }),
         );
       });

--- a/packages/patrol_cli/test/general/coverage_common_test.dart
+++ b/packages/patrol_cli/test/general/coverage_common_test.dart
@@ -1,7 +1,7 @@
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:patrol_cli/src/base/extensions/platform.dart';
-import 'package:patrol_cli/src/coverage/coverage_tool.dart';
+import 'package:patrol_cli/src/coverage/coverage_common.dart';
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 

--- a/packages/patrol_cli/test/general/web_coverage_tool_test.dart
+++ b/packages/patrol_cli/test/general/web_coverage_tool_test.dart
@@ -62,19 +62,16 @@ void main() {
       );
     });
 
-    test(
-      'attributes relative sources escaping to a top-level lib/ '
-      'to the app package',
-      () {
-        expect(
-          resolve(
-            '../../lib/main.dart',
-            scriptUrl: 'http://localhost:8080/main.dart.js',
-          ),
-          Uri.parse('package:example_app/main.dart'),
-        );
-      },
-    );
+    test('attributes relative sources escaping to a top-level lib/ '
+        'to the app package', () {
+      expect(
+        resolve(
+          '../../lib/main.dart',
+          scriptUrl: 'http://localhost:8080/main.dart.js',
+        ),
+        Uri.parse('package:example_app/main.dart'),
+      );
+    });
 
     test('returns null for relative sources without a script URL', () {
       expect(resolve('lib/main.dart'), isNull);
@@ -123,11 +120,7 @@ void main() {
           jsonEncode({
             'configVersion': 2,
             'packages': [
-              {
-                'name': 'example_app',
-                'rootUri': '../',
-                'packageUri': 'lib/',
-              },
+              {'name': 'example_app', 'rootUri': '../', 'packageUri': 'lib/'},
             ],
           }),
         );
@@ -145,10 +138,7 @@ void main() {
       verify(
         () => logger.warn(any(that: contains('No web coverage data'))),
       ).called(1);
-      expect(
-        reportFs.file('coverage/patrol_lcov.info').existsSync(),
-        isFalse,
-      );
+      expect(reportFs.file('coverage/patrol_lcov.info').existsSync(), isFalse);
     });
 
     test('converts V8 coverage into an LCOV report', () async {
@@ -249,10 +239,7 @@ void main() {
           any(that: contains('did not map back to any Dart sources')),
         ),
       ).called(1);
-      expect(
-        reportFs.file('coverage/patrol_lcov.info').existsSync(),
-        isFalse,
-      );
+      expect(reportFs.file('coverage/patrol_lcov.info').existsSync(), isFalse);
     });
 
     test('prepareDataDirectory clears data from previous runs', () async {

--- a/packages/patrol_cli/test/general/web_coverage_tool_test.dart
+++ b/packages/patrol_cli/test/general/web_coverage_tool_test.dart
@@ -4,6 +4,7 @@ import 'dart:io' as io;
 import 'package:file/local.dart';
 import 'package:file/memory.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' show join;
 import 'package:patrol_cli/src/coverage/web_coverage_tool.dart';
 import 'package:test/test.dart';
 
@@ -190,7 +191,7 @@ void main() {
       final report = reportFs
           .file('coverage/patrol_lcov.info')
           .readAsStringSync();
-      expect(report, contains('lib/main.dart'));
+      expect(report, contains(join('lib', 'main.dart')));
       expect(report, contains('DA:1,1'));
       expect(report, contains('DA:2,1'));
       expect(report, contains('DA:3,0'));

--- a/packages/patrol_cli/test/general/web_coverage_tool_test.dart
+++ b/packages/patrol_cli/test/general/web_coverage_tool_test.dart
@@ -1,0 +1,269 @@
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:file/local.dart';
+import 'package:file/memory.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:patrol_cli/src/coverage/web_coverage_tool.dart';
+import 'package:test/test.dart';
+
+import '../src/mocks.dart';
+
+void main() {
+  group('resolveDartSourceUri', () {
+    Uri? resolve(String sourceUrl, {String? scriptUrl}) {
+      return resolveDartSourceUri(
+        sourceUrl: sourceUrl,
+        scriptUrl: scriptUrl,
+        appPackageName: 'example_app',
+      );
+    }
+
+    test('passes package: and file: URIs through', () {
+      expect(
+        resolve('package:foo/src/bar.dart'),
+        Uri.parse('package:foo/src/bar.dart'),
+      );
+      expect(
+        resolve('file:///home/user/app/lib/main.dart'),
+        Uri.parse('file:///home/user/app/lib/main.dart'),
+      );
+    });
+
+    test('maps org-dartlang-app lib/ sources to the app package', () {
+      expect(
+        resolve('org-dartlang-app:///lib/src/home.dart'),
+        Uri.parse('package:example_app/src/home.dart'),
+      );
+    });
+
+    test('maps org-dartlang-app packages/ sources to that package', () {
+      expect(
+        resolve('org-dartlang-app:///packages/dep/src/util.dart'),
+        Uri.parse('package:dep/src/util.dart'),
+      );
+    });
+
+    test('ignores org-dartlang-app sources outside lib/ and packages/', () {
+      expect(resolve('org-dartlang-app:///web/main.dart'), isNull);
+    });
+
+    test('ignores unknown schemes', () {
+      expect(resolve('webpack:///src/index.js'), isNull);
+    });
+
+    test('resolves relative sources against the script URL', () {
+      expect(
+        resolve(
+          'util.dart',
+          scriptUrl: 'http://localhost:8080/packages/dep/util.dart.lib.js',
+        ),
+        Uri.parse('package:dep/util.dart'),
+      );
+    });
+
+    test(
+      'attributes relative sources escaping to a top-level lib/ '
+      'to the app package',
+      () {
+        expect(
+          resolve(
+            '../../lib/main.dart',
+            scriptUrl: 'http://localhost:8080/main.dart.js',
+          ),
+          Uri.parse('package:example_app/main.dart'),
+        );
+      },
+    );
+
+    test('returns null for relative sources without a script URL', () {
+      expect(resolve('lib/main.dart'), isNull);
+    });
+
+    test('returns null for unattributable relative sources', () {
+      expect(
+        resolve(
+          'src/main.dart',
+          scriptUrl: 'http://localhost:8080/main.dart.js',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('WebCoverageTool', () {
+    late MockLogger logger;
+    late MemoryFileSystem reportFs;
+    late io.Directory tempDir;
+    late WebCoverageTool tool;
+
+    setUp(() {
+      logger = MockLogger();
+      reportFs = MemoryFileSystem.test();
+      tempDir = io.Directory.systemTemp.createTempSync(
+        'web_coverage_tool_test',
+      );
+      addTearDown(() => tempDir.delete(recursive: true));
+
+      // The report goes to the memory fs; coverage data and package config
+      // live in a real temp dir because package:coverage's Resolver reads
+      // package_config.json with dart:io.
+      const localFs = LocalFileSystem();
+      tool = WebCoverageTool(
+        fs: reportFs,
+        rootDirectory: localFs.directory(tempDir.path),
+        logger: logger,
+      );
+    });
+
+    void writePackageConfig() {
+      io.File('${tempDir.path}/.dart_tool/package_config.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          jsonEncode({
+            'configVersion': 2,
+            'packages': [
+              {
+                'name': 'example_app',
+                'rootUri': '../',
+                'packageUri': 'lib/',
+              },
+            ],
+          }),
+        );
+    }
+
+    test('warns and writes no report when no data was collected', () async {
+      writePackageConfig();
+
+      await tool.run(
+        flutterPackageName: 'example_app',
+        packagesRegExps: {RegExp('example_app')},
+        ignoreGlobs: {},
+      );
+
+      verify(
+        () => logger.warn(any(that: contains('No web coverage data'))),
+      ).called(1);
+      expect(
+        reportFs.file('coverage/patrol_lcov.info').existsSync(),
+        isFalse,
+      );
+    });
+
+    test('converts V8 coverage into an LCOV report', () async {
+      writePackageConfig();
+      // The Resolver only reports files that exist on disk.
+      io.File('${tempDir.path}/lib/main.dart')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('void main() {}\n');
+
+      // Three 4-char JS lines; the source map ("AAAA;AACA;AACA") maps JS line
+      // N col 0 to line N of lib/main.dart. First range covers lines 1-2, the
+      // second marks line 3 as not executed.
+      final coverageData = {
+        'entries': [
+          {
+            'url': 'http://localhost:8080/main.dart.js',
+            'scriptId': '42',
+            'source': 'aaaa\nbbbb\ncccc\n',
+            'sourceMap': jsonEncode({
+              'version': 3,
+              'file': 'main.dart.js',
+              'sources': ['org-dartlang-app:///lib/main.dart'],
+              'names': <String>[],
+              'mappings': 'AAAA;AACA;AACA',
+            }),
+            'functions': [
+              {
+                'functionName': 'main',
+                'isBlockCoverage': true,
+                'ranges': [
+                  {'startOffset': 0, 'endOffset': 10, 'count': 1},
+                  {'startOffset': 10, 'endOffset': 15, 'count': 0},
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      io.File('${tempDir.path}/.dart_tool/patrol/web_coverage/test-1.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(jsonEncode(coverageData));
+
+      await tool.run(
+        flutterPackageName: 'example_app',
+        packagesRegExps: {RegExp('example_app')},
+        ignoreGlobs: {},
+      );
+
+      final report = reportFs
+          .file('coverage/patrol_lcov.info')
+          .readAsStringSync();
+      expect(report, contains('lib/main.dart'));
+      expect(report, contains('DA:1,1'));
+      expect(report, contains('DA:2,1'));
+      expect(report, contains('DA:3,0'));
+    });
+
+    test('excludes packages not selected for the report', () async {
+      writePackageConfig();
+
+      final coverageData = {
+        'entries': [
+          {
+            'url': 'http://localhost:8080/packages/other_dep/util.dart.lib.js',
+            'scriptId': '7',
+            'source': 'aaaa\n',
+            'sourceMap': jsonEncode({
+              'version': 3,
+              'file': 'util.dart.lib.js',
+              'sources': ['org-dartlang-app:///packages/other_dep/util.dart'],
+              'names': <String>[],
+              'mappings': 'AAAA',
+            }),
+            'functions': [
+              {
+                'functionName': '',
+                'isBlockCoverage': true,
+                'ranges': [
+                  {'startOffset': 0, 'endOffset': 5, 'count': 1},
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      io.File('${tempDir.path}/.dart_tool/patrol/web_coverage/test-2.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(jsonEncode(coverageData));
+
+      await tool.run(
+        flutterPackageName: 'example_app',
+        packagesRegExps: {RegExp('example_app')},
+        ignoreGlobs: {},
+      );
+
+      verify(
+        () => logger.warn(
+          any(that: contains('did not map back to any Dart sources')),
+        ),
+      ).called(1);
+      expect(
+        reportFs.file('coverage/patrol_lcov.info').existsSync(),
+        isFalse,
+      );
+    });
+
+    test('prepareDataDirectory clears data from previous runs', () async {
+      final stale = io.File(
+        '${tempDir.path}/.dart_tool/patrol/web_coverage/stale.json',
+      )..createSync(recursive: true);
+
+      final dir = await tool.prepareDataDirectory();
+
+      expect(io.Directory(dir.path).existsSync(), isTrue);
+      expect(stale.existsSync(), isFalse);
+    });
+  });
+}

--- a/packages/patrol_cli/test/general/web_coverage_tool_test.dart
+++ b/packages/patrol_cli/test/general/web_coverage_tool_test.dart
@@ -49,6 +49,30 @@ void main() {
       expect(resolve('org-dartlang-app:///web/main.dart'), isNull);
     });
 
+    test('keeps app sources under a nested packages/ directory '
+        'in the app package', () {
+      expect(
+        resolve('org-dartlang-app:///lib/packages/widgets/button.dart'),
+        Uri.parse('package:example_app/packages/widgets/button.dart'),
+      );
+      expect(
+        resolve('org-dartlang-app:///lib/foo/packages/bar.dart'),
+        Uri.parse('package:example_app/foo/packages/bar.dart'),
+      );
+    });
+
+    test('keeps a dependency source under its own nested packages/ directory '
+        'in that dependency', () {
+      expect(
+        resolve('org-dartlang-app:///packages/dep/src/packages/inner.dart'),
+        Uri.parse('package:dep/src/packages/inner.dart'),
+      );
+    });
+
+    test('ignores packages/ sources without a path inside the package', () {
+      expect(resolve('org-dartlang-app:///packages/dep.dart'), isNull);
+    });
+
     test('ignores unknown schemes', () {
       expect(resolve('webpack:///src/index.js'), isNull);
     });
@@ -85,6 +109,17 @@ void main() {
           scriptUrl: 'http://localhost:8080/main.dart.js',
         ),
         isNull,
+      );
+    });
+
+    test('attributes relative sources under a nested packages/ directory '
+        'to the app package', () {
+      expect(
+        resolve(
+          '../../lib/foo/packages/bar.dart',
+          scriptUrl: 'http://localhost:8080/main.dart.js',
+        ),
+        Uri.parse('package:example_app/foo/packages/bar.dart'),
       );
     });
   });


### PR DESCRIPTION
Closes #3121

## What was implemented

`patrol test --coverage` now works on the web platform. Coverage was previously
collected only on Android/iOS from the Dart VM service; the browser has no Dart VM,
so web runs produced no report. This change collects the browser's native JavaScript
coverage during the Playwright run and maps it back to Dart sources, producing the
**same `coverage/patrol_lcov.info` LCOV report** as the mobile flow.

Notable differences, surfaced in `--help` and the docs:

- Web reports **covered / uncovered only**, without the per-line hit counts.
- Every **non-debug build** error out with `--coverage`. It previously just silently skipped coverage collection

## How it works

During a web test run the Playwright runner records Chrome's native JavaScript
coverage (with source maps) for each test. Afterwards the CLI reads that data,
maps the covered JS back to the original Dart lines through the source maps, and
writes the same LCOV report as on mobile. The VM and web paths share the report
formatting and package/workspace filtering, so the output is consistent across
platforms.

## Results

Ran the existing `text_fields_test.dart` on both an Android emulator and Chrome with
`--coverage`. Both produce a valid report over the same file set; below is the
coverage of the exercised widget (`text_fields_screen.dart`):

| Platform | Lines | Covered | % |
|---|---|---|---|
| Android (VM) | 17 | 17 | 100% |
| Web (V8 + source maps) | 21 | 20 | 95.2% |

The two agree on the widget body. The gap is the documented behaviour: web is binary
covered/uncovered (no hit counts) and the toolchains differ slightly on which lines
are "coverable" — web instruments a few more lines (e.g. the field initializer and the
`const` constructor, which it marks uncovered) that the VM omits.