### PR TITLE
fix(patrol): restore not suppressing Android accessibility services (configurable)

### DIFF
--- a/docs/documentation/native/advanced.mdx
+++ b/docs/documentation/native/advanced.mdx
@@ -52,6 +52,42 @@ defaultConfig {
 }
 ```
 
+### Third-party accessibility services (Android)
+
+Patrol drives Android through `UiAutomation`. By default it acquires it with
+`FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES`, so other `AccessibilityService`s on the
+device (screen readers like TalkBack, accessibility-audit tools, accessibility-based
+automation) **keep running during the test session**.
+
+<Info>
+    In Patrol 4.8.0 these services were suppressed for the whole session. The default
+    was restored to keeping them alive; set the flag below to `false` to opt back into
+    suppression.
+</Info>
+
+Set it in your test config:
+
+```dart
+patrolTest(
+  'my test',
+  platformAutomatorConfig: PlatformAutomatorConfig.fromOptions(
+    androidDontSuppressAccessibilityServices: false, // default: true
+  ),
+  ($) async {
+    // ...
+  },
+);
+```
+
+or, without touching test code, as a dart-define:
+
+```bash
+patrol test --dart-define=PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES=false
+```
+
+Setting it to `false` can help when a native [extension package](/documentation/native/extension-packages)
+needs the default `UiAutomation` connection.
+
 ### Embrace the native tests
 
 If you've diligently followed the steps in [native automation setup] and `patrol test` prints a **TEST

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Android: keep third-party `AccessibilityService`s running during the test session again. `AndroidAutomatorConfig.dontSuppressAccessibilityServices` now defaults to `true` (it was effectively `false` since 4.8.0) and is configurable, also via the `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` dart-define. (#3227)
+
 ## 4.9.0
 
 - Fix macOS builds failing with `module 'PatrolImpl' not found` under Swift Package Manager (#3177). The public `patrol` module no longer `@import`s the Swift implementation; `PatrolPlugin` is ObjC and macro-facing types are declared as ObjC interfaces in the umbrella, so app builds and RunnerUITests keep working with a single `@import patrol` / `import patrol`.

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -100,16 +100,19 @@ class Automator private constructor() {
         if (!this::uiDevice.isInitialized) {
             uiDevice = UiDevice.getInstance(instrumentation)
         }
-        if (!this::uiAutomation.isInitialized) {
-            uiAutomation = instrumentation.uiAutomation
-        }
+        // Acquired in configure() with the requested flags (#3201), not here with flags=0.
     }
 
-    fun configure(waitForSelectorTimeout: Long) {
+    fun configure(
+        waitForSelectorTimeout: Long,
+        dontSuppressAccessibilityServices: Boolean = true
+    ) {
         timeoutMillis = waitForSelectorTimeout
         configurator.waitForSelectorTimeout = waitForSelectorTimeout
         configurator.waitForIdleTimeout = 5000
         configurator.keyInjectionDelay = 50
+
+        applyDontSuppressAccessibilityServices(dontSuppressAccessibilityServices)
 
         Logger.i("Timeout: $timeoutMillis ms")
         Logger.i("Android UiAutomator configuration:")
@@ -119,6 +122,25 @@ class Automator private constructor() {
         Logger.i("\tactionAcknowledgmentTimeout: ${configurator.actionAcknowledgmentTimeout} ms")
         Logger.i("\tscrollAcknowledgmentTimeout: ${configurator.scrollAcknowledgmentTimeout} ms")
         Logger.i("\ttoolType: ${configurator.toolType}")
+        Logger.i("\tuiAutomationFlags: ${configurator.uiAutomationFlags}")
+        Logger.i("\tdontSuppressAccessibilityServices: $dontSuppressAccessibilityServices")
+    }
+
+    // Applied for both values every configure(): the Configurator persists across a test
+    // bundle, so a later opt-out must flip the flag back. Requires API 24+.
+    private fun applyDontSuppressAccessibilityServices(dontSuppress: Boolean) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            if (!this::uiAutomation.isInitialized) {
+                uiAutomation = instrumentation.uiAutomation
+            }
+            if (dontSuppress) Logger.i("dontSuppressAccessibilityServices requires API 24+, ignoring")
+            return
+        }
+
+        val flags = if (dontSuppress) UiAutomation.FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES else 0
+        configurator.uiAutomationFlags = flags
+        uiAutomation = instrumentation.getUiAutomation(flags)
+        Logger.i("Acquired UiAutomation with uiAutomationFlags=$flags")
     }
 
     private fun executeShellCommand(cmd: String) {

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
@@ -40,7 +40,10 @@ class AutomatorServer(private val automation: Automator) : MobileAutomatorServer
     }
 
     override fun configure(request: ConfigureRequest) {
-        automation.configure(waitForSelectorTimeout = request.findTimeoutMillis)
+        automation.configure(
+            waitForSelectorTimeout = request.findTimeoutMillis,
+            dontSuppressAccessibilityServices = request.androidDontSuppressAccessibilityServices ?: true
+        )
     }
 
     override fun pressHome() {

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
@@ -216,8 +216,13 @@ class Contracts {
   }
 
   data class ConfigureRequest (
-    val findTimeoutMillis: Long
-  )
+    val findTimeoutMillis: Long,
+    val androidDontSuppressAccessibilityServices: Boolean? = null
+  ){
+    fun hasAndroidDontSuppressAccessibilityServices(): Boolean {
+      return androidDontSuppressAccessibilityServices != null
+    }
+  }
 
   data class OpenAppRequest (
     val appId: String

--- a/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Contracts.swift
+++ b/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Contracts.swift
@@ -212,6 +212,7 @@ public struct RunDartTestResponse: Codable {
 
 public struct ConfigureRequest: Codable {
   public var findTimeoutMillis: Int
+  public var androidDontSuppressAccessibilityServices: Bool?
 }
 
 public struct OpenAppRequest: Codable {

--- a/packages/patrol/lib/src/platform/android/android_automator_config.dart
+++ b/packages/patrol/lib/src/platform/android/android_automator_config.dart
@@ -9,6 +9,7 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
     String? packageName,
     String? appName,
     KeyboardBehavior? keyboardBehavior,
+    bool? dontSuppressAccessibilityServices,
     super.host,
     super.port,
     super.connectionTimeout,
@@ -19,7 +20,13 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
            const String.fromEnvironment('PATROL_APP_PACKAGE_NAME'),
        appName =
            appName ?? const String.fromEnvironment('PATROL_ANDROID_APP_NAME'),
-       keyboardBehavior = keyboardBehavior ?? KeyboardBehavior.showAndDismiss;
+       keyboardBehavior = keyboardBehavior ?? KeyboardBehavior.showAndDismiss,
+       dontSuppressAccessibilityServices =
+           dontSuppressAccessibilityServices ??
+           const bool.fromEnvironment(
+             'PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES',
+             defaultValue: true,
+           );
 
   /// How the keyboard should behave when entering text.
   ///
@@ -34,6 +41,17 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
   /// Name of the application under test on Android.
   final String appName;
 
+  /// Whether other third-party `AccessibilityService`s (screen readers,
+  /// accessibility-based tools) keep running while the test session is active.
+  ///
+  /// When `true` (the default) Patrol acquires `UiAutomation` with
+  /// `FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES`; when `false` the platform
+  /// suppresses them for the whole session. Can also be set with the
+  /// `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` dart-define.
+  ///
+  /// See https://github.com/leancodepl/patrol/issues/3201.
+  final bool dontSuppressAccessibilityServices;
+
   /// Creates a copy of this config but with the given fields replaced with the
   /// new values.
   AndroidAutomatorConfig copyWith({
@@ -44,6 +62,7 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
     Duration? connectionTimeout,
     Duration? findTimeout,
     KeyboardBehavior? keyboardBehavior,
+    bool? dontSuppressAccessibilityServices,
     void Function(String)? logger,
   }) {
     return AndroidAutomatorConfig(
@@ -54,6 +73,9 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
       connectionTimeout: connectionTimeout ?? this.connectionTimeout,
       findTimeout: findTimeout ?? this.findTimeout,
       keyboardBehavior: keyboardBehavior ?? this.keyboardBehavior,
+      dontSuppressAccessibilityServices:
+          dontSuppressAccessibilityServices ??
+          this.dontSuppressAccessibilityServices,
       logger: logger ?? this.logger,
     );
   }

--- a/packages/patrol/lib/src/platform/android/android_automator_native.dart
+++ b/packages/patrol/lib/src/platform/android/android_automator_native.dart
@@ -56,6 +56,13 @@ class AndroidAutomator extends NativeMobileAutomator
 
   late final AndroidAutomatorClient _client;
 
+  @override
+  ConfigureRequest buildConfigureRequest() => ConfigureRequest(
+    findTimeoutMillis: _config.findTimeout.inMilliseconds,
+    androidDontSuppressAccessibilityServices:
+        _config.dontSuppressAccessibilityServices,
+  );
+
   /// Opens a platform-specific app.
   ///
   /// On Android, opens the app specified by [androidAppId] (package name).

--- a/packages/patrol/lib/src/platform/contracts/contracts.dart
+++ b/packages/patrol/lib/src/platform/contracts/contracts.dart
@@ -290,17 +290,24 @@ class RunDartTestResponse with Equatable {
 
 @JsonSerializable()
 class ConfigureRequest with Equatable {
-  const ConfigureRequest({required this.findTimeoutMillis});
+  const ConfigureRequest({
+    required this.findTimeoutMillis,
+    this.androidDontSuppressAccessibilityServices,
+  });
 
   factory ConfigureRequest.fromJson(Map<String, dynamic> json) =>
       _$ConfigureRequestFromJson(json);
 
   final int findTimeoutMillis;
+  final bool? androidDontSuppressAccessibilityServices;
 
   Map<String, dynamic> toJson() => _$ConfigureRequestToJson(this);
 
   @override
-  List<Object?> get props => [findTimeoutMillis];
+  List<Object?> get props => [
+    findTimeoutMillis,
+    androidDontSuppressAccessibilityServices,
+  ];
 }
 
 @JsonSerializable()

--- a/packages/patrol/lib/src/platform/contracts/contracts.g.dart
+++ b/packages/patrol/lib/src/platform/contracts/contracts.g.dart
@@ -69,10 +69,16 @@ const _$RunDartTestResponseResultEnumMap = {
 ConfigureRequest _$ConfigureRequestFromJson(Map<String, dynamic> json) =>
     ConfigureRequest(
       findTimeoutMillis: (json['findTimeoutMillis'] as num).toInt(),
+      androidDontSuppressAccessibilityServices:
+          json['androidDontSuppressAccessibilityServices'] as bool?,
     );
 
 Map<String, dynamic> _$ConfigureRequestToJson(ConfigureRequest instance) =>
-    <String, dynamic>{'findTimeoutMillis': instance.findTimeoutMillis};
+    <String, dynamic>{
+      'findTimeoutMillis': instance.findTimeoutMillis,
+      'androidDontSuppressAccessibilityServices':
+          instance.androidDontSuppressAccessibilityServices,
+    };
 
 OpenAppRequest _$OpenAppRequestFromJson(Map<String, dynamic> json) =>
     OpenAppRequest(appId: json['appId'] as String);

--- a/packages/patrol/lib/src/platform/mobile/mobile_automator_native.dart
+++ b/packages/patrol/lib/src/platform/mobile/mobile_automator_native.dart
@@ -92,6 +92,14 @@ abstract class NativeMobileAutomator implements MobileAutomator {
     }
   }
 
+  /// Builds the request sent to the native automator's `configure` endpoint.
+  ///
+  /// Platform-specific automators override this to send extra, platform-only
+  /// options (e.g. Android accessibility flags).
+  @protected
+  ConfigureRequest buildConfigureRequest() =>
+      ConfigureRequest(findTimeoutMillis: _config.findTimeout.inMilliseconds);
+
   /// Configures the native automator.
   ///
   /// Must be called before using any native features.
@@ -104,11 +112,7 @@ abstract class NativeMobileAutomator implements MobileAutomator {
       try {
         await wrapRequest(
           'configure',
-          () => _client.configure(
-            ConfigureRequest(
-              findTimeoutMillis: _config.findTimeout.inMilliseconds,
-            ),
-          ),
+          () => _client.configure(buildConfigureRequest()),
           enablePatrolLog: false,
         );
         exception = null;

--- a/packages/patrol/lib/src/platform/platform_automator.dart
+++ b/packages/patrol/lib/src/platform/platform_automator.dart
@@ -66,6 +66,13 @@ class PlatformAutomatorConfig {
     /// Name of the application under test on iOS.
     String? iosAppName,
 
+    /// Whether Patrol should keep third-party `AccessibilityService`s running
+    /// during the test session.
+    ///
+    /// Android only. See
+    /// [AndroidAutomatorConfig.dontSuppressAccessibilityServices].
+    bool? androidDontSuppressAccessibilityServices,
+
     /// Called when a native action is performed.
     void Function(String)? logger,
 
@@ -80,6 +87,8 @@ class PlatformAutomatorConfig {
         packageName: packageName,
         appName: androidAppName,
         keyboardBehavior: keyboardBehavior,
+        dontSuppressAccessibilityServices:
+            androidDontSuppressAccessibilityServices,
         connectionTimeout: connectionTimeout,
         findTimeout: findTimeout,
         logger: logger,

--- a/packages/patrol/test/android_automator_config_test.dart
+++ b/packages/patrol/test/android_automator_config_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/src/platform/android/android_automator_config.dart';
+import 'package:patrol/src/platform/android/android_automator_native.dart';
+
+void main() {
+  group('AndroidAutomatorConfig', () {
+    test('dontSuppressAccessibilityServices defaults to true', () {
+      const config = AndroidAutomatorConfig();
+
+      expect(config.dontSuppressAccessibilityServices, isTrue);
+    });
+
+    test('copyWith overrides dontSuppressAccessibilityServices', () {
+      const config = AndroidAutomatorConfig();
+
+      expect(
+        config
+            .copyWith(dontSuppressAccessibilityServices: false)
+            .dontSuppressAccessibilityServices,
+        isFalse,
+      );
+    });
+  });
+
+  group('AndroidAutomator.buildConfigureRequest()', () {
+    test('forwards the accessibility flag to the native side', () {
+      final automator = AndroidAutomator(
+        config: const AndroidAutomatorConfig(
+          dontSuppressAccessibilityServices: false,
+        ),
+      );
+
+      final request = automator.buildConfigureRequest();
+
+      expect(request.androidDontSuppressAccessibilityServices, isFalse);
+    });
+
+    test('forwards the default (true)', () {
+      final automator = AndroidAutomator(
+        config: const AndroidAutomatorConfig(),
+      );
+
+      final request = automator.buildConfigureRequest();
+
+      expect(request.androidDontSuppressAccessibilityServices, isTrue);
+    });
+  });
+}

--- a/packages/patrol_devtools_extension/CHANGELOG.md
+++ b/packages/patrol_devtools_extension/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Regenerate API contracts for the new Android `ConfigureRequest` accessibility flag. (#3227)
+
 ## 0.4.1
 
 - Bump `equatable` to `^2.1.0` and migrate API contract types from deprecated `EquatableMixin` to `with Equatable`.

--- a/packages/patrol_devtools_extension/lib/api/contracts.dart
+++ b/packages/patrol_devtools_extension/lib/api/contracts.dart
@@ -289,17 +289,24 @@ class RunDartTestResponse with Equatable {
 
 @JsonSerializable()
 class ConfigureRequest with Equatable {
-  const ConfigureRequest({required this.findTimeoutMillis});
+  const ConfigureRequest({
+    required this.findTimeoutMillis,
+    this.androidDontSuppressAccessibilityServices,
+  });
 
   factory ConfigureRequest.fromJson(Map<String, dynamic> json) =>
       _$ConfigureRequestFromJson(json);
 
   final int findTimeoutMillis;
+  final bool? androidDontSuppressAccessibilityServices;
 
   Map<String, dynamic> toJson() => _$ConfigureRequestToJson(this);
 
   @override
-  List<Object?> get props => [findTimeoutMillis];
+  List<Object?> get props => [
+    findTimeoutMillis,
+    androidDontSuppressAccessibilityServices,
+  ];
 }
 
 @JsonSerializable()

--- a/packages/patrol_devtools_extension/lib/api/contracts.g.dart
+++ b/packages/patrol_devtools_extension/lib/api/contracts.g.dart
@@ -69,10 +69,16 @@ const _$RunDartTestResponseResultEnumMap = {
 ConfigureRequest _$ConfigureRequestFromJson(Map<String, dynamic> json) =>
     ConfigureRequest(
       findTimeoutMillis: (json['findTimeoutMillis'] as num).toInt(),
+      androidDontSuppressAccessibilityServices:
+          json['androidDontSuppressAccessibilityServices'] as bool?,
     );
 
 Map<String, dynamic> _$ConfigureRequestToJson(ConfigureRequest instance) =>
-    <String, dynamic>{'findTimeoutMillis': instance.findTimeoutMillis};
+    <String, dynamic>{
+      'findTimeoutMillis': instance.findTimeoutMillis,
+      'androidDontSuppressAccessibilityServices':
+          instance.androidDontSuppressAccessibilityServices,
+    };
 
 OpenAppRequest _$OpenAppRequestFromJson(Map<String, dynamic> json) =>
     OpenAppRequest(appId: json['appId'] as String);

--- a/schema.dart
+++ b/schema.dart
@@ -39,6 +39,9 @@ abstract class PatrolAppService<IOSClient, AndroidClient, DartServer> {
 
 class ConfigureRequest {
   late int findTimeoutMillis;
+  // Android only. true (default) keeps third-party AccessibilityServices running
+  // (FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES); false suppresses them.
+  bool? androidDontSuppressAccessibilityServices;
 }
 
 class OpenAppRequest {


### PR DESCRIPTION
Restore not suppressing third-party Android `AccessibilityService`s, and make it configurable.

**Problem**
- Until 4.7.1 Patrol acquired `UiAutomation` with `FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` (added in #849), so other a11y services (screen readers, accessibility tools) kept running.
- Commit `549bdd2d1` ("Remove unnecessary flag that breaks axe dashboard"), released in **4.8.0** via plugins PR #3160, dropped it → since 4.8.0 they're suppressed for the whole session.

**Change**
- `AndroidAutomatorConfig.dontSuppressAccessibilityServices` — plain `bool`, defaults to `true` (restores pre-4.8.0); `false` suppresses.
- Also settable via the `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` dart-define.
- Applied for both values every `configure()` and acquired there, not `initialize()`, so the flag is set before any service is suppressed (`Configurator` persists across a test bundle).
- Flows config → `ConfigureRequest` → `Automator.configure()`; iOS ignores it. API 24+.
- Docs: new "Third-party accessibility services (Android)" section in `native/advanced.mdx`.

**Watch out**
- The default flips to `true` (behavioral change vs 4.8.0). If a future native extension (e.g. `patrol_axe`) needs the old connection, set `false`.

**Result**
- 14 Dart tests pass. Native flag effect needs on-device verification — couldn't run an emulator here.

Closes #3201
