### PR TITLE
Fix zero-height visibleBounds on Android

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix `AndroidNativeView.visibleBounds` always having zero height. (#3202)
+
 ## 4.8.0
 
 - Wire additional Playwright browser launch and context options into the web runner config, configurable through the matching `patrol_cli` `--web-*` flags: (#3155)

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -61,7 +61,7 @@ private fun fromUiObject2(obj: UiObject2): AndroidNativeView {
             minX = bounds.left.toDouble(),
             minY = bounds.top.toDouble(),
             maxX = bounds.right.toDouble(),
-            maxY = bounds.top.toDouble()
+            maxY = bounds.bottom.toDouble()
         ),
         visibleCenter = Point2D(
             x = center.x.toDouble(),


### PR DESCRIPTION
`fromUiObject2` built the `Rectangle` with `maxY` taken from `bounds.top`, so every `AndroidNativeView.visibleBounds` reported zero height. `maxY` is the bottom edge, as `UITreeUtils` and the iOS `frame` mapping already do.

Closes #3202