### PR TITLE
[patrol_cli] Pin mason_logger to 0.3.4 to unblock package_info_plus 10.x

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Pin `mason_logger` to `0.3.4`. (#3166)
+
 ## 4.6.0
 
 - Download only Chromium instead of all default Playwright browsers during web runner setup. (#3156)

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   file: ^7.0.0
   glob: ^2.1.2
   http: ^1.1.0
-  mason_logger: ^0.3.5
+  mason_logger: 0.3.4
   meta: ^1.10.0
   package_config: ^2.1.1
   path: ^1.8.3


### PR DESCRIPTION
Fixes #3166.

## Problem

`mason_logger 0.3.5` (latest) depends on `win32 ^5.11.0`, so `patrol_cli` — and transitively `patrol_mcp` — force `win32 ^5.x`. This conflicts with `package_info_plus` 10.x, which requires `win32 ^6.0.1`, making the two impossible to reconcile.

`mason_logger 0.3.5` deliberately reverted `win32` back to `^5.11.0` ([changelog](https://pub.dev/packages/mason_logger/changelog)) because `win32 6.x`'s native assets broke *mason hook execution* on Windows — a code path `patrol_cli` does not use. `mason_logger 0.3.4` allows `win32 ^6.0.0`.

## Fix

Pin `mason_logger` to `0.3.4`, which lets `win32` resolve to `6.x` and unblocks `package_info_plus` 10.x.

## Verification

- `dart pub get` in `patrol_cli` → `mason_logger 0.3.4` + `win32 6.3.0`.
- `dart analyze` clean.
- Minimal consumer app (`package_info_plus ^10.2.0` + `patrol_cli`):
  - against `master` → version solving fails with the exact `win32 ^5.11.0` vs `^6.0.1` conflict from the issue.
  - with this change → resolves `package_info_plus 10.2.1` + `win32 6.3.0`.

`patrol_mcp` needs no code change — it depends on `patrol_cli: ^4.3.0` and inherits the fix once `patrol_cli` is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)