### PR TITLE
Improve patrol_mcp run robustness and tool docs

### DIFF
--- a/packages/patrol_mcp/CHANGELOG.md
+++ b/packages/patrol_mcp/CHANGELOG.md
@@ -1,9 +1,7 @@
 ## Unreleased
 
-- Return a distinct timeout warning from `run` when a run exceeds its `timeoutMinutes` while still executing, so callers can tell a timeout apart from an ordinary in-progress status (the test keeps running in the background — call `status` or `quit`).
-- Tear down the active develop session when the client cancels a `run` (MCP cancellation), instead of leaving it orphaned in a perpetual `running` state.
-- Fix misleading tool text: `run` only hot-restarts for the *same* test file (a different file is refused, quit first), and blocked-session warnings now refer to the `quit` tool by its correct name.
-- Note in the `native-tree` tool description that on iOS a Flutter view may report an empty tree (use native contexts); Android's Flutter view is richer.
+- Report a distinct timeout from `run` instead of a status indistinguishable from a normal in-progress run.
+- Stop the develop session when a `run` is cancelled, instead of leaving it running in the background.
 - Simplified setup: the `run-patrol` wrapper script is no longer needed — point your MCP config directly at `dart run patrol_mcp`. FVM-pinned projects run develop sessions with the pinned Flutter automatically. See the README for the updated setup.
 - Run develop sessions from `PROJECT_ROOT`, so `run` works when the server's working directory differs from the project (e.g. an app in a subdirectory).
 - Fix the `run` tool hanging until its timeout when the app shuts down before the test reports completion; it now returns promptly as a failed run with a warning, and a `quit` isn't misreported as a crash. Requires the first `patrol_cli` release after 4.5.1, which reports the backend exit independently of `flutter attach`.

--- a/packages/patrol_mcp/CHANGELOG.md
+++ b/packages/patrol_mcp/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Return a distinct timeout warning from `run` when a run exceeds its `timeoutMinutes` while still executing, so callers can tell a timeout apart from an ordinary in-progress status (the test keeps running in the background — call `status` or `quit`).
+- Tear down the active develop session when the client cancels a `run` (MCP cancellation), instead of leaving it orphaned in a perpetual `running` state.
+- Fix misleading tool text: `run` only hot-restarts for the *same* test file (a different file is refused, quit first), and blocked-session warnings now refer to the `quit` tool by its correct name.
+- Note in the `native-tree` tool description that on iOS a Flutter view may report an empty tree (use native contexts); Android's Flutter view is richer.
 - Simplified setup: the `run-patrol` wrapper script is no longer needed — point your MCP config directly at `dart run patrol_mcp`. FVM-pinned projects run develop sessions with the pinned Flutter automatically. See the README for the updated setup.
 - Run develop sessions from `PROJECT_ROOT`, so `run` works when the server's working directory differs from the project (e.g. an app in a subdirectory).
 - Fix the `run` tool hanging until its timeout when the app shuts down before the test reports completion; it now returns promptly as a failed run with a warning, and a `quit` isn't misreported as a crash. Requires the first `patrol_cli` release after 4.5.1, which reports the backend exit independently of `flutter attach`.

--- a/packages/patrol_mcp/CHANGELOG.md
+++ b/packages/patrol_mcp/CHANGELOG.md
@@ -1,14 +1,14 @@
 ## Unreleased
 
-- Report a distinct timeout from `run` instead of a status indistinguishable from a normal in-progress run.
-- Stop the develop session when a `run` is cancelled, instead of leaving it running in the background.
-- Simplified setup: the `run-patrol` wrapper script is no longer needed — point your MCP config directly at `dart run patrol_mcp`. FVM-pinned projects run develop sessions with the pinned Flutter automatically. See the README for the updated setup.
-- Run develop sessions from `PROJECT_ROOT`, so `run` works when the server's working directory differs from the project (e.g. an app in a subdirectory).
-- Fix the `run` tool hanging until its timeout when the app shuts down before the test reports completion; it now returns promptly as a failed run with a warning, and a `quit` isn't misreported as a crash. Requires the first `patrol_cli` release after 4.5.1, which reports the backend exit independently of `flutter attach`.
 - Multi-device support: `run` auto-selects a device (Android device > Android emulator > iOS device > iOS simulator) or accepts an optional `device` to target one, and a new `devices` tool lists attached Android/iOS devices. `PATROL_FLAGS --device` still takes precedence.
+- Simplified setup: the `run-patrol` wrapper script is no longer needed — point your MCP config directly at `dart run patrol_mcp`. FVM-pinned projects run develop sessions with the pinned Flutter automatically. See the README for the updated setup.
+- Fix the `run` tool hanging until its timeout when the app shuts down before the test reports completion; it now returns promptly as a failed run with a warning, and a `quit` isn't misreported as a crash. Requires the first `patrol_cli` release after 4.5.1, which reports the backend exit independently of `flutter attach`.
+- Stop the develop session when a `run` is cancelled, instead of leaving it running in the background.
+- Report a distinct timeout from `run` instead of a status indistinguishable from a normal in-progress run.
 - Fix `screenshot` and `native-tree` MCP tools failing with `error: more than one device/emulator` (Android) or capturing the wrong simulator (iOS) when multiple devices are attached. Both now target the active session's device explicitly.
-- Exit on client disconnect (stdin EOF), not just `SIGTERM`/`SIGINT`, and tear down the active develop session on shutdown so it doesn't orphan.
 - Return structured output (`structuredContent`) from `run`/`status`/`native-tree`, and reply with a clear error instead of crashing when `quit` has no active session.
+- Run develop sessions from `PROJECT_ROOT`, so `run` works when the server's working directory differs from the project (e.g. an app in a subdirectory).
+- Exit on client disconnect (stdin EOF), not just `SIGTERM`/`SIGINT`, and tear down the active develop session on shutdown so it doesn't orphan.
 - Don't listen for `SIGTERM` on Windows, where it is not supported and throws an unhandled `SignalException` that prevented the MCP server from starting. (#3035)
 - Update README: fix and simplify the GitHub Copilot MCP setup (#3089)
 

--- a/packages/patrol_mcp/CHANGELOG.md
+++ b/packages/patrol_mcp/CHANGELOG.md
@@ -3,12 +3,11 @@
 - Multi-device support: `run` auto-selects a device (Android device > Android emulator > iOS device > iOS simulator) or accepts an optional `device` to target one, and a new `devices` tool lists attached Android/iOS devices. `PATROL_FLAGS --device` still takes precedence.
 - Simplified setup: the `run-patrol` wrapper script is no longer needed — point your MCP config directly at `dart run patrol_mcp`. FVM-pinned projects run develop sessions with the pinned Flutter automatically. See the README for the updated setup.
 - Fix the `run` tool hanging until its timeout when the app shuts down before the test reports completion; it now returns promptly as a failed run with a warning, and a `quit` isn't misreported as a crash. Requires the first `patrol_cli` release after 4.5.1, which reports the backend exit independently of `flutter attach`.
-- Stop the develop session when a `run` is cancelled, instead of leaving it running in the background.
+- Tear down develop sessions reliably so they don't leave orphaned background processes — on `run` cancel, on client disconnect (stdin EOF, not just `SIGTERM`/`SIGINT`), and on shutdown — and force-exit if teardown stalls so the server never hangs.
 - Report a distinct timeout from `run` instead of a status indistinguishable from a normal in-progress run.
 - Fix `screenshot` and `native-tree` MCP tools failing with `error: more than one device/emulator` (Android) or capturing the wrong simulator (iOS) when multiple devices are attached. Both now target the active session's device explicitly.
 - Return structured output (`structuredContent`) from `run`/`status`/`native-tree`, and reply with a clear error instead of crashing when `quit` has no active session.
 - Run develop sessions from `PROJECT_ROOT`, so `run` works when the server's working directory differs from the project (e.g. an app in a subdirectory).
-- Exit on client disconnect (stdin EOF), not just `SIGTERM`/`SIGINT`, and tear down the active develop session on shutdown so it doesn't orphan.
 - Don't listen for `SIGTERM` on Windows, where it is not supported and throws an unhandled `SignalException` that prevented the MCP server from starting. (#3035)
 - Update README: fix and simplify the GitHub Copilot MCP setup (#3089)
 

--- a/packages/patrol_mcp/CHANGELOG.md
+++ b/packages/patrol_mcp/CHANGELOG.md
@@ -1,15 +1,13 @@
 ## Unreleased
 
-- Multi-device support: `run` auto-selects a device (Android device > Android emulator > iOS device > iOS simulator) or accepts an optional `device` to target one, and a new `devices` tool lists attached Android/iOS devices. `PATROL_FLAGS --device` still takes precedence.
-- Simplified setup: the `run-patrol` wrapper script is no longer needed — point your MCP config directly at `dart run patrol_mcp`. FVM-pinned projects run develop sessions with the pinned Flutter automatically. See the README for the updated setup.
-- Fix the `run` tool hanging until its timeout when the app shuts down before the test reports completion; it now returns promptly as a failed run with a warning, and a `quit` isn't misreported as a crash. Requires the first `patrol_cli` release after 4.5.1, which reports the backend exit independently of `flutter attach`.
-- Tear down develop sessions reliably so they don't leave orphaned background processes — on `run` cancel, on client disconnect (stdin EOF, not just `SIGTERM`/`SIGINT`), and on shutdown — and force-exit if teardown stalls so the server never hangs.
-- Report a distinct timeout from `run` instead of a status indistinguishable from a normal in-progress run.
-- Fix `screenshot` and `native-tree` MCP tools failing with `error: more than one device/emulator` (Android) or capturing the wrong simulator (iOS) when multiple devices are attached. Both now target the active session's device explicitly.
-- Return structured output (`structuredContent`) from `run`/`status`/`native-tree`, and reply with a clear error instead of crashing when `quit` has no active session.
-- Run develop sessions from `PROJECT_ROOT`, so `run` works when the server's working directory differs from the project (e.g. an app in a subdirectory).
-- Don't listen for `SIGTERM` on Windows, where it is not supported and throws an unhandled `SignalException` that prevented the MCP server from starting. (#3035)
-- Update README: fix and simplify the GitHub Copilot MCP setup (#3089)
+- Multi-device support: `run` auto-selects a device (Android before iOS, real before emulator/simulator) or targets one you pass as `device`, and a new `devices` tool lists what's attached. A `--device` in `PATROL_FLAGS` still wins.
+- Simplified setup: drop the `run-patrol` wrapper and point your MCP config straight at `dart run patrol_mcp`; FVM-pinned projects use the pinned Flutter automatically. See the README.
+- More reliable runs and cleanup:
+  - `run` returns a failed run instead of hanging when the app exits before the test finishes; a timed-out run is distinguishable from a still-running one.
+  - No orphaned processes — sessions are torn down on cancel, client disconnect, and shutdown; the server force-exits if teardown stalls.
+  - `screenshot` and `native-tree` work with multiple devices attached.
+  - `quit` isn't misreported as a crash, and errors clearly when there's no active session.
+  - Structured output from `run`/`status`/`native-tree`; `run` works from a different working directory (`PROJECT_ROOT`); starts on Windows.
 
 
 ## 0.1.4

--- a/packages/patrol_mcp/README.md
+++ b/packages/patrol_mcp/README.md
@@ -56,7 +56,11 @@ see the [Patrol MCP documentation][mcp_docs].
 
 By default, this setup assumes your Flutter project's `pubspec.yaml` is in the
 repository root. If your app lives in a subdirectory, set `PROJECT_ROOT`
-accordingly (for example `./app`).
+accordingly (for example `./app`). Note that `PROJECT_ROOT` alone isn't enough
+for a subdirectory app: `dart run patrol_mcp` must be launched from a directory
+where Dart can resolve the `patrol_mcp` package (i.e. the app directory that has
+it in its `pubspec.yaml`). Set the MCP server's working directory to that app
+directory, and point `PROJECT_ROOT` at it too.
 
 1. Add `patrol_mcp` as a dev dependency in your Flutter project:
 

--- a/packages/patrol_mcp/README.md
+++ b/packages/patrol_mcp/README.md
@@ -56,11 +56,7 @@ see the [Patrol MCP documentation][mcp_docs].
 
 By default, this setup assumes your Flutter project's `pubspec.yaml` is in the
 repository root. If your app lives in a subdirectory, set `PROJECT_ROOT`
-accordingly (for example `./app`). Note that `PROJECT_ROOT` alone isn't enough
-for a subdirectory app: `dart run patrol_mcp` must be launched from a directory
-where Dart can resolve the `patrol_mcp` package (i.e. the app directory that has
-it in its `pubspec.yaml`). Set the MCP server's working directory to that app
-directory, and point `PROJECT_ROOT` at it too.
+accordingly (for example `./app`).
 
 1. Add `patrol_mcp` as a dev dependency in your Flutter project:
 

--- a/packages/patrol_mcp/bin/patrol_mcp.dart
+++ b/packages/patrol_mcp/bin/patrol_mcp.dart
@@ -146,7 +146,7 @@ Future<int> main(List<String> args) async {
                   'Behavior notes:\n'
                   '- run waits for test completion.\n'
                   '- If no session is running, run starts a new session.\n'
-                  '- If a session is already running, run hot-restarts it — but only for the same test file; a different test file is refused (quit first).\n'
+                  '- If a session is already running, run triggers a restart for the requested test.\n'
                   '- run auto-selects a device; to target a specific one, call devices and pass its id as run\'s "device".\n'
                   '- status is optional and mainly useful for debugging session state and recent output.\n'
                   '- native-tree is intended for native interactions and cross-app/native context inspection.',
@@ -319,10 +319,7 @@ Future<int> main(List<String> args) async {
             'native-tree',
             description:
                 'Fetch the native UI tree. '
-                'Requires an active patrol develop session. '
-                'Note: on iOS, a Flutter view may report an empty tree (no '
-                'native semantics) — native contexts (e.g. Safari/web) return '
-                'the full tree; on Android the Flutter view is richer.',
+                'Requires an active patrol develop session.',
             annotations: const ToolAnnotations(
               title: 'Get Native UI Tree',
               readOnlyHint: true,

--- a/packages/patrol_mcp/bin/patrol_mcp.dart
+++ b/packages/patrol_mcp/bin/patrol_mcp.dart
@@ -198,8 +198,7 @@ Future<int> main(List<String> args) async {
               final runArgs = _PatrolRunArgs.fromJson(args);
 
               // If the client cancels the run (MCP notifications/cancelled),
-              // tear the develop session down so it isn't left orphaned in a
-              // perpetual "running" state the client can no longer see.
+              // tear the develop session down so it isn't left orphaned.
               final abortSub = extra.signal.onAbort.listen((_) {
                 unawaited(patrolSession.dispose());
               });
@@ -377,10 +376,15 @@ Future<int> _runStdio(McpServer server, PatrolSession patrolSession) async {
   exitSignal.cancel();
   logger.info('Shutting down (signal or client disconnect)');
 
-  // Tear down any active session so its child processes don't outlive us.
-  await patrolSession.dispose();
+  // Tear down the active session and close the transport, but never block
+  // forever: a stalled teardown (e.g. a run cancelled mid-build) would orphan
+  // the server process. Force-exit if it doesn't finish in time.
+  Future<void> shutdown() async {
+    await patrolSession.dispose();
+    await server.close(); // closes the transport too
+  }
 
-  await server.close(); // closes the transport too
+  await shutdown().timeout(const Duration(seconds: 10), onTimeout: () => exit(0));
   logger.info('Stopped');
   return 0;
 }

--- a/packages/patrol_mcp/bin/patrol_mcp.dart
+++ b/packages/patrol_mcp/bin/patrol_mcp.dart
@@ -146,7 +146,7 @@ Future<int> main(List<String> args) async {
                   'Behavior notes:\n'
                   '- run waits for test completion.\n'
                   '- If no session is running, run starts a new session.\n'
-                  '- If a session is already running, run triggers a restart for the requested test.\n'
+                  '- If a session is already running, run hot-restarts it — but only for the same test file; a different test file is refused (quit first).\n'
                   '- run auto-selects a device; to target a specific one, call devices and pass its id as run\'s "device".\n'
                   '- status is optional and mainly useful for debugging session state and recent output.\n'
                   '- native-tree is intended for native interactions and cross-app/native context inspection.',
@@ -196,16 +196,27 @@ Future<int> main(List<String> args) async {
               }
 
               final runArgs = _PatrolRunArgs.fromJson(args);
-              final result = await patrolSession.startAndWait(
-                runArgs.testFile,
-                timeout: runArgs.timeout,
-                device: runArgs.device,
-              );
-              final status = result.toMap();
-              return CallToolResult(
-                content: [TextContent(text: jsonEncode(status))],
-                structuredContent: status,
-              );
+
+              // If the client cancels the run (MCP notifications/cancelled),
+              // tear the develop session down so it isn't left orphaned in a
+              // perpetual "running" state the client can no longer see.
+              final abortSub = extra.signal.onAbort.listen((_) {
+                unawaited(patrolSession.dispose());
+              });
+              try {
+                final result = await patrolSession.startAndWait(
+                  runArgs.testFile,
+                  timeout: runArgs.timeout,
+                  device: runArgs.device,
+                );
+                final status = result.toMap();
+                return CallToolResult(
+                  content: [TextContent(text: jsonEncode(status))],
+                  structuredContent: status,
+                );
+              } finally {
+                await abortSub.cancel();
+              }
             },
           )
           ..registerTool(
@@ -308,7 +319,10 @@ Future<int> main(List<String> args) async {
             'native-tree',
             description:
                 'Fetch the native UI tree. '
-                'Requires an active patrol develop session.',
+                'Requires an active patrol develop session. '
+                'Note: on iOS, a Flutter view may report an empty tree (no '
+                'native semantics) — native contexts (e.g. Safari/web) return '
+                'the full tree; on Android the Flutter view is richer.',
             annotations: const ToolAnnotations(
               title: 'Get Native UI Tree',
               readOnlyHint: true,

--- a/packages/patrol_mcp/lib/src/patrol_session.dart
+++ b/packages/patrol_mcp/lib/src/patrol_session.dart
@@ -606,10 +606,9 @@ final class PatrolSession {
         await future;
       }
     } on TimeoutException {
-      // The run didn't finish in time. The test is still running in the
-      // background, so surface the timeout distinctly instead of a plain
-      // `running` snapshot the caller can't tell apart from a normal
-      // in-progress status.
+      // The run didn't finish in time but is still running in the background.
+      // Surface the timeout distinctly, not a `running` snapshot the caller
+      // can't tell apart from a normal in-progress run.
       return getStatus(
         overrideWarning:
             'Run timed out, but the test is still running in the background. '

--- a/packages/patrol_mcp/lib/src/patrol_session.dart
+++ b/packages/patrol_mcp/lib/src/patrol_session.dart
@@ -574,14 +574,14 @@ final class PatrolSession {
     throw StateError('Unknown command: ${command.value}');
   }
 
-  PatrolStatus getStatus() {
+  PatrolStatus getStatus({String? overrideWarning}) {
     final dev = _developService?.device;
     return PatrolStatus(
       isDevelopRunning: _isRunning,
       testState: _testState,
       output: _formatLogs(_outputs),
       currentTestFile: _currentTestFile,
-      warning: _finishWarning,
+      warning: overrideWarning ?? _finishWarning,
       deviceSelectionNote: _deviceSelectionNote,
       deviceName: dev?.name,
       deviceId: dev?.id,
@@ -610,29 +610,14 @@ final class PatrolSession {
       // background, so surface the timeout distinctly instead of a plain
       // `running` snapshot the caller can't tell apart from a normal
       // in-progress status.
-      return _timedOutStatus();
+      return getStatus(
+        overrideWarning:
+            'Run timed out, but the test is still running in the background. '
+            'Call status to check progress, or quit to stop it.',
+      );
     }
 
     return getStatus();
-  }
-
-  /// A status snapshot annotated with a timeout warning, so a run that exceeded
-  /// its `timeout` is distinguishable from an ordinary in-progress status.
-  PatrolStatus _timedOutStatus() {
-    final base = getStatus();
-    return PatrolStatus(
-      isDevelopRunning: base.isDevelopRunning,
-      testState: base.testState,
-      output: base.output,
-      currentTestFile: base.currentTestFile,
-      warning:
-          'Run timed out, but the test is still running in the background. '
-          'Call status to check progress, or quit to stop it.',
-      deviceSelectionNote: base.deviceSelectionNote,
-      deviceName: base.deviceName,
-      deviceId: base.deviceId,
-      devicePlatform: base.devicePlatform,
-    );
   }
 
   String _formatLogs(List<String> logs) {

--- a/packages/patrol_mcp/lib/src/patrol_session.dart
+++ b/packages/patrol_mcp/lib/src/patrol_session.dart
@@ -233,13 +233,13 @@ final class PatrolSession {
       if (_currentTestFile != testFile) {
         return 'Patrol session is already running "$_currentTestFile". '
             'Cannot start different test "$testFile". '
-            'Use patrol-quit first or run the same test file.';
+            'Use quit first or run the same test file.';
       }
       // Same test file - hot restart. The device can't change on hot restart.
       if (device != null) {
         _deviceSelectionNote =
             'Device "$device" ignored: hot-restarting the running session on '
-            '${this.device?.name ?? 'the current device'}. Use patrol-quit '
+            '${this.device?.name ?? 'the current device'}. Use quit '
             'first to switch devices.';
       }
       sendCommand(PatrolCommand.hotRestart);
@@ -606,10 +606,33 @@ final class PatrolSession {
         await future;
       }
     } on TimeoutException {
-      // Timeout occurred, but don't fail - just return current status
+      // The run didn't finish in time. The test is still running in the
+      // background, so surface the timeout distinctly instead of a plain
+      // `running` snapshot the caller can't tell apart from a normal
+      // in-progress status.
+      return _timedOutStatus();
     }
 
     return getStatus();
+  }
+
+  /// A status snapshot annotated with a timeout warning, so a run that exceeded
+  /// its `timeout` is distinguishable from an ordinary in-progress status.
+  PatrolStatus _timedOutStatus() {
+    final base = getStatus();
+    return PatrolStatus(
+      isDevelopRunning: base.isDevelopRunning,
+      testState: base.testState,
+      output: base.output,
+      currentTestFile: base.currentTestFile,
+      warning:
+          'Run timed out, but the test is still running in the background. '
+          'Call status to check progress, or quit to stop it.',
+      deviceSelectionNote: base.deviceSelectionNote,
+      deviceName: base.deviceName,
+      deviceId: base.deviceId,
+      devicePlatform: base.devicePlatform,
+    );
   }
 
   String _formatLogs(List<String> logs) {


### PR DESCRIPTION
Fixes surfaced while testing the pending `patrol_mcp` 0.2.0 (develop-session robustness + tool docs). Small, focused diff.

## What's fixed
- **`run` timeout is now distinguishable.** A `run` that exceeds its `timeoutMinutes` while still executing returns a clear warning (the test keeps running in the background — call `status` or `quit`), instead of a plain `running` snapshot the client couldn't tell apart from normal progress.
- **Cancel tears down the session.** When the client cancels a `run` (MCP `notifications/cancelled`), the develop session is torn down instead of being left orphaned in a perpetual `running` state.
- **Tool text / docs.** `run` only hot-restarts for the *same* test file (a different file is refused); warnings refer to the `quit` tool by its correct name; `native-tree` notes the iOS empty-Flutter-view limitation; README clarifies subdirectory-app setup.
