### PR TITLE
fix(patrol_cli): don't pass --flavor to flutter attach

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Unreleased
 
+- Fix hot restart silently doing nothing for the whole `patrol develop` session on projects with a flavor, by no longer passing `--flavor` to `flutter attach`, which defines no such option and exited with a usage error. Regressed in 4.6.1.
 - Support running Patrol tests on multiple iOS simulators in parallel, by reading the native automation ports at runtime in the generated test bundle. See the [Marathon integration guide](https://patrol.leancode.co/documentation/integrations/marathon).
 - Add experimental build-time test discovery, enabled with `patrol.emit_test_manifest` in
   pubspec.yaml (or `--emit-test-manifest`): Dart tests are discovered while building and each

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## Unreleased
 
-- Fix hot restart silently doing nothing for the whole `patrol develop` session on projects with a flavor, by no longer passing `--flavor` to `flutter attach`, which defines no such option and exited with a usage error. Regressed in 4.6.1.
+- Fix hot restart silently doing nothing for the whole `patrol develop` session on projects with a flavor, by no longer passing `--flavor` to `flutter attach`, which defines no such option and exited with a usage error. Regressed in 4.6.1. (#3223)
 - Support running Patrol tests on multiple iOS simulators in parallel, by reading the native automation ports at runtime in the generated test bundle. See the [Marathon integration guide](https://patrol.leancode.co/documentation/integrations/marathon).
 - Add experimental build-time test discovery, enabled with `patrol.emit_test_manifest` in
   pubspec.yaml (or `--emit-test-manifest`): Dart tests are discovered while building and each

--- a/packages/patrol_cli/lib/src/commands/develop_service.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_service.dart
@@ -461,7 +461,6 @@ class DevelopService {
           appId: appId,
           dartDefines: flutterOpts.dartDefines,
           openDevtools: openDevtools,
-          flavor: flutterOpts.flavor,
           attachUsingUrl: device.targetPlatform == TargetPlatform.macOS,
           onQuit: onQuitCleanup,
         );

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -49,7 +49,6 @@ class FlutterTool {
     required String? appId,
     required Map<String, String> dartDefines,
     required bool openDevtools,
-    String? flavor,
     bool attachUsingUrl = false,
     Future<void> Function()? onQuit,
   }) async {
@@ -83,7 +82,6 @@ class FlutterTool {
         debugUrl: url,
         dartDefines: dartDefines,
         openBrowser: openDevtools,
-        flavor: flavor,
         onQuit: onQuitWithRevertInteractiveMode,
       );
     } else {
@@ -96,7 +94,6 @@ class FlutterTool {
           appId: appId,
           dartDefines: dartDefines,
           openBrowser: openDevtools,
-          flavor: flavor,
           onQuit: onQuitWithRevertInteractiveMode,
         ),
       ]);
@@ -118,7 +115,6 @@ class FlutterTool {
     required String? appId,
     required Map<String, String> dartDefines,
     required bool openBrowser,
-    String? flavor,
     Future<void> Function()? onQuit,
   }) async {
     await _disposeScope.run((scope) async {
@@ -132,7 +128,6 @@ class FlutterTool {
               ...['--device-id', deviceId],
               if (debugUrl != null) ...['--debug-url', debugUrl],
               if (appId != null) ...['--app-id', appId],
-              if (flavor != null) ...['--flavor', flavor],
               ...['--target', target],
               for (final dartDefine in dartDefines.entries) ...[
                 '--dart-define',

--- a/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
@@ -54,9 +54,11 @@ void main() {
       verify(() => processManager.start(any(that: contains('testDeviceId'))));
     });
 
-    // `flutter attach` defines no --flavor option and exits with a usage error
-    // if it is passed one.
-    test('attach never passes --flavor', () {
+    // `flutter attach` exits with a usage error on an option it does not
+    // define, and that failure is silent, so an unvetted option here disables
+    // hot restart for a whole develop session. Check `flutter attach --help`
+    // before extending this set.
+    test('attach passes only options flutter attach defines', () {
       final process = MockProcess();
       when(
         () => process.stdout,
@@ -71,13 +73,26 @@ void main() {
         deviceId: 'testDeviceId',
         target: 'target',
         appId: 'appId',
-        dartDefines: {},
+        debugUrl: 'http://127.0.0.1:1234/abc=/',
+        dartDefines: {'key': 'value'},
         openBrowser: false,
       );
 
-      verify(
-        () => processManager.start(any(that: isNot(contains('--flavor')))),
-      );
+      final args =
+          (verify(() => processManager.start(captureAny())).captured.single
+                  as List<Object>)
+              .map((arg) => arg.toString());
+
+      expect(args.where((arg) => arg.startsWith('--')).toSet(), {
+        '--no-version-check',
+        '--suppress-analytics',
+        '--debug',
+        '--device-id',
+        '--debug-url',
+        '--app-id',
+        '--target',
+        '--dart-define',
+      });
     });
   });
 

--- a/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
@@ -54,34 +54,9 @@ void main() {
       verify(() => processManager.start(any(that: contains('testDeviceId'))));
     });
 
-    test('attach passes --flavor when a flavor is provided', () {
-      final process = MockProcess();
-      when(
-        () => process.stdout,
-      ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
-      when(
-        () => process.stderr,
-      ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
-      when(() => processManager.start(any())).thenAnswer((_) async => process);
-
-      flutterTool.attach(
-        flutterCommand: flutterCommand,
-        deviceId: 'testDeviceId',
-        target: 'target',
-        appId: 'appId',
-        dartDefines: {},
-        openBrowser: false,
-        flavor: 'dev',
-      );
-
-      verify(
-        () => processManager.start(
-          any(that: containsAllInOrder(['attach', '--flavor', 'dev'])),
-        ),
-      );
-    });
-
-    test('attach omits --flavor when no flavor is provided', () {
+    // `flutter attach` defines no --flavor option and exits with a usage error
+    // if it is passed one.
+    test('attach never passes --flavor', () {
       final process = MockProcess();
       when(
         () => process.stdout,


### PR DESCRIPTION
Closes #3223. Reverts the code from #3190, which passed `--flavor` to `flutter attach` — an option it does not define, so attach exited with a usage error and hot restart silently stopped working for the rest of the session.

#3190's test asserted the flag was passed, pinning the bug in place; it now asserts the opposite.

This reopens #2465. That warning is also a `throwToolExit`, so attach was already dying there before #3190 — silencing it needs its own change, not a flag `flutter attach` does not accept.