### PR TITLE
docs: add changelog entry for patrol extension support

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Add option to use patrol extension. (#3160)
+- Add support for Patrol extensions. (#3160)
 
 ## 4.7.1
 

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add option to use patrol extension. (#3160)
+
 ## 4.7.1
 
 - Add a Swift Package Manager support note to the README.


### PR DESCRIPTION
Adds the CHANGELOG entry missed in #3160, which added a way to register extensions/plugins to `patrol`.

- Adds a `## Unreleased` section to `packages/patrol/CHANGELOG.md` with:
  - Add option to use patrol extension. (#3160)

🤖 Generated with [Claude Code](https://claude.com/claude-code)