### PR TITLE
Fix/use ktor bom

### DIFF
--- a/dev/e2e_app/pubspec.lock
+++ b/dev/e2e_app/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -293,10 +293,10 @@ packages:
     dependency: transitive
     description:
       name: equatable
-      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.7"
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -592,6 +592,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  http_multi_server:
+    dependency: transitive
+    description:
+      name: http_multi_server
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
@@ -740,18 +748,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   mcp_dart:
     dependency: transitive
     description:
@@ -764,10 +772,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -862,30 +870,30 @@ packages:
       path: "../../packages/patrol"
       relative: true
     source: path
-    version: "4.6.1"
+    version: "4.7.1"
   patrol_cli:
     dependency: "direct dev"
     description:
       path: "../../packages/patrol_cli"
       relative: true
     source: path
-    version: "4.4.0"
+    version: "4.5.1"
   patrol_finders:
     dependency: transitive
     description:
       name: patrol_finders
-      sha256: "34e75a59df653dc9e6fc6c0caa469b950b18aaa538aaf859f756b52f937f0da8"
+      sha256: "8608cdacaab90a3b00ecd7b09df11f13a62b01dea13c211b9f13fd86854e103a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.0"
   patrol_log:
     dependency: transitive
     description:
       name: patrol_log
-      sha256: "16ab747b28621640115d9493138eae82a1d410a613857cb0caf9000ce62fc546"
+      sha256: "1f5b6f7e1d9feaab7a60eef31e34a83a6168d754e5c0336006a4f50fb5f27526"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0"
+    version: "0.10.0"
   patrol_mcp:
     dependency: "direct dev"
     description:
@@ -1110,10 +1118,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   timezone:
     dependency: "direct main"
     description:

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -20,6 +20,7 @@
   - storage state
   - accept downloads
 - Add support for Patrol extensions. (#3160)
+- Bump ktor packages. (#3187)
 
 ## 4.7.1
 

--- a/packages/patrol/android/build.gradle
+++ b/packages/patrol/android/build.gradle
@@ -81,10 +81,10 @@ android {
         implementation "com.squareup.okhttp:okhttp:2.7.5" // See https://github.com/square/okhttp/issues/8031
         implementation "org.http4k:http4k-server-ktorcio"
         implementation "com.google.code.gson:gson:2.10.1"
-        implementation "io.ktor:ktor-client-core:3.0.3"
-        implementation "io.ktor:ktor-client-cio:3.0.3"
-        implementation "io.ktor:ktor-client-content-negotiation:3.0.3"
-        implementation "io.ktor:ktor-serialization-gson:3.0.3"
+        implementation "io.ktor:ktor-client-core"
+        implementation "io.ktor:ktor-client-cio"
+        implementation "io.ktor:ktor-client-content-negotiation"
+        implementation "io.ktor:ktor-serialization-gson"
 
         testImplementation "org.jetbrains.kotlin:kotlin-test"
     }

--- a/packages/patrol/android/build.gradle
+++ b/packages/patrol/android/build.gradle
@@ -76,6 +76,7 @@ android {
         api "androidx.test.uiautomator:uiautomator:2.3.0"
 
         implementation platform("org.http4k:http4k-bom:5.47.0.0")
+        implementation platform("io.ktor:ktor-bom:3.0.3")
         implementation "org.http4k:http4k-core"
         implementation "com.squareup.okhttp:okhttp:2.7.5" // See https://github.com/square/okhttp/issues/8031
         implementation "org.http4k:http4k-server-ktorcio"

--- a/packages/patrol/android/build.gradle
+++ b/packages/patrol/android/build.gradle
@@ -76,7 +76,7 @@ android {
         api "androidx.test.uiautomator:uiautomator:2.3.0"
 
         implementation platform("org.http4k:http4k-bom:5.47.0.0")
-        implementation platform("io.ktor:ktor-bom:3.0.3")
+        implementation platform("io.ktor:ktor-bom:3.2.2")
         implementation "org.http4k:http4k-core"
         implementation "com.squareup.okhttp:okhttp:2.7.5" // See https://github.com/square/okhttp/issues/8031
         implementation "org.http4k:http4k-server-ktorcio"


### PR DESCRIPTION
Another attempt to fix incompatible ktor packages versions. This PR adds ktor-bom 3.2.2. Previously we used ktor in 3.0.3. It works with our e2e_app without any changes to the app's config.