### PR TITLE
fix: stabilise flaky iOS CI and fix patrol develop hang

### DIFF
--- a/dev/e2e_app/patrol_test/enter_text_native_test.dart
+++ b/dev/e2e_app/patrol_test/enter_text_native_test.dart
@@ -6,8 +6,10 @@ void main() {
 
     await $('Open webview (Hacker News)').scrollTo().tap();
 
-    await $.pump(Duration(seconds: 5));
-
+    // The Hacker News page is loaded into the webview over the network. Wait
+    // for its content to actually render instead of racing a fixed delay,
+    // which is flaky on CI when the page is slow to load.
+    await $.platform.mobile.waitUntilVisible(Selector(text: 'login'));
     await $.platform.mobile.tap(Selector(text: 'login'));
     await $.platform.ios.enterText(
       IOSSelector(elementType: IOSElementType.textField),

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix iOS tests that pass being reported as failed with `Failed to terminate <app>:0`. The app under test now hard-exits shortly after reporting its result to the native side, so XCUITest's teardown finds the process already gone instead of racing Flutter's slow graceful shutdown on loaded CI simulators. (#2291, #1474)
+
 ## 4.7.1
 
 - Add a Swift Package Manager support note to the README.

--- a/packages/patrol/lib/src/platform/mobile/patrol_app_service_io.dart
+++ b/packages/patrol/lib/src/platform/mobile/patrol_app_service_io.dart
@@ -2,12 +2,15 @@
 // ignore_for_file: avoid_print
 
 import 'dart:async';
+import 'dart:io' show exit;
 
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:patrol/patrol.dart';
 import 'package:patrol/src/common.dart';
+import 'package:patrol/src/constants.dart' as constants;
 import 'package:patrol/src/platform/contracts/contracts.dart';
 import 'package:patrol/src/platform/contracts/patrol_app_service_server.dart';
+import 'package:patrol/src/platform/current.dart' as current_platform;
 import 'package:patrol_log/patrol_log.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
@@ -173,11 +176,47 @@ class PatrolAppService extends PatrolAppServiceServer {
       );
     }
 
+    _scheduleFastExitIfNeeded();
+
     return RunDartTestResponse(
       result: testExecutionResult.passed
           ? RunDartTestResponseResult.success
           : RunDartTestResponseResult.failure,
       details: testExecutionResult.details,
+    );
+  }
+
+  /// Hard-exits the app process shortly after the result of a Dart test has
+  /// been reported back to the native side, on iOS only.
+  ///
+  /// The native side runs each Dart test in its own freshly launched app
+  /// process, and [runDartTest] is called exactly once per process. When the
+  /// test finishes, XCUITest terminates the app under test during its teardown
+  /// and waits — with a fixed, short internal timeout — for the process to
+  /// reach the "Not Running" state. Flutter's graceful shutdown on a loaded CI
+  /// simulator is frequently slower than that timeout, so XCUITest reports
+  /// `Failed to terminate <app>:0` and fails a test that actually passed.
+  ///
+  /// See:
+  ///  * https://github.com/leancodepl/patrol/issues/2291
+  ///  * https://github.com/leancodepl/patrol/issues/1474
+  ///
+  /// A hard [exit] makes the process disappear almost immediately, so by the
+  /// time XCUITest terminates it there is nothing left to wait for. The delay
+  /// is long enough for this HTTP response to flush to the native side over the
+  /// loopback socket (which happens within milliseconds) before the process
+  /// dies, yet far shorter than the slow graceful shutdown that trips the
+  /// timeout.
+  ///
+  /// It is skipped in Hot Restart (develop) mode, where the app must stay alive
+  /// between runs, and on Android, whose Espresso-based runner is unaffected.
+  void _scheduleFastExitIfNeeded() {
+    if (!current_platform.isIOS || constants.hotRestartEnabled) {
+      return;
+    }
+
+    unawaited(
+      Future<void>.delayed(const Duration(milliseconds: 500), () => exit(0)),
     );
   }
 }

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix `patrol develop` hanging on the iOS simulator and Android emulator. Hot Restart attach now always uses the VM service URL discovered from `flutter logs` instead of Flutter's discovery-based attach ("Waiting for a connection from Flutter ..."), which could wait forever on CI and never arm Hot Restart.
 - Download only Chromium instead of all default Playwright browsers during web runner setup. (#3156)
 - Fix `patrol develop` not reporting completion when the app shuts down before the tests finish, causing `patrol_mcp` to hang until its timeout. The backend exit is now detected independently of `flutter attach`.
 - Fix `patrol test -d chrome` failing with `No devices attached` on machines without a system Chrome installation. (#3172)

--- a/packages/patrol_cli/lib/src/commands/develop_service.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_service.dart
@@ -456,7 +456,15 @@ class DevelopService {
           appId: appId,
           dartDefines: flutterOpts.dartDefines,
           openDevtools: openDevtools,
-          attachUsingUrl: device.targetPlatform == TargetPlatform.macOS,
+          // Always attach using the VM service URL discovered from
+          // `flutter logs`, on every native platform. Discovery-based attach
+          // (Flutter's "Waiting for a connection from Flutter ..." mode) is
+          // unreliable on the iOS simulator and Android emulator on CI: it can
+          // wait forever without ever connecting, so Hot Restart is never armed
+          // and `patrol develop` hangs. The URL-based path is deterministic and
+          // has been used for macOS all along. Web never reaches this call (see
+          // the `!= TargetPlatform.web` guard above).
+          attachUsingUrl: true,
           onQuit: onQuitCleanup,
         );
       }


### PR DESCRIPTION
## What & why

Three CI-stabilisation changes, from investigating recurring red/flaky workflows.

### 1. iOS `Failed to terminate <app>:0` flake (`test ios simulator`, `test ios simulator webview`)
The Dart test **passes**, but XCUITest's teardown `terminate()` waits on a fixed internal timeout for the app to stop; Flutter's graceful shutdown on a loaded CI simulator is often slower, so the run is reported failed with `Failed to terminate <app>:0`. Confirmed from simulator logs: terminate errored ~2s *before* the app actually died.
**Fix:** on iOS, the app hard-exits ~500ms after reporting its result to the native side (guarded to iOS, skipped in develop/Hot-Restart mode), so teardown finds the process already gone. (#2291, #1474)

### 2. `patrol develop` hang (`test patrol develop`)
Hot-Restart attach used Flutter's discovery mode (`Waiting for a connection from Flutter ...`), which hangs indefinitely on the iOS simulator / Android emulator on CI and never arms Hot Restart → 330s inactivity timeout.
**Fix:** always attach using the VM service URL discovered from `flutter logs` (the deterministic path already used for macOS).

### 3. `enter_text_native_test` external-site flake (webview job)
Replaced a fixed `pump(5s)` with `waitUntilVisible` so a slow Hacker News page load doesn't race a fixed delay.

## Validation notes
- **Not yet CI-validated** — iOS/simulator behaviour only manifests on CI.
- The `test patrol develop` **PR check runs master's code** (`pull_request_target` + plain checkout), so it does **not** exercise this branch's develop fix — validate that via `workflow_dispatch` on this branch instead.
- `test ios simulator webview` is dispatch/cron only — also validate via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)