### PR TITLE
fix(patrol): make Android UiAutomation accessibility flags configurable

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Add opt-in `AndroidAutomatorConfig.dontSuppressAccessibilityServices` (dart-define `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES`) to keep third-party `AccessibilityService`s running during the session. Defaults to today's behavior. (#3216)
+- Add opt-in `AndroidAutomatorConfig.retrieveInteractiveWindows` (dart-define `PATROL_ANDROID_RETRIEVE_INTERACTIVE_WINDOWS`); set it to `false` to clear the `FLAG_RETRIEVE_INTERACTIVE_WINDOWS` that uiautomator 2.3.0 force-enables, restoring WebView native selectors. Defaults to today's behavior. (#3216)
 - Fix `AndroidNativeView.visibleBounds` always having zero height. (#3202)
 - Collect Chrome JavaScript coverage in the web runner when `patrol test --coverage` runs on the web platform.
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -1,5 +1,6 @@
 package pl.leancode.patrol
 
+import android.accessibilityservice.AccessibilityServiceInfo
 import android.app.Instrumentation
 import android.app.UiAutomation
 import android.content.Context
@@ -105,11 +106,26 @@ class Automator private constructor() {
         }
     }
 
-    fun configure(waitForSelectorTimeout: Long) {
+    fun configure(
+        waitForSelectorTimeout: Long,
+        dontSuppressAccessibilityServices: Boolean = false,
+        retrieveInteractiveWindows: Boolean = true,
+    ) {
         timeoutMillis = waitForSelectorTimeout
         configurator.waitForSelectorTimeout = waitForSelectorTimeout
         configurator.waitForIdleTimeout = 5000
         configurator.keyInjectionDelay = 50
+
+        // Opt-in (#3201): keep third-party AccessibilityServices alive during the
+        // session instead of letting the platform suppress them.
+        if (dontSuppressAccessibilityServices) {
+            configureDontSuppressAccessibilityServices()
+        }
+        // Opt-in (#3178): undo uiautomator 2.3.0 force-enabling
+        // FLAG_RETRIEVE_INTERACTIVE_WINDOWS, which breaks WebView tree population.
+        if (!retrieveInteractiveWindows) {
+            clearRetrieveInteractiveWindowsFlag()
+        }
 
         Logger.i("Timeout: $timeoutMillis ms")
         Logger.i("Android UiAutomator configuration:")
@@ -119,6 +135,89 @@ class Automator private constructor() {
         Logger.i("\tactionAcknowledgmentTimeout: ${configurator.actionAcknowledgmentTimeout} ms")
         Logger.i("\tscrollAcknowledgmentTimeout: ${configurator.scrollAcknowledgmentTimeout} ms")
         Logger.i("\ttoolType: ${configurator.toolType}")
+        Logger.i("\tuiAutomationFlags: ${configurator.uiAutomationFlags}")
+        Logger.i("\tdontSuppressAccessibilityServices: $dontSuppressAccessibilityServices")
+        Logger.i("\tretrieveInteractiveWindows: $retrieveInteractiveWindows")
+    }
+
+    // See https://github.com/leancodepl/patrol/issues/3201.
+    private fun configureDontSuppressAccessibilityServices() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            Logger.i("dontSuppressAccessibilityServices requires API 24+, ignoring")
+            return
+        }
+
+        // UiDevice.getUiAutomation() forwards Configurator.uiAutomationFlags to
+        // Instrumentation.getUiAutomation(flags), so setting it here is enough for
+        // uiautomator's own queries.
+        configurator.uiAutomationFlags = UiAutomation.FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES
+
+        // getUiAutomation(flags) reuses an existing instance only when the flags
+        // match, otherwise it reconnects. Re-acquiring our own reference forces the
+        // reconnect now and keeps it consistent with what UiDevice will use.
+        uiAutomation = uiAutomationForConfiguredFlags()
+        Logger.i("Acquired UiAutomation with FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES")
+    }
+
+    // Instrumentation.getUiAutomation(flags) exists only on API 24+. Below that,
+    // the flags-based opt-ins are unavailable and Configurator.uiAutomationFlags
+    // stays at its default (0), so the no-arg overload is equivalent.
+    private fun uiAutomationForConfiguredFlags(): UiAutomation {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            instrumentation.getUiAutomation(configurator.uiAutomationFlags)
+        } else {
+            instrumentation.uiAutomation
+        }
+    }
+
+    // See https://github.com/leancodepl/patrol/issues/3178.
+    private fun clearRetrieveInteractiveWindowsFlag() {
+        try {
+            // Same instance UiDevice queries with (both route through
+            // Instrumentation.getUiAutomation(Configurator.uiAutomationFlags)).
+            val automation = uiAutomationForConfiguredFlags()
+            val serviceInfo = automation.serviceInfo
+            if (serviceInfo == null) {
+                Logger.e("Cannot clear FLAG_RETRIEVE_INTERACTIVE_WINDOWS: serviceInfo is null")
+                return
+            }
+
+            // Mirror uiautomator 2.3.0's own (non-compressed) flag setup, minus the
+            // interactive-windows bit. Keeping FLAG_INCLUDE_NOT_IMPORTANT_VIEWS
+            // preserves normal selector behavior.
+            var flags = serviceInfo.flags
+            flags = flags or AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS
+            flags = flags and AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS.inv()
+            serviceInfo.flags = flags
+            automation.setServiceInfo(serviceInfo)
+            uiAutomation = automation
+
+            // UiDevice.getUiAutomation() re-adds FLAG_RETRIEVE_INTERACTIVE_WINDOWS
+            // whenever serviceInfo.flags != mCachedServiceFlags, or every
+            // SERVICE_FLAGS_TIMEOUT (2s). Pin its private cache so it never rewrites
+            // the flags we just set.
+            pinUiDeviceServiceFlags(flags)
+
+            Logger.i("Cleared FLAG_RETRIEVE_INTERACTIVE_WINDOWS (serviceInfo.flags=$flags)")
+        } catch (e: Throwable) {
+            Logger.e("Failed to clear FLAG_RETRIEVE_INTERACTIVE_WINDOWS, keeping default behavior", e)
+        }
+    }
+
+    private fun pinUiDeviceServiceFlags(flags: Int) {
+        val uiDeviceClass = uiDevice.javaClass
+        uiDeviceClass.getDeclaredField("mCachedServiceFlags")
+            .apply { isAccessible = true }
+            .setInt(uiDevice, flags)
+        try {
+            uiDeviceClass.getDeclaredField("mLastServiceFlagsTime")
+                .apply { isAccessible = true }
+                .setLong(uiDevice, Long.MAX_VALUE)
+        } catch (e: NoSuchFieldException) {
+            // Older uiautomator without the periodic re-check; syncing the cached
+            // flags alone is enough there.
+            Logger.i("mLastServiceFlagsTime not present, cache sync alone is enough")
+        }
     }
 
     private fun executeShellCommand(cmd: String) {

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
@@ -40,7 +40,11 @@ class AutomatorServer(private val automation: Automator) : MobileAutomatorServer
     }
 
     override fun configure(request: ConfigureRequest) {
-        automation.configure(waitForSelectorTimeout = request.findTimeoutMillis)
+        automation.configure(
+            waitForSelectorTimeout = request.findTimeoutMillis,
+            dontSuppressAccessibilityServices = request.androidDontSuppressAccessibilityServices ?: false,
+            retrieveInteractiveWindows = request.androidRetrieveInteractiveWindows ?: true,
+        )
     }
 
     override fun pressHome() {

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
@@ -216,8 +216,17 @@ class Contracts {
   }
 
   data class ConfigureRequest (
-    val findTimeoutMillis: Long
-  )
+    val findTimeoutMillis: Long,
+    val androidDontSuppressAccessibilityServices: Boolean? = null,
+    val androidRetrieveInteractiveWindows: Boolean? = null
+  ){
+    fun hasAndroidDontSuppressAccessibilityServices(): Boolean {
+      return androidDontSuppressAccessibilityServices != null
+    }
+    fun hasAndroidRetrieveInteractiveWindows(): Boolean {
+      return androidRetrieveInteractiveWindows != null
+    }
+  }
 
   data class OpenAppRequest (
     val appId: String

--- a/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Contracts.swift
+++ b/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Contracts.swift
@@ -212,6 +212,8 @@ public struct RunDartTestResponse: Codable {
 
 public struct ConfigureRequest: Codable {
   public var findTimeoutMillis: Int
+  public var androidDontSuppressAccessibilityServices: Bool?
+  public var androidRetrieveInteractiveWindows: Bool?
 }
 
 public struct OpenAppRequest: Codable {

--- a/packages/patrol/lib/src/platform/android/android_automator_config.dart
+++ b/packages/patrol/lib/src/platform/android/android_automator_config.dart
@@ -9,6 +9,8 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
     String? packageName,
     String? appName,
     KeyboardBehavior? keyboardBehavior,
+    bool? dontSuppressAccessibilityServices,
+    bool? retrieveInteractiveWindows,
     super.host,
     super.port,
     super.connectionTimeout,
@@ -19,7 +21,18 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
            const String.fromEnvironment('PATROL_APP_PACKAGE_NAME'),
        appName =
            appName ?? const String.fromEnvironment('PATROL_ANDROID_APP_NAME'),
-       keyboardBehavior = keyboardBehavior ?? KeyboardBehavior.showAndDismiss;
+       keyboardBehavior = keyboardBehavior ?? KeyboardBehavior.showAndDismiss,
+       dontSuppressAccessibilityServices =
+           dontSuppressAccessibilityServices ??
+           const bool.fromEnvironment(
+             'PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES',
+           ),
+       retrieveInteractiveWindows =
+           retrieveInteractiveWindows ??
+           const bool.fromEnvironment(
+             'PATROL_ANDROID_RETRIEVE_INTERACTIVE_WINDOWS',
+             defaultValue: true,
+           );
 
   /// How the keyboard should behave when entering text.
   ///
@@ -34,6 +47,35 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
   /// Name of the application under test on Android.
   final String appName;
 
+  /// Whether Patrol should keep third-party `AccessibilityService`s running
+  /// during the test session.
+  ///
+  /// By default Patrol acquires `UiAutomation` with `flags=0`, which makes the
+  /// platform suppress every other `AccessibilityService` (screen readers,
+  /// accessibility-based automation tools, …) for the whole session. Set this
+  /// to `true` to acquire it with `FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES`
+  /// instead, so those services keep running alongside Patrol.
+  ///
+  /// Defaults to `false` (today's behavior). Can also be set with the
+  /// `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` dart-define.
+  ///
+  /// See https://github.com/leancodepl/patrol/issues/3201.
+  final bool dontSuppressAccessibilityServices;
+
+  /// Whether Patrol keeps `FLAG_RETRIEVE_INTERACTIVE_WINDOWS` on its
+  /// `UiAutomation` accessibility service.
+  ///
+  /// uiautomator 2.3.0 force-enables this flag, which prevents some WebViews
+  /// (e.g. the Plaid Link SDK) from ever populating their accessibility tree,
+  /// so `$.native` selectors targeting text inside them fail. Set this to
+  /// `false` to clear the flag and restore the pre-2.3.0 behavior.
+  ///
+  /// Defaults to `true` (today's behavior). Can also be set with the
+  /// `PATROL_ANDROID_RETRIEVE_INTERACTIVE_WINDOWS` dart-define.
+  ///
+  /// See https://github.com/leancodepl/patrol/issues/3178.
+  final bool retrieveInteractiveWindows;
+
   /// Creates a copy of this config but with the given fields replaced with the
   /// new values.
   AndroidAutomatorConfig copyWith({
@@ -44,6 +86,8 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
     Duration? connectionTimeout,
     Duration? findTimeout,
     KeyboardBehavior? keyboardBehavior,
+    bool? dontSuppressAccessibilityServices,
+    bool? retrieveInteractiveWindows,
     void Function(String)? logger,
   }) {
     return AndroidAutomatorConfig(
@@ -54,6 +98,11 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
       connectionTimeout: connectionTimeout ?? this.connectionTimeout,
       findTimeout: findTimeout ?? this.findTimeout,
       keyboardBehavior: keyboardBehavior ?? this.keyboardBehavior,
+      dontSuppressAccessibilityServices:
+          dontSuppressAccessibilityServices ??
+          this.dontSuppressAccessibilityServices,
+      retrieveInteractiveWindows:
+          retrieveInteractiveWindows ?? this.retrieveInteractiveWindows,
       logger: logger ?? this.logger,
     );
   }

--- a/packages/patrol/lib/src/platform/android/android_automator_native.dart
+++ b/packages/patrol/lib/src/platform/android/android_automator_native.dart
@@ -56,6 +56,14 @@ class AndroidAutomator extends NativeMobileAutomator
 
   late final AndroidAutomatorClient _client;
 
+  @override
+  ConfigureRequest buildConfigureRequest() => ConfigureRequest(
+    findTimeoutMillis: _config.findTimeout.inMilliseconds,
+    androidDontSuppressAccessibilityServices:
+        _config.dontSuppressAccessibilityServices,
+    androidRetrieveInteractiveWindows: _config.retrieveInteractiveWindows,
+  );
+
   /// Opens a platform-specific app.
   ///
   /// On Android, opens the app specified by [androidAppId] (package name).

--- a/packages/patrol/lib/src/platform/contracts/contracts.dart
+++ b/packages/patrol/lib/src/platform/contracts/contracts.dart
@@ -290,17 +290,27 @@ class RunDartTestResponse with Equatable {
 
 @JsonSerializable()
 class ConfigureRequest with Equatable {
-  const ConfigureRequest({required this.findTimeoutMillis});
+  const ConfigureRequest({
+    required this.findTimeoutMillis,
+    this.androidDontSuppressAccessibilityServices,
+    this.androidRetrieveInteractiveWindows,
+  });
 
   factory ConfigureRequest.fromJson(Map<String, dynamic> json) =>
       _$ConfigureRequestFromJson(json);
 
   final int findTimeoutMillis;
+  final bool? androidDontSuppressAccessibilityServices;
+  final bool? androidRetrieveInteractiveWindows;
 
   Map<String, dynamic> toJson() => _$ConfigureRequestToJson(this);
 
   @override
-  List<Object?> get props => [findTimeoutMillis];
+  List<Object?> get props => [
+    findTimeoutMillis,
+    androidDontSuppressAccessibilityServices,
+    androidRetrieveInteractiveWindows,
+  ];
 }
 
 @JsonSerializable()

--- a/packages/patrol/lib/src/platform/contracts/contracts.g.dart
+++ b/packages/patrol/lib/src/platform/contracts/contracts.g.dart
@@ -69,10 +69,20 @@ const _$RunDartTestResponseResultEnumMap = {
 ConfigureRequest _$ConfigureRequestFromJson(Map<String, dynamic> json) =>
     ConfigureRequest(
       findTimeoutMillis: (json['findTimeoutMillis'] as num).toInt(),
+      androidDontSuppressAccessibilityServices:
+          json['androidDontSuppressAccessibilityServices'] as bool?,
+      androidRetrieveInteractiveWindows:
+          json['androidRetrieveInteractiveWindows'] as bool?,
     );
 
 Map<String, dynamic> _$ConfigureRequestToJson(ConfigureRequest instance) =>
-    <String, dynamic>{'findTimeoutMillis': instance.findTimeoutMillis};
+    <String, dynamic>{
+      'findTimeoutMillis': instance.findTimeoutMillis,
+      'androidDontSuppressAccessibilityServices':
+          instance.androidDontSuppressAccessibilityServices,
+      'androidRetrieveInteractiveWindows':
+          instance.androidRetrieveInteractiveWindows,
+    };
 
 OpenAppRequest _$OpenAppRequestFromJson(Map<String, dynamic> json) =>
     OpenAppRequest(appId: json['appId'] as String);

--- a/packages/patrol/lib/src/platform/mobile/mobile_automator_native.dart
+++ b/packages/patrol/lib/src/platform/mobile/mobile_automator_native.dart
@@ -85,6 +85,14 @@ abstract class NativeMobileAutomator implements MobileAutomator {
     }
   }
 
+  /// Builds the request sent to the native automator's `configure` endpoint.
+  ///
+  /// Platform-specific automators override this to send extra, platform-only
+  /// options (e.g. Android accessibility flags).
+  @protected
+  ConfigureRequest buildConfigureRequest() =>
+      ConfigureRequest(findTimeoutMillis: _config.findTimeout.inMilliseconds);
+
   /// Configures the native automator.
   ///
   /// Must be called before using any native features.
@@ -97,11 +105,7 @@ abstract class NativeMobileAutomator implements MobileAutomator {
       try {
         await wrapRequest(
           'configure',
-          () => _client.configure(
-            ConfigureRequest(
-              findTimeoutMillis: _config.findTimeout.inMilliseconds,
-            ),
-          ),
+          () => _client.configure(buildConfigureRequest()),
           enablePatrolLog: false,
         );
         exception = null;

--- a/packages/patrol/lib/src/platform/platform_automator.dart
+++ b/packages/patrol/lib/src/platform/platform_automator.dart
@@ -66,6 +66,18 @@ class PlatformAutomatorConfig {
     /// Name of the application under test on iOS.
     String? iosAppName,
 
+    /// Whether Patrol should keep third-party `AccessibilityService`s running
+    /// during the test session.
+    ///
+    /// Android only. See [AndroidAutomatorConfig.dontSuppressAccessibilityServices].
+    bool? androidDontSuppressAccessibilityServices,
+
+    /// Whether Patrol keeps `FLAG_RETRIEVE_INTERACTIVE_WINDOWS` on its
+    /// `UiAutomation`.
+    ///
+    /// Android only. See [AndroidAutomatorConfig.retrieveInteractiveWindows].
+    bool? androidRetrieveInteractiveWindows,
+
     /// Called when a native action is performed.
     void Function(String)? logger,
   }) {
@@ -74,6 +86,9 @@ class PlatformAutomatorConfig {
         packageName: packageName,
         appName: androidAppName,
         keyboardBehavior: keyboardBehavior,
+        dontSuppressAccessibilityServices:
+            androidDontSuppressAccessibilityServices,
+        retrieveInteractiveWindows: androidRetrieveInteractiveWindows,
         connectionTimeout: connectionTimeout,
         findTimeout: findTimeout,
         logger: logger,

--- a/packages/patrol/test/android_automator_config_test.dart
+++ b/packages/patrol/test/android_automator_config_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/src/platform/android/android_automator_config.dart';
+import 'package:patrol/src/platform/android/android_automator_native.dart';
+
+void main() {
+  group('AndroidAutomatorConfig', () {
+    test('defaults keep today behavior', () {
+      const config = AndroidAutomatorConfig();
+
+      expect(config.dontSuppressAccessibilityServices, isFalse);
+      expect(config.retrieveInteractiveWindows, isTrue);
+    });
+
+    test('copyWith overrides the accessibility flags', () {
+      const config = AndroidAutomatorConfig();
+
+      final updated = config.copyWith(
+        dontSuppressAccessibilityServices: true,
+        retrieveInteractiveWindows: false,
+      );
+
+      expect(updated.dontSuppressAccessibilityServices, isTrue);
+      expect(updated.retrieveInteractiveWindows, isFalse);
+    });
+  });
+
+  group('AndroidAutomator.buildConfigureRequest()', () {
+    test('forwards the accessibility flags to the native side', () {
+      final automator = AndroidAutomator(
+        config: const AndroidAutomatorConfig(
+          dontSuppressAccessibilityServices: true,
+          retrieveInteractiveWindows: false,
+        ),
+      );
+
+      // ignore: invalid_use_of_protected_member
+      final request = automator.buildConfigureRequest();
+
+      expect(request.androidDontSuppressAccessibilityServices, isTrue);
+      expect(request.androidRetrieveInteractiveWindows, isFalse);
+    });
+
+    test('defaults forward today behavior', () {
+      final automator = AndroidAutomator(
+        config: const AndroidAutomatorConfig(),
+      );
+
+      // ignore: invalid_use_of_protected_member
+      final request = automator.buildConfigureRequest();
+
+      expect(request.androidDontSuppressAccessibilityServices, isFalse);
+      expect(request.androidRetrieveInteractiveWindows, isTrue);
+    });
+  });
+}

--- a/packages/patrol_devtools_extension/CHANGELOG.md
+++ b/packages/patrol_devtools_extension/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Regenerate API contracts for the new Android `ConfigureRequest` accessibility flags. (#3216)
 - Bump `equatable` to `^2.1.0` and migrate API contract types from deprecated `EquatableMixin` to `with Equatable`.
 
 ## 0.4.0

--- a/packages/patrol_devtools_extension/lib/api/contracts.dart
+++ b/packages/patrol_devtools_extension/lib/api/contracts.dart
@@ -2,6 +2,7 @@
 //  Generated code. Do not modify.
 //  source: schema.dart
 //
+// ignore_for_file: public_member_api_docs
 
 import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -289,17 +290,27 @@ class RunDartTestResponse with Equatable {
 
 @JsonSerializable()
 class ConfigureRequest with Equatable {
-  const ConfigureRequest({required this.findTimeoutMillis});
+  const ConfigureRequest({
+    required this.findTimeoutMillis,
+    this.androidDontSuppressAccessibilityServices,
+    this.androidRetrieveInteractiveWindows,
+  });
 
   factory ConfigureRequest.fromJson(Map<String, dynamic> json) =>
       _$ConfigureRequestFromJson(json);
 
   final int findTimeoutMillis;
+  final bool? androidDontSuppressAccessibilityServices;
+  final bool? androidRetrieveInteractiveWindows;
 
   Map<String, dynamic> toJson() => _$ConfigureRequestToJson(this);
 
   @override
-  List<Object?> get props => [findTimeoutMillis];
+  List<Object?> get props => [
+    findTimeoutMillis,
+    androidDontSuppressAccessibilityServices,
+    androidRetrieveInteractiveWindows,
+  ];
 }
 
 @JsonSerializable()

--- a/packages/patrol_devtools_extension/lib/api/contracts.g.dart
+++ b/packages/patrol_devtools_extension/lib/api/contracts.g.dart
@@ -69,10 +69,20 @@ const _$RunDartTestResponseResultEnumMap = {
 ConfigureRequest _$ConfigureRequestFromJson(Map<String, dynamic> json) =>
     ConfigureRequest(
       findTimeoutMillis: (json['findTimeoutMillis'] as num).toInt(),
+      androidDontSuppressAccessibilityServices:
+          json['androidDontSuppressAccessibilityServices'] as bool?,
+      androidRetrieveInteractiveWindows:
+          json['androidRetrieveInteractiveWindows'] as bool?,
     );
 
 Map<String, dynamic> _$ConfigureRequestToJson(ConfigureRequest instance) =>
-    <String, dynamic>{'findTimeoutMillis': instance.findTimeoutMillis};
+    <String, dynamic>{
+      'findTimeoutMillis': instance.findTimeoutMillis,
+      'androidDontSuppressAccessibilityServices':
+          instance.androidDontSuppressAccessibilityServices,
+      'androidRetrieveInteractiveWindows':
+          instance.androidRetrieveInteractiveWindows,
+    };
 
 OpenAppRequest _$OpenAppRequestFromJson(Map<String, dynamic> json) =>
     OpenAppRequest(appId: json['appId'] as String);

--- a/schema.dart
+++ b/schema.dart
@@ -39,6 +39,16 @@ abstract class PatrolAppService<IOSClient, AndroidClient, DartServer> {
 
 class ConfigureRequest {
   late int findTimeoutMillis;
+  // Android only. When true, Patrol acquires UiAutomation with
+  // FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES so third-party
+  // AccessibilityServices keep running during the session. Defaults to today's
+  // behavior (suppressed) when absent.
+  bool? androidDontSuppressAccessibilityServices;
+  // Android only. When false, Patrol clears the
+  // FLAG_RETRIEVE_INTERACTIVE_WINDOWS that uiautomator 2.3.0 force-enables,
+  // which restores WebView accessibility-tree population. Defaults to today's
+  // behavior (flag retained) when absent.
+  bool? androidRetrieveInteractiveWindows;
 }
 
 class OpenAppRequest {


### PR DESCRIPTION
Make two Android `UiAutomation` accessibility flags configurable. Both opt-in, default = today's behavior.

**Problem**
- #3201: Patrol acquires `UiAutomation` with `flags=0`, so the platform suppresses every third-party `AccessibilityService` for the whole session.
- #3178: uiautomator 2.3.0 force-enables `FLAG_RETRIEVE_INTERACTIVE_WINDOWS`, which stops some WebViews (e.g. Plaid Link) from populating their a11y tree, breaking `$.native` selectors.

**Change**
- `AndroidAutomatorConfig.dontSuppressAccessibilityServices` (dart-define `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES`) → sets `FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` via `Configurator`.
- `AndroidAutomatorConfig.retrieveInteractiveWindows` (dart-define `PATROL_ANDROID_RETRIEVE_INTERACTIVE_WINDOWS`) → `false` clears the flag.
- Flags flow config → `ConfigureRequest` contract → `Automator.configure()`; iOS ignores them.

**Watch out**
- uiautomator re-adds the flag when `serviceInfo.flags != mCachedServiceFlags` or every `SERVICE_FLAGS_TIMEOUT` (2s), so a plain `setServiceInfo()` won't stick — `mCachedServiceFlags`/`mLastServiceFlagsTime` are pinned via reflection (guarded, degrades to default on failure).
- `FLAG_INCLUDE_NOT_IMPORTANT_VIEWS` is preserved so normal selectors keep working.

**Result**
- 14 Dart tests pass (4 new, covering config defaults + `ConfigureRequest` threading).
- Native flag effect needs on-device verification (couldn't run an emulator here).

Closes #3201
Closes #3178
