### PR TITLE
Add patrol_mcp badge to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![patrol on pub.dev][patrol_badge]][patrol_link]
 [![patrol_cli on pub.dev][patrol_cli_badge]][patrol_cli_link]
 [![patrol_finders on pub.dev][patrol_finders_badge]][patrol_finders_link]
+[![patrol_mcp on pub.dev][patrol_mcp_badge]][patrol_mcp_link]
 [![patrol_discord]][patrol_discord_link]
 [![code style][leancode_lint_badge]][leancode_lint_link]
 [![patrol_github_stars]][patrol_github_link]
@@ -218,6 +219,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 
 [patrol_badge]: https://img.shields.io/pub/v/patrol?label=patrol
 [patrol_finders_badge]: https://img.shields.io/pub/v/patrol_finders?label=patrol_finders
+[patrol_mcp_badge]: https://img.shields.io/pub/v/patrol_mcp?label=patrol_mcp
 [patrol_cli_badge]: https://img.shields.io/pub/v/patrol_cli?label=patrol_cli
 [leancode_lint_badge]: https://img.shields.io/badge/code%20style-leancode__lint-black
 [patrol_github_stars]: https://img.shields.io/github/stars/leancodepl/patrol
@@ -225,6 +227,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 [patrol_discord]: https://img.shields.io/discord/1167030497612922931?color=blue&logo=discord
 [patrol_link]: https://pub.dev/packages/patrol
 [patrol_finders_link]: https://pub.dev/packages/patrol_finders
+[patrol_mcp_link]: https://pub.dev/packages/patrol_mcp
 [patrol_cli_link]: https://pub.dev/packages/patrol_cli
 [leancode_lint_link]: https://pub.dev/packages/leancode_lint
 [patrol_x_link]: https://x.com/patrol_leancode

--- a/packages/patrol/README.md
+++ b/packages/patrol/README.md
@@ -3,6 +3,7 @@
 [![patrol on pub.dev][patrol_badge]][patrol_link]
 [![patrol_cli on pub.dev][patrol_cli_badge]][patrol_cli_link]
 [![patrol_finders on pub.dev][patrol_finders_badge]][patrol_finders_link]
+[![patrol_mcp on pub.dev][patrol_mcp_badge]][patrol_mcp_link]
 [![patrol_discord]][patrol_discord_link]
 [![code style][leancode_lint_badge]][leancode_lint_link]
 [![patrol_github_stars]][patrol_github_link]
@@ -166,6 +167,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 [skills]: https://github.com/leancodepl/patrol/tree/master/skills
 [patrol_badge]: https://img.shields.io/pub/v/patrol?label=patrol
 [patrol_finders_badge]: https://img.shields.io/pub/v/patrol_finders?label=patrol_finders
+[patrol_mcp_badge]: https://img.shields.io/pub/v/patrol_mcp?label=patrol_mcp
 [patrol_cli_badge]: https://img.shields.io/pub/v/patrol_cli?label=patrol_cli
 [leancode_lint_badge]: https://img.shields.io/badge/code%20style-leancode__lint-blue
 [patrol_github_stars]: https://img.shields.io/github/stars/leancodepl/patrol
@@ -173,6 +175,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 [patrol_discord]: https://img.shields.io/discord/1167030497612922931?color=blue&logo=discord
 [patrol_link]: https://pub.dev/packages/patrol
 [patrol_finders_link]: https://pub.dev/packages/patrol_finders
+[patrol_mcp_link]: https://pub.dev/packages/patrol_mcp
 [patrol_cli_link]: https://pub.dev/packages/patrol_cli
 [leancode_lint_link]: https://pub.dev/packages/leancode_lint
 [patrol_x_link]: https://x.com/patrol_leancode

--- a/packages/patrol_cli/README.md
+++ b/packages/patrol_cli/README.md
@@ -3,6 +3,7 @@
 [![patrol on pub.dev][patrol_badge]][patrol_link]
 [![patrol_cli on pub.dev][patrol_cli_badge]][patrol_cli_link]
 [![patrol_finders on pub.dev][patrol_finders_badge]][patrol_finders_link]
+[![patrol_mcp on pub.dev][patrol_mcp_badge]][patrol_mcp_link]
 [![patrol_discord]][patrol_discord_link]
 [![code style][leancode_lint_badge]][leancode_lint_link]
 [![patrol_github_stars]][patrol_github_link]
@@ -113,6 +114,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 [cli_completion package]: https://pub.dev/packages/cli_completion
 [patrol_badge]: https://img.shields.io/pub/v/patrol?label=patrol
 [patrol_finders_badge]: https://img.shields.io/pub/v/patrol_finders?label=patrol_finders
+[patrol_mcp_badge]: https://img.shields.io/pub/v/patrol_mcp?label=patrol_mcp
 [patrol_cli_badge]: https://img.shields.io/pub/v/patrol_cli?label=patrol_cli
 [leancode_lint_badge]: https://img.shields.io/badge/code%20style-leancode__lint-blue
 [patrol_github_stars]: https://img.shields.io/github/stars/leancodepl/patrol
@@ -120,6 +122,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 [patrol_discord]: https://img.shields.io/discord/1167030497612922931?color=blue&logo=discord
 [patrol_link]: https://pub.dev/packages/patrol
 [patrol_finders_link]: https://pub.dev/packages/patrol_finders
+[patrol_mcp_link]: https://pub.dev/packages/patrol_mcp
 [patrol_cli_link]: https://pub.dev/packages/patrol_cli
 [leancode_lint_link]: https://pub.dev/packages/leancode_lint
 [patrol_x_link]: https://x.com/patrol_leancode

--- a/packages/patrol_finders/README.md
+++ b/packages/patrol_finders/README.md
@@ -3,6 +3,7 @@
 [![patrol on pub.dev][patrol_badge]][patrol_link]
 [![patrol_cli on pub.dev][patrol_cli_badge]][patrol_cli_link]
 [![patrol_finders on pub.dev][patrol_finders_badge]][patrol_finders_link]
+[![patrol_mcp on pub.dev][patrol_mcp_badge]][patrol_mcp_link]
 [![patrol_discord]][patrol_discord_link]
 [![code style][leancode_lint_badge]][leancode_lint_link]
 [![patrol_github_stars]][patrol_github_link]
@@ -113,6 +114,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 [custom finders]: https://patrol.leancode.co/finders/overview
 [patrol_badge]: https://img.shields.io/pub/v/patrol?label=patrol
 [patrol_finders_badge]: https://img.shields.io/pub/v/patrol_finders?label=patrol_finders
+[patrol_mcp_badge]: https://img.shields.io/pub/v/patrol_mcp?label=patrol_mcp
 [patrol_cli_badge]: https://img.shields.io/pub/v/patrol_cli?label=patrol_cli
 [leancode_lint_badge]: https://img.shields.io/badge/code%20style-leancode__lint-blue
 [patrol_github_stars]: https://img.shields.io/github/stars/leancodepl/patrol
@@ -120,6 +122,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 [patrol_discord]: https://img.shields.io/discord/1167030497612922931?color=blue&logo=discord
 [patrol_link]: https://pub.dev/packages/patrol
 [patrol_finders_link]: https://pub.dev/packages/patrol_finders
+[patrol_mcp_link]: https://pub.dev/packages/patrol_mcp
 [patrol_cli_link]: https://pub.dev/packages/patrol_cli
 [leancode_lint_link]: https://pub.dev/packages/leancode_lint
 [patrol_x_link]: https://x.com/patrol_leancode

--- a/packages/patrol_mcp/README.md
+++ b/packages/patrol_mcp/README.md
@@ -3,6 +3,7 @@
 [![patrol on pub.dev][patrol_badge]][patrol_link]
 [![patrol_cli on pub.dev][patrol_cli_badge]][patrol_cli_link]
 [![patrol_finders on pub.dev][patrol_finders_badge]][patrol_finders_link]
+[![patrol_mcp on pub.dev][patrol_mcp_badge]][patrol_mcp_link]
 [![patrol_discord]][patrol_discord_link]
 [![code style][leancode_lint_badge]][leancode_lint_link]
 [![patrol_github_stars]][patrol_github_link]
@@ -204,6 +205,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 
 [patrol_badge]: https://img.shields.io/pub/v/patrol?label=patrol
 [patrol_finders_badge]: https://img.shields.io/pub/v/patrol_finders?label=patrol_finders
+[patrol_mcp_badge]: https://img.shields.io/pub/v/patrol_mcp?label=patrol_mcp
 [patrol_cli_badge]: https://img.shields.io/pub/v/patrol_cli?label=patrol_cli
 [leancode_lint_badge]: https://img.shields.io/badge/code%20style-leancode__lint-blue
 [patrol_github_stars]: https://img.shields.io/github/stars/leancodepl/patrol
@@ -211,6 +213,7 @@ We are **top-tier experts** focused on Flutter Enterprise solutions.
 [patrol_discord]: https://img.shields.io/discord/1167030497612922931?color=blue&logo=discord
 [patrol_link]: https://pub.dev/packages/patrol
 [patrol_finders_link]: https://pub.dev/packages/patrol_finders
+[patrol_mcp_link]: https://pub.dev/packages/patrol_mcp
 [patrol_cli_link]: https://pub.dev/packages/patrol_cli
 [leancode_lint_link]: https://pub.dev/packages/leancode_lint
 [patrol_x_link]: https://x.com/patrol_leancode


### PR DESCRIPTION

<img width="906" height="145" alt="image" src="https://github.com/user-attachments/assets/bc079bac-d209-4b18-9401-4a11e51a0e90" />

(orange -> under 1.0.0)

Adds the `patrol_mcp` pub.dev version badge to the badge row in all READMEs that display it, styled identically to the existing `patrol` / `patrol_cli` / `patrol_finders` badges.

Updated files:
- `README.md`
- `packages/patrol/README.md`
- `packages/patrol_cli/README.md`
- `packages/patrol_finders/README.md`
- `packages/patrol_mcp/README.md`

Each got the badge display line plus its `patrol_mcp_badge` / `patrol_mcp_link` reference definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)