### PR TITLE
docs: document test execution order and $.tester access

### DIFF
--- a/docs/documentation/other/meta.json
+++ b/docs/documentation/other/meta.json
@@ -5,6 +5,7 @@
     "patrol-vs-code-extension",
     "patrol-devtools-extension",
     "effective-patrol",
+    "test-execution-order",
     "tips-and-tricks",
     "debugging-patrol-tests",
     "patrol-mcp",

--- a/docs/documentation/other/test-execution-order.mdx
+++ b/docs/documentation/other/test-execution-order.mdx
@@ -1,0 +1,79 @@
+---
+title: Test execution order
+---
+
+When you run `patrol test` (or `patrol build`) against a directory, Patrol
+collects every test file and bundles them into a single entrypoint. This page
+explains the order in which those tests run.
+
+### Order across test files
+
+Patrol finds every file ending with `_test.dart` (or your custom
+[`test_file_suffix`](/documentation/write-your-first-test)) under the test
+directory, **recursively**, and sorts them **alphabetically by their full
+path**. Tests then run file by file in that order.
+
+For example, given this layout:
+
+```
+patrol_test/
+├── auth/
+│   ├── sign_in_test.dart
+│   └── sign_up_test.dart
+├── home_test.dart
+└── settings_test.dart
+```
+
+the files execute in this order:
+
+```
+patrol_test/auth/sign_in_test.dart
+patrol_test/auth/sign_up_test.dart
+patrol_test/home_test.dart
+patrol_test/settings_test.dart
+```
+
+Because the sort is over the whole path, files in subdirectories are grouped
+with their directory, not interleaved with top-level files.
+
+### Order within a single test file
+
+Within a file, tests run **in the order they are declared** — top to bottom —
+just like in `package:flutter_test`. `group`s run in declaration order too, and
+the tests inside a group run before Patrol moves on to whatever is declared
+after the group.
+
+```dart
+void main() {
+  patrolTest('runs first', ($) async {});
+
+  group('a group', () {
+    patrolTest('runs second', ($) async {});
+    patrolTest('runs third', ($) async {});
+  });
+
+  patrolTest('runs fourth', ($) async {});
+}
+```
+
+### Selecting and skipping tests
+
+Running a single file targets just that file:
+
+```
+patrol test --target patrol_test/auth/sign_in_test.dart
+```
+
+You can exclude files or whole directories with `--exclude`, which does not
+change the relative order of the tests that remain:
+
+```
+patrol test --exclude patrol_test/auth
+```
+
+<Info>
+  Patrol does not run tests in parallel or in a randomized order. The order
+  described above is deterministic, so tests that depend on running after one
+  another (though we recommend keeping tests independent) will behave
+  consistently across machines and CI.
+</Info>

--- a/docs/documentation/other/tips-and-tricks.mdx
+++ b/docs/documentation/other/tips-and-tricks.mdx
@@ -170,6 +170,26 @@ if (exceptionCount != 0) {
 }
 ```
 
+### Accessing the underlying WidgetTester
+
+`PatrolIntegrationTester` (the `$` passed to your test body) is a thin wrapper
+around Flutter's [`WidgetTester`](https://api.flutter.dev/flutter/flutter_test/WidgetTester-class.html).
+Whenever you need a `WidgetTester` API that
+Patrol doesn't expose directly, reach for it through `$.tester`:
+
+```dart
+patrolTest('reads a widget property', ($) async {
+  await $.pumpWidgetAndSettle(const MyApp());
+
+  // Use any WidgetTester API via $.tester.
+  final size = $.tester.getSize(find.byType(MyBox));
+  expect(size.width, 100);
+});
+```
+
+This means you can drop down to plain `flutter_test` at any point without giving
+up Patrol's finders and native automation.
+
 ### Handling permission dialogs before the main app widget is pumped
 
 Sometimes you might want to manually request permissions in the test before the


### PR DESCRIPTION
## Summary

Closes #2137 and #405.

- **Test execution order (#2137):** new page under Documentation → Other explaining the deterministic order Patrol runs tests in — files are discovered recursively and sorted alphabetically by full path (verified in `TestFinder.findAllTests`, which sorts with `a.path.compareTo(b.path)`), and tests within a file run in declaration order like `package:flutter_test`. Also covers selecting a single file and `--exclude`.
- **$.tester (#405):** short tip in Tips and tricks showing that `PatrolIntegrationTester` wraps Flutter's `WidgetTester` and any `WidgetTester` API is reachable via `$.tester`.

## Verification

Docs-only change. Validated `meta.json` and matched the MDX structure (frontmatter, `<Info>` callout) against existing pages in the same section. Registered the new page in `documentation/other/meta.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)