### PR TITLE
docs: document iOS/macOS flavor build-configuration naming convention

### DIFF
--- a/docs/documentation/index.mdx
+++ b/docs/documentation/index.mdx
@@ -785,6 +785,31 @@ Check out our video version of this tutorial on YouTube!
       bundle_id: com.example.macos.MyApp
   ```
 
+  ### iOS and macOS naming convention
+
+  On iOS and macOS, Patrol derives the Xcode **scheme** and **build configuration**
+  names from the flavor and build mode using a fixed convention. Your Xcode project
+  must match it exactly:
+
+  | Patrol input | Xcode object | Expected name |
+  |---|---|---|
+  | `--flavor development` | Scheme | `development` |
+  | `--flavor development` (debug) | Build Configuration | `Debug-development` |
+  | `--flavor development` (profile) | Build Configuration | `Profile-development` |
+  | `--flavor development` (release) | Build Configuration | `Release-development` |
+
+  The build configuration format is always `<BuildMode>-<flavor>`, with `BuildMode`
+  capitalized (`Debug`, `Profile`, `Release`). This is the same convention Flutter
+  uses for iOS flavors.
+
+  <Warning>
+    If your build configurations use a different format (for example
+    `Development-debug` instead of `Debug-development`), `xcodebuild` silently falls
+    back to its default configuration and the build fails with a misleading error
+    such as *"release/profile builds are only supported for physical devices."*
+    Rename (or duplicate) your configurations to match the convention above.
+  </Warning>
+
 ## FAQ
 
 <Accordions>
@@ -883,6 +908,16 @@ Check out our video version of this tutorial on YouTube!
   ```
 
   Make sure to replace `patrol_test/example_test.dart` with the path to your test file.
+</Accordion>
+
+<Accordion id="faq-release-profile-physical-devices" title="Build fails with 'release/profile builds are only supported for physical devices' when using a flavor">
+  This almost always means the Xcode **build configuration** name doesn't match the
+  convention Patrol expects. Patrol looks for a configuration named
+  `<BuildMode>-<flavor>` (for example `Debug-development`). If it doesn't exist,
+  `xcodebuild` silently falls back to its default and produces this misleading error.
+  Open your Xcode project and make sure your build configurations are named
+  `Debug-<flavor>`, `Profile-<flavor>` and `Release-<flavor>`. See the
+  [Flavors](#flavors) section for the full convention.
 </Accordion>
 </Accordions>
 


### PR DESCRIPTION
Addresses #2952.

**Problem**
- Patrol hardcodes the Xcode build-configuration name as `<BuildMode>-<flavor>` (e.g. `Debug-development`) in `BuildMode.createConfiguration` (`ios_test_backend.dart`).
- This convention was undocumented.
- Projects using a different format (e.g. `Development-debug`) hit a misleading error — *"release/profile builds are only supported for physical devices"* — because `xcodebuild` silently falls back to its default config.

**Changes**
- Flavors section: add an "iOS and macOS naming convention" subsection with a table (scheme + per-mode configs) and a `<Warning>` about the fallback error.
- iOS FAQ: add an entry mapping the misleading error back to a config-name mismatch, linking to the Flavors section.
- Docs-only; no code or behavior change.

**Notes**
- This is the cheapest of the three fixes proposed in #2952. Validation (surface available configs) and a configurable format remain open as follow-up code changes.