### PR TITLE
ci: require a CHANGELOG entry for package source changes

### DIFF
--- a/.github/workflows/check-changelog.yaml
+++ b/.github/workflows/check-changelog.yaml
@@ -1,0 +1,24 @@
+name: check changelog
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'packages/**'
+      - 'tool/check_changelog.sh'
+      - '.github/workflows/check-changelog.yaml'
+
+jobs:
+  check-changelog:
+    name: Check CHANGELOG entries
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip changelog') }}
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check CHANGELOG entries
+        run: tool/check_changelog.sh "origin/${{ github.base_ref }}"

--- a/.github/workflows/check-changelog.yaml
+++ b/.github/workflows/check-changelog.yaml
@@ -3,6 +3,9 @@ name: check changelog
 on:
   workflow_dispatch:
   pull_request:
+    # `labeled`/`unlabeled` are included so toggling the `skip changelog`
+    # label re-evaluates the job condition below and updates the check status.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - 'packages/**'
       - 'tool/check_changelog.sh'
@@ -21,4 +24,6 @@ jobs:
           fetch-depth: 0
 
       - name: Check CHANGELOG entries
-        run: tool/check_changelog.sh "origin/${{ github.base_ref }}"
+        # github.base_ref is empty on workflow_dispatch, so fall back to the
+        # repository's default branch.
+        run: tool/check_changelog.sh "origin/${{ github.base_ref || github.event.repository.default_branch }}"

--- a/tool/check_changelog.sh
+++ b/tool/check_changelog.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Ensures that a pull request touching a package's source also updates that
+# package's CHANGELOG.md. Run locally with:
+#
+#   tool/check_changelog.sh [base-ref]
+#
+# `base-ref` defaults to `origin/master`. The set of changed files is computed
+# as the diff between the merge-base of `base-ref` and HEAD.
+#
+# A package is any `packages/*` directory that has a CHANGELOG.md. A change
+# requires a changelog entry unless every changed file in that package is one
+# of: the CHANGELOG.md itself, a test, an example, or a Markdown doc.
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+base_ref="${1:-origin/master}"
+
+changed_files="$(git diff --name-only "$base_ref"...HEAD)"
+
+fail=0
+err() { echo "❌ $1"; fail=1; }
+
+# Files that don't warrant a changelog entry on their own.
+is_exempt() {
+  local file="$1" pkg="$2"
+  case "$file" in
+    "$pkg/CHANGELOG.md") return 0 ;;
+    "$pkg"/test/*) return 0 ;;
+    "$pkg"/*/test/*) return 0 ;;
+    "$pkg"/example/*) return 0 ;;
+    "$pkg"/integration_test/*) return 0 ;;
+    *.md) return 0 ;;
+  esac
+  return 1
+}
+
+for changelog in packages/*/CHANGELOG.md; do
+  pkg="$(dirname "$changelog")"
+  name="$(basename "$pkg")"
+
+  changelog_changed=0
+  source_changed=0
+
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    case "$file" in
+      "$pkg"/*) ;;
+      *) continue ;;
+    esac
+
+    if [ "$file" = "$changelog" ]; then
+      changelog_changed=1
+    fi
+    if ! is_exempt "$file" "$pkg"; then
+      source_changed=1
+    fi
+  done <<< "$changed_files"
+
+  if [ "$source_changed" -eq 1 ] && [ "$changelog_changed" -eq 0 ]; then
+    err "$name: source changed but $changelog was not updated. Add an entry under '## Unreleased' (or label the PR 'skip changelog' if this change is not user-facing)."
+  fi
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "✅ CHANGELOG check passed"
+fi
+
+exit "$fail"


### PR DESCRIPTION
## Summary

Closes #2318.

Adds a `check changelog` GitHub Actions workflow (backed by `tool/check_changelog.sh`, runnable locally) that fails a pull request which changes a package's source without updating that package's `CHANGELOG.md`.

Rules:
- Applies to every `packages/*` directory that has a `CHANGELOG.md`.
- Exempt (no entry required): the `CHANGELOG.md` itself, `test/`, `example/`, `integration_test/`, and any `*.md` file.
- Bypass for non-user-facing changes: add the `skip changelog` label to the PR.

## How to use

**As a contributor** — when your PR touches a package's source (e.g. `packages/patrol_cli/lib/...`), add an entry under the `## Unreleased` heading of that package's `CHANGELOG.md`. Create the heading if it isn't there yet:

```markdown
## Unreleased

- Short, user-facing description of the change. (#<PR>)

## 4.6.0
...
```

The check runs automatically on every PR and reports **Check CHANGELOG entries** in the PR's checks. If it fails, the log names the package that's missing an entry, e.g.:

```
❌ patrol_cli: source changed but packages/patrol_cli/CHANGELOG.md was not updated.
   Add an entry under '## Unreleased' (or label the PR 'skip changelog' if this change is not user-facing).
✅ CHANGELOG check passed   # once fixed
```

**Run it locally** before pushing (diffs your branch against `origin/master` by default):

```bash
tool/check_changelog.sh              # compare against origin/master
tool/check_changelog.sh origin/main  # or an explicit base ref
```

**Skipping** — for changes that aren't user-facing (internal refactors, CI, tooling), add the **`skip changelog`** label to the PR. The check re-runs when the label is toggled and turns green.

## Verification

Ran `tool/check_changelog.sh` locally against several scenarios:
- Source + CHANGELOG changed → passes.
- Source changed, CHANGELOG missing → fails with an actionable message naming the package.
- Test-only change → passes (exempt).
- This PR itself → passes (green in CI via the `pull_request` trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
