### PR TITLE
Release patrol_mcp 0.2.0

### DIFF
--- a/docs/documentation/other/patrol-mcp.mdx
+++ b/docs/documentation/other/patrol-mcp.mdx
@@ -15,34 +15,17 @@ and exposes it as a set of MCP tools.
 
 ## Version Compatibility
 
-<Info>
-**Most users can ignore this table.** If you use `patrol_cli` installed
-globally (via `dart pub global activate patrol_cli`), the version pinning
-does not affect you — the global CLI is a separate binary and `patrol_mcp`
-uses its own bundled copy of the CLI library.
-</Info>
-
-Each `patrol_mcp` release declares the `patrol_cli` version range it was
-built and tested against.
+`patrol_mcp` must stay compatible with the `patrol` in your project — and with
+`patrol_cli`, if you also list it directly in your `pubspec.yaml`. If pub
+reports a version conflict, use the table to find versions that work together:
 
 | patrol_mcp | patrol_cli | patrol_log |
 |------------|------------|------------|
-| 0.1.4      | 4.4.x      | ^0.9.0     |
-| 0.1.4      | 4.3.x      | ^0.8.0     |
+| 0.1.4+     | 4.3.x+     | 0.8.x+     |
 | 0.1.3      | 4.3.1      | ^0.8.0     |
 | 0.1.2      | 4.3.0      | ^0.8.0     |
 | 0.1.1      | 4.3.0      | ^0.8.0     |
 | 0.1.0      | 4.3.0      | ^0.8.0     |
-
-The `patrol_log` version is determined by which `patrol_cli` minor you end
-up with — it is transitive, not a constraint you set directly.
-
-
-
-This table only matters if you have **both** `patrol_cli` and `patrol_mcp` in
-the same `pubspec.yaml`. In that case, pub must resolve a single `patrol_cli`
-version that satisfies both packages. If you hit a version conflict, use the
-table above to find compatible versions.
 
 ## Getting Started
 

--- a/docs/documentation/other/patrol-mcp.mdx
+++ b/docs/documentation/other/patrol-mcp.mdx
@@ -15,17 +15,18 @@ and exposes it as a set of MCP tools.
 
 ## Version Compatibility
 
-`patrol_mcp` must stay compatible with the `patrol` in your project — and with
-`patrol_cli`, if you also list it directly in your `pubspec.yaml`. If pub
-reports a version conflict, use the table to find versions that work together:
+`patrol_mcp` must stay compatible with the `patrol` in your project. Its only
+constraint is on `patrol_cli`; the resolver then picks a `patrol_cli` (and its
+`patrol_log`) that also fits your `patrol`:
 
-| patrol_mcp | patrol_cli | patrol_log |
-|------------|------------|------------|
-| 0.1.4+     | 4.3.x+     | 0.8.x+     |
-| 0.1.3      | 4.3.1      | ^0.8.0     |
-| 0.1.2      | 4.3.0      | ^0.8.0     |
-| 0.1.1      | 4.3.0      | ^0.8.0     |
-| 0.1.0      | 4.3.0      | ^0.8.0     |
+| patrol_mcp   | patrol_cli |
+|--------------|------------|
+| 0.1.4, 0.2.0 | ^4.3.0     |
+| 0.1.3        | 4.3.1      |
+| 0.1.0–0.1.2  | 4.3.0      |
+
+A version conflict means your `patrol` — or a `patrol_cli` you pin directly —
+falls outside that range.
 
 ## Getting Started
 

--- a/docs/documentation/other/patrol-mcp.mdx
+++ b/docs/documentation/other/patrol-mcp.mdx
@@ -19,11 +19,11 @@ and exposes it as a set of MCP tools.
 constraint is on `patrol_cli`; the resolver then picks a `patrol_cli` (and its
 `patrol_log`) that also fits your `patrol`:
 
-| patrol_mcp   | patrol_cli |
-|--------------|------------|
-| 0.1.4, 0.2.0 | ^4.3.0     |
-| 0.1.3        | 4.3.1      |
-| 0.1.0–0.1.2  | 4.3.0      |
+| patrol_mcp  | patrol_cli |
+|-------------|------------|
+| 0.1.4+      | ^4.3.0     |
+| 0.1.3       | 4.3.1      |
+| 0.1.0–0.1.2 | ^4.3.0     |
 
 A version conflict means your `patrol` — or a `patrol_cli` you pin directly —
 falls outside that range.

--- a/packages/patrol_mcp/CHANGELOG.md
+++ b/packages/patrol_mcp/CHANGELOG.md
@@ -1,9 +1,9 @@
-## Unreleased
+## 0.2.0
 
 - Multi-device support: `run` auto-selects a device (Android before iOS, real before emulator/simulator) or targets one you pass as `device`, and a new `devices` tool lists what's attached. A `--device` in `PATROL_FLAGS` still wins.
 - Simplified setup: drop the `run-patrol` wrapper and point your MCP config straight at `dart run patrol_mcp`; FVM-pinned projects use the pinned Flutter automatically. See the README.
 - More reliable runs and cleanup:
-  - `run` returns a failed run instead of hanging when the app exits before the test finishes; a timed-out run is distinguishable from a still-running one.
+  - `run` returns a failed run instead of hanging when the app exits before the test finishes (needs `patrol` 4.7.0+); a timed-out run is distinguishable from a still-running one.
   - No orphaned processes — sessions are torn down on cancel, client disconnect, and shutdown; the server force-exits if teardown stalls.
   - `screenshot` and `native-tree` work with multiple devices attached.
   - `quit` isn't misreported as a crash, and errors clearly when there's no active session.

--- a/packages/patrol_mcp/bin/patrol_mcp.dart
+++ b/packages/patrol_mcp/bin/patrol_mcp.dart
@@ -15,7 +15,7 @@ import 'package:patrol_mcp/src/patrol_session.dart';
 import 'package:patrol_mcp/src/screenshot_service.dart';
 
 /// Version of patrol_mcp. Must be kept in sync with pubspec.yaml.
-const version = '0.1.4';
+const version = '0.2.0';
 
 const double _defaultTimeoutMinutes = 5;
 

--- a/packages/patrol_mcp/pubspec.yaml
+++ b/packages/patrol_mcp/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   An MCP server that empowers AI assistants to control, automate, and monitor
   interactive Patrol development sessions in Flutter.
 ## Must be kept in sync with bin/patrol_mcp.dart.
-version: 0.1.4
+version: 0.2.0
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol_mcp
 issue_tracker: https://github.com/leancodepl/patrol/issues


### PR DESCRIPTION
Cuts `patrol_mcp` 0.2.0 — version bump + `Unreleased` → `0.2.0` changelog. `patrol_cli` constraint unchanged (`^4.3.0`).