### PR TITLE
fix(patrol_cli): pass flavor to flutter attach in patrol develop

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix `patrol develop` printing "You must specify a --flavor option" on iOS/macOS projects with schemes, by passing the flavor to `flutter attach`.
+
 ## 4.6.0
 
 - Download only Chromium instead of all default Playwright browsers during web runner setup. (#3156)

--- a/packages/patrol_cli/lib/src/commands/develop_service.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_service.dart
@@ -456,6 +456,7 @@ class DevelopService {
           appId: appId,
           dartDefines: flutterOpts.dartDefines,
           openDevtools: openDevtools,
+          flavor: flutterOpts.flavor,
           attachUsingUrl: device.targetPlatform == TargetPlatform.macOS,
           onQuit: onQuitCleanup,
         );

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -49,6 +49,7 @@ class FlutterTool {
     required String? appId,
     required Map<String, String> dartDefines,
     required bool openDevtools,
+    String? flavor,
     bool attachUsingUrl = false,
     Future<void> Function()? onQuit,
   }) async {
@@ -82,6 +83,7 @@ class FlutterTool {
         debugUrl: url,
         dartDefines: dartDefines,
         openBrowser: openDevtools,
+        flavor: flavor,
         onQuit: onQuitWithRevertInteractiveMode,
       );
     } else {
@@ -94,6 +96,7 @@ class FlutterTool {
           appId: appId,
           dartDefines: dartDefines,
           openBrowser: openDevtools,
+          flavor: flavor,
           onQuit: onQuitWithRevertInteractiveMode,
         ),
       ]);
@@ -115,6 +118,7 @@ class FlutterTool {
     required String? appId,
     required Map<String, String> dartDefines,
     required bool openBrowser,
+    String? flavor,
     Future<void> Function()? onQuit,
   }) async {
     await _disposeScope.run((scope) async {
@@ -128,6 +132,7 @@ class FlutterTool {
               ...['--device-id', deviceId],
               if (debugUrl != null) ...['--debug-url', debugUrl],
               if (appId != null) ...['--app-id', appId],
+              if (flavor != null) ...['--flavor', flavor],
               ...['--target', target],
               for (final dartDefine in dartDefines.entries) ...[
                 '--dart-define',

--- a/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
@@ -53,6 +53,57 @@ void main() {
 
       verify(() => processManager.start(any(that: contains('testDeviceId'))));
     });
+
+    test('attach passes --flavor when a flavor is provided', () {
+      final process = MockProcess();
+      when(
+        () => process.stdout,
+      ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
+      when(
+        () => process.stderr,
+      ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
+      when(() => processManager.start(any())).thenAnswer((_) async => process);
+
+      flutterTool.attach(
+        flutterCommand: flutterCommand,
+        deviceId: 'testDeviceId',
+        target: 'target',
+        appId: 'appId',
+        dartDefines: {},
+        openBrowser: false,
+        flavor: 'dev',
+      );
+
+      verify(
+        () => processManager.start(
+          any(that: containsAllInOrder(['attach', '--flavor', 'dev'])),
+        ),
+      );
+    });
+
+    test('attach omits --flavor when no flavor is provided', () {
+      final process = MockProcess();
+      when(
+        () => process.stdout,
+      ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
+      when(
+        () => process.stderr,
+      ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
+      when(() => processManager.start(any())).thenAnswer((_) async => process);
+
+      flutterTool.attach(
+        flutterCommand: flutterCommand,
+        deviceId: 'testDeviceId',
+        target: 'target',
+        appId: 'appId',
+        dartDefines: {},
+        openBrowser: false,
+      );
+
+      verify(
+        () => processManager.start(any(that: isNot(contains('--flavor')))),
+      );
+    });
   });
 
   group('getObservationUrl', () {


### PR DESCRIPTION
## Summary

Closes #2465.

`patrol develop` builds the app with the selected `--flavor`, but invoked `flutter attach` without it. On iOS/macOS projects that define flavor-specific schemes (e.g. `dev`, `prod`), attach then printed:

> The Xcode project defines schemes: dev, prod. You must specify a --flavor option to select one of the available schemes.

This threads the flavor through `attachForHotRestart` → `attach`, adding `--flavor <flavor>` to the `flutter attach` invocation when a flavor is set.

## Verification

- Added unit tests: `attach` includes `--flavor <flavor>` when a flavor is provided and omits it otherwise.
- `flutter_tool` test suite passes (11 tests), `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)