### PR TITLE
feat(web): make uploadFile work with Flutter-triggered file pickers

### DIFF
--- a/packages/patrol/lib/src/platform/web/web_automator.dart
+++ b/packages/patrol/lib/src/platform/web/web_automator.dart
@@ -56,8 +56,19 @@ abstract interface class WebAutomator {
   /// Clears all cookies.
   Future<void> clearCookies();
 
-  /// Uploads files.
-  Future<void> uploadFile({required List<UploadFileData> files});
+  /// Uploads [files] to the browser file chooser that [trigger] opens.
+  ///
+  /// Flutter-web friendly. Opening a file chooser requires a trusted user
+  /// gesture, which a synthetic Patrol/Flutter tap does not provide. So this
+  /// first grants the page transient user activation and arms a one-time chooser
+  /// handler carrying [files] (supplied in-memory, no disk path), then runs
+  /// [trigger] — the app interaction that opens the picker, e.g.
+  /// `() => $(uploadButton).tap()`. The armed handler answers the chooser that
+  /// [trigger] opens.
+  Future<void> uploadFile({
+    required List<UploadFileData> files,
+    required Future<void> Function() trigger,
+  });
 
   /// Accepts the next dialog that appears.
   Future<String> acceptNextDialog();

--- a/packages/patrol/lib/src/platform/web/web_automator_native.dart
+++ b/packages/patrol/lib/src/platform/web/web_automator_native.dart
@@ -171,13 +171,21 @@ class WebAutomator implements web_automator.WebAutomator {
   }
 
   @override
-  Future<void> uploadFile({required List<UploadFileData> files}) async {
+  Future<void> uploadFile({
+    required List<UploadFileData> files,
+    required Future<void> Function() trigger,
+  }) async {
+    // Arm: grant transient user activation and register a one-time file-chooser
+    // handler carrying [files]. Returns as soon as the handler is armed.
     await callPlaywright(
       'uploadFile',
       {'files': files.map((f) => f.toJson()).toList()},
       logger: _config.logger,
       patrolLog: _patrolLog,
     );
+    // Trigger: run the app interaction that opens the picker (e.g. a tap). The
+    // armed handler supplies [files] to the chooser it opens.
+    await trigger();
   }
 
   @override

--- a/packages/patrol/web_runner/tests/actions/uploadFile.ts
+++ b/packages/patrol/web_runner/tests/actions/uploadFile.ts
@@ -1,13 +1,34 @@
 import { ActionParams, UploadFileRequest } from "../contracts"
 
-export async function uploadFile({ pageManager, params }: ActionParams<UploadFileRequest>) {
+// Opening a browser file chooser requires a trusted user gesture. A Patrol/
+// Flutter tap is a synthetic framework pointer event, not a trusted DOM gesture,
+// so the app's file <input>.click() (triggered from Flutter) would be
+// suppressed and no `filechooser` event would fire. Instead we:
+//   (1) grant the page transient user activation via a real key press — this is
+//       a window-global ~5s flag that a subsequent (synthetic-tap-triggered)
+//       input.click() can consume, so the chooser is allowed to open; and
+//   (2) arm a one-time chooser handler carrying the in-memory files.
+// We return immediately (no blocking `waitForEvent`) so the Dart side can then
+// perform the tap that opens the picker; the armed handler answers it.
+export async function uploadFile({
+  pageManager,
+  params,
+}: ActionParams<UploadFileRequest>) {
   const files = params.files.map(file => ({
     name: file.name,
     mimeType: file.mimeType,
     buffer: Buffer.from(file.base64Data, "base64"),
   }))
 
-  const fileChooser = await pageManager.activePage.waitForEvent("filechooser")
+  const page = pageManager.activePage
 
-  await fileChooser.setFiles(files)
+  // (1) Grant transient user activation.
+  await page.keyboard.press("Tab")
+
+  // (2) Arm a one-time handler that supplies the files when the app opens the
+  // chooser. Registered before this action returns, so it is listening before
+  // the caller's tap triggers the picker.
+  page.once("filechooser", async chooser => {
+    await chooser.setFiles(files)
+  })
 }


### PR DESCRIPTION
The web uploadFile action only awaited waitForEvent('filechooser') then setFiles, which cannot work when the chooser is opened by a synthetic Patrol/Flutter tap: opening a file chooser requires transient user activation, which a synthetic tap does not provide, so the picker is suppressed and no filechooser event fires.

Make uploadFile arm-then-trigger:
- Node action (web_runner/tests/actions/uploadFile.ts): grant transient user activation via a real key press (a window-global ~5s flag a later tap-triggered input.click() can consume), register a one-time filechooser handler carrying the in-memory files, and return immediately (no blocking waitForEvent).
- Dart WebAutomator.uploadFile gains a required `trigger` callback, awaited after arming - the app interaction that opens the picker, e.g. () => $(uploadButton).tap(). The armed handler answers the chooser it opens.

Usable via the existing public path: $.platform.web.uploadFile(files, trigger).