### PR TITLE
fix(e2e): bump AGP to 8.13.2 so D8 can parse Kotlin 2.3 metadata

### DIFF
--- a/dev/e2e_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/e2e_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip

--- a/dev/e2e_app/android/settings.gradle.kts
+++ b/dev/e2e_app/android/settings.gradle.kts
@@ -18,7 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.9.1" apply false
+    // Kotlin 2.3 metadata needs the D8 8.13.19 bundled since AGP 8.13.2.
+    id("com.android.application") version "8.13.2" apply false
     id("org.jetbrains.kotlin.android") version "2.3.20" apply false
 }
 


### PR DESCRIPTION
Fixes the `test patrol develop` Linux job, which timed out at 30 min on every run.

**Problem**
- Kotlin 2.3 metadata needs D8/R8 >= 8.13.19. AGP 8.9.1 bundles D8 8.9.32.
- Every Kotlin 2.3 class made D8 log a metadata warning plus a ~250-frame stack trace.
- `patrol develop` pipes gradle output line by line, stretching ~290 warnings over 20+ min into the 30 min timeout.
- Introduced by 4e3d57c66 (Kotlin 2.3.20 for google_maps_flutter_android 2.19.10) on top of AGP 8.9.1.

**Change**
- AGP 8.9.1 -> 8.13.2
- Gradle wrapper 8.12 -> 8.14.3 (required by AGP 8.13; also clears Flutter's "will soon be dropped" warnings)

**Watch out**
- AGP 8.13.0 and 8.13.1 bundle D8 8.13.17 and do **not** fix this. Only 8.13.2 bundles 8.13.19.
- R8 is shaded into `com.android.tools.build:builder`, so its version appears in no POM. Check with `java -cp builder-<version>.jar com.android.tools.r8.D8 --version`.

**Result** — [run 30903971635](https://github.com/leancodepl/patrol/actions/runs/30903971635), dispatched on this branch because `pull_request_target` tests master (see #3212)
- D8 metadata warnings: 365 -> **0**
- Linux: cancelled at 30 min -> **success in 10 min**
- macOS: success
- First green `test patrol develop` in over 100 runs.
