### PR TITLE
fix(patrol_cli): attach by VM service URL on iOS simulators in `patrol develop`

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Add `--record-video` flag to `patrol test` and `patrol develop` to record a video per test case (Android and iOS simulators). (#2741)
 - Fix `patrol test`/`patrol develop` not reading logs from iOS simulators, by streaming the simulator's log via `simctl spawn`. (#3198)
+- Fix `patrol develop` hanging on iOS simulators with `Hot Restart: not attached to the app yet`, by attaching to the Dart VM service URL read from the device logs instead of relying on `flutter attach` discovery.
 
 ## 4.6.0
 

--- a/packages/patrol_cli/lib/src/commands/develop_service.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_service.dart
@@ -462,7 +462,13 @@ class DevelopService {
           dartDefines: flutterOpts.dartDefines,
           openDevtools: openDevtools,
           flavor: flutterOpts.flavor,
-          attachUsingUrl: device.targetPlatform == TargetPlatform.macOS,
+          // xcodebuild launches the app, so `flutter attach` discovery is
+          // unreliable on the simulator. Physical devices keep using discovery.
+          attachUsingUrl: switch (device.targetPlatform) {
+            TargetPlatform.macOS => true,
+            TargetPlatform.iOS => !device.real,
+            TargetPlatform.android || TargetPlatform.web => false,
+          },
           onQuit: onQuitCleanup,
         );
       }

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -280,9 +280,11 @@ class FlutterTool {
 
       process
           .listenStdOut((line) {
-            if (line.contains('Dart VM service')) {
-              final url = getObservationUrl(line);
-              observationUrlCompleter?.complete(url);
+            final urlCompleter = observationUrlCompleter;
+            if (line.contains('Dart VM service') &&
+                urlCompleter != null &&
+                !urlCompleter.isCompleted) {
+              urlCompleter.complete(getObservationUrl(line));
             }
             if (line.startsWith('Showing ') && line.endsWith('logs:')) {
               _logger.success('Hot Restart: logs connected');


### PR DESCRIPTION
`patrol develop` on the iOS simulator hangs after the first test run and never hot restarts 

**Cause**
- `attachUsingUrl` reads the Dart VM service URL from the device logs and passes it to `flutter attach` as `--debug-url`. It was enabled for macOS only.
- iOS therefore fell back to `flutter attach` self-discovery. The app is launched by xcodebuild, and that discovery is unreliable on the simulator.
- Failing run: attach invoked with no `--debug-url`, stuck on "Waiting for a connection from Flutter on iPhone 16 Pro..." while the log stream had already reported the VM service on 127.0.0.1:56551.

**Change**
- iOS **simulators** now use the same URL-based attach as macOS. Physical iOS devices keep discovery; Android keeps it too (reliable over adb).
- Guard the URL completer against completing twice — it fires on every `Dart VM service` line, and a relaunch would throw a `StateError` in the log listener.

**Verified** — same harness CI runs, iPhone 17 Pro Max / iOS 26.4
- attach now gets `--debug-url`, `Hot Restart: attached to the app` fires, rewritten test hot-restarts and fails as expected, `HARNESS EXIT=0`.
- 394 unit tests, `dart analyze`, `dart format`, `tool/check_changelog.sh` all pass.
- CI macOS job green: [run 30905940094](https://github.com/leancodepl/patrol/actions/runs/30905940094). Same runner and simulator config that fails on #3211 without this fix ([run 30905929549](https://github.com/leancodepl/patrol/actions/runs/30905929549), no `--debug-url`, `isReloaded: false`).

Removes a flake rather than a hard failure — the macOS leg also passes intermittently without this.

**Follow-up** — `[WARN] Hot Restart: not attached to the app yet` still prints once, since `logs()` connects before `attach()` starts. Expected sequencing now, but reads as an error. Worth demoting separately.

