### PR TITLE
Bump patrol_cli to 4.6.0

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 4.6.0
 
 - Download only Chromium instead of all default Playwright browsers during web runner setup. (#3156)
 - Fix `patrol develop` not reporting completion when the app shuts down before the tests finish, causing `patrol_mcp` to hang until its timeout. The backend exit is now detected independently of `flutter attach`.

--- a/packages/patrol_cli/lib/src/base/constants.dart
+++ b/packages/patrol_cli/lib/src/base/constants.dart
@@ -1,3 +1,3 @@
 /// Version of Patrol CLI. Must be kept in sync with pubspec.yaml.
 /// If you update this, make sure that compatibility-table.mdx is updated (if needed)
-const version = '4.5.1';
+const version = '4.6.0';

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: patrol_cli
 description: >
   Command-line tool for Patrol, a powerful Flutter-native UI testing framework.
-version: 4.5.1  # Must be kept in sync with constants.dart
+version: 4.6.0  # Must be kept in sync with constants.dart
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol_cli
 issue_tracker: https://github.com/leancodepl/patrol/issues?q=is%3Aopen+is%3Aissue+label%3A%22package%3A+patrol_cli%22


### PR DESCRIPTION
Release `patrol_cli` 4.6.0.

Bumps the version in the three places `check_versions` validates (`pubspec.yaml`, `lib/src/base/constants.dart`, `CHANGELOG.md`) and renames the `## Unreleased` changelog heading to `## 4.6.0`.

Minor bump (not a patch) because the release includes new features alongside bug fixes:
- New `--web-*` options for web tests (#3155)
- `--web-headless` converted to a flag with `--no-web-headless` (#3155)

Tagging `patrol_cli-v4.6.0` after merge triggers the publish workflow.