### PR TITLE
fix(patrol): let Android tests clear FLAG_RETRIEVE_INTERACTIVE_WINDOWS

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Android: keep third-party `AccessibilityService`s running during the test session again. `AndroidAutomatorConfig.dontSuppressAccessibilityServices` now defaults to `true` (it was effectively `false` since 4.8.0) and is configurable, also via the `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` dart-define. (#3227)
+- Add opt-in `AndroidAutomatorConfig.retrieveInteractiveWindows` (dart-define `PATROL_ANDROID_RETRIEVE_INTERACTIVE_WINDOWS`); set it to `false` to clear the `FLAG_RETRIEVE_INTERACTIVE_WINDOWS` that uiautomator 2.3.0 force-enables, restoring `$.native` selectors inside some WebViews. Defaults to today's behavior. (#3228)
 
 ## 4.9.0
 

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Android: keep third-party `AccessibilityService`s running during the test session again. `AndroidAutomatorConfig.dontSuppressAccessibilityServices` now defaults to `true` (it was effectively `false` since 4.8.0) and is configurable, also via the `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` dart-define. (#3227)
 - Report uncaught exceptions (e.g. from `onPressed`) in `patrol develop` instead of silently passing. (#3200)
 - Add opt-in native failure screenshots on Android for device farms (e.g. BrowserStack, Firebase Test Lab): set `screenshot_on_failure: true` in the pubspec's `patrol` section to capture the failing screen from the Dart failure path (before teardown). The screenshot is written to the folder named after the running JUnit test (read from its `Description`), so it matches what the farm reports. Also adds `$.takeNativeScreenshot('tag')` for on-demand captures. Off by default; iOS is a no-op for now. (#3222)
+- Add opt-in `AndroidAutomatorConfig.retrieveInteractiveWindows` (dart-define `PATROL_ANDROID_RETRIEVE_INTERACTIVE_WINDOWS`); set it to `false` to clear the `FLAG_RETRIEVE_INTERACTIVE_WINDOWS` that uiautomator 2.3.0 force-enables, restoring `$.native` selectors inside some WebViews. Defaults to today's behavior. (#3228)
 
 ## 4.9.0
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -1,5 +1,6 @@
 package pl.leancode.patrol
 
+import android.accessibilityservice.AccessibilityServiceInfo
 import android.app.Instrumentation
 import android.app.UiAutomation
 import android.content.ContentValues
@@ -118,7 +119,8 @@ class Automator private constructor() {
 
     fun configure(
         waitForSelectorTimeout: Long,
-        dontSuppressAccessibilityServices: Boolean = true
+        dontSuppressAccessibilityServices: Boolean = true,
+        retrieveInteractiveWindows: Boolean = true
     ) {
         timeoutMillis = waitForSelectorTimeout
         configurator.waitForSelectorTimeout = waitForSelectorTimeout
@@ -126,6 +128,9 @@ class Automator private constructor() {
         configurator.keyInjectionDelay = 50
 
         applyDontSuppressAccessibilityServices(dontSuppressAccessibilityServices)
+        if (!retrieveInteractiveWindows) {
+            clearRetrieveInteractiveWindowsFlag()
+        }
 
         Logger.i("Timeout: $timeoutMillis ms")
         Logger.i("Android UiAutomator configuration:")
@@ -137,6 +142,7 @@ class Automator private constructor() {
         Logger.i("\ttoolType: ${configurator.toolType}")
         Logger.i("\tuiAutomationFlags: ${configurator.uiAutomationFlags}")
         Logger.i("\tdontSuppressAccessibilityServices: $dontSuppressAccessibilityServices")
+        Logger.i("\tretrieveInteractiveWindows: $retrieveInteractiveWindows")
     }
 
     // Applied for both values every configure(): the Configurator persists across a test
@@ -154,6 +160,52 @@ class Automator private constructor() {
         configurator.uiAutomationFlags = flags
         uiAutomation = instrumentation.getUiAutomation(flags)
         Logger.i("Acquired UiAutomation with uiAutomationFlags=$flags")
+    }
+
+    // #3178: clear the FLAG_RETRIEVE_INTERACTIVE_WINDOWS that uiautomator 2.3.0 force-enables.
+    private fun clearRetrieveInteractiveWindowsFlag() {
+        try {
+            val automation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                instrumentation.getUiAutomation(configurator.uiAutomationFlags)
+            } else {
+                instrumentation.uiAutomation
+            }
+            val serviceInfo = automation.serviceInfo
+            if (serviceInfo == null) {
+                Logger.e("Cannot clear FLAG_RETRIEVE_INTERACTIVE_WINDOWS: serviceInfo is null")
+                return
+            }
+
+            // Keep FLAG_INCLUDE_NOT_IMPORTANT_VIEWS (uiautomator's default) so normal selectors work.
+            var flags = serviceInfo.flags
+            flags = flags or AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS
+            flags = flags and AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS.inv()
+            serviceInfo.flags = flags
+            automation.setServiceInfo(serviceInfo)
+            uiAutomation = automation
+
+            // uiautomator re-adds the flag when serviceInfo.flags != mCachedServiceFlags or every
+            // SERVICE_FLAGS_TIMEOUT (2s), so pin its private cache to keep our flags.
+            pinUiDeviceServiceFlags(flags)
+
+            Logger.i("Cleared FLAG_RETRIEVE_INTERACTIVE_WINDOWS (serviceInfo.flags=$flags)")
+        } catch (e: Throwable) {
+            Logger.e("Failed to clear FLAG_RETRIEVE_INTERACTIVE_WINDOWS, keeping default behavior", e)
+        }
+    }
+
+    private fun pinUiDeviceServiceFlags(flags: Int) {
+        val uiDeviceClass = uiDevice.javaClass
+        uiDeviceClass.getDeclaredField("mCachedServiceFlags")
+            .apply { isAccessible = true }
+            .setInt(uiDevice, flags)
+        try {
+            uiDeviceClass.getDeclaredField("mLastServiceFlagsTime")
+                .apply { isAccessible = true }
+                .setLong(uiDevice, Long.MAX_VALUE)
+        } catch (e: NoSuchFieldException) {
+            Logger.i("mLastServiceFlagsTime not present, cache sync alone is enough")
+        }
     }
 
     private fun executeShellCommand(cmd: String) {

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/Automator.kt
@@ -1,5 +1,6 @@
 package pl.leancode.patrol
 
+import android.accessibilityservice.AccessibilityServiceInfo
 import android.app.Instrumentation
 import android.app.UiAutomation
 import android.content.Context
@@ -105,7 +106,8 @@ class Automator private constructor() {
 
     fun configure(
         waitForSelectorTimeout: Long,
-        dontSuppressAccessibilityServices: Boolean = true
+        dontSuppressAccessibilityServices: Boolean = true,
+        retrieveInteractiveWindows: Boolean = true
     ) {
         timeoutMillis = waitForSelectorTimeout
         configurator.waitForSelectorTimeout = waitForSelectorTimeout
@@ -113,6 +115,9 @@ class Automator private constructor() {
         configurator.keyInjectionDelay = 50
 
         applyDontSuppressAccessibilityServices(dontSuppressAccessibilityServices)
+        if (!retrieveInteractiveWindows) {
+            clearRetrieveInteractiveWindowsFlag()
+        }
 
         Logger.i("Timeout: $timeoutMillis ms")
         Logger.i("Android UiAutomator configuration:")
@@ -124,6 +129,7 @@ class Automator private constructor() {
         Logger.i("\ttoolType: ${configurator.toolType}")
         Logger.i("\tuiAutomationFlags: ${configurator.uiAutomationFlags}")
         Logger.i("\tdontSuppressAccessibilityServices: $dontSuppressAccessibilityServices")
+        Logger.i("\tretrieveInteractiveWindows: $retrieveInteractiveWindows")
     }
 
     // Applied for both values every configure(): the Configurator persists across a test
@@ -141,6 +147,52 @@ class Automator private constructor() {
         configurator.uiAutomationFlags = flags
         uiAutomation = instrumentation.getUiAutomation(flags)
         Logger.i("Acquired UiAutomation with uiAutomationFlags=$flags")
+    }
+
+    // #3178: clear the FLAG_RETRIEVE_INTERACTIVE_WINDOWS that uiautomator 2.3.0 force-enables.
+    private fun clearRetrieveInteractiveWindowsFlag() {
+        try {
+            val automation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                instrumentation.getUiAutomation(configurator.uiAutomationFlags)
+            } else {
+                instrumentation.uiAutomation
+            }
+            val serviceInfo = automation.serviceInfo
+            if (serviceInfo == null) {
+                Logger.e("Cannot clear FLAG_RETRIEVE_INTERACTIVE_WINDOWS: serviceInfo is null")
+                return
+            }
+
+            // Keep FLAG_INCLUDE_NOT_IMPORTANT_VIEWS (uiautomator's default) so normal selectors work.
+            var flags = serviceInfo.flags
+            flags = flags or AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS
+            flags = flags and AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS.inv()
+            serviceInfo.flags = flags
+            automation.setServiceInfo(serviceInfo)
+            uiAutomation = automation
+
+            // uiautomator re-adds the flag when serviceInfo.flags != mCachedServiceFlags or every
+            // SERVICE_FLAGS_TIMEOUT (2s), so pin its private cache to keep our flags.
+            pinUiDeviceServiceFlags(flags)
+
+            Logger.i("Cleared FLAG_RETRIEVE_INTERACTIVE_WINDOWS (serviceInfo.flags=$flags)")
+        } catch (e: Throwable) {
+            Logger.e("Failed to clear FLAG_RETRIEVE_INTERACTIVE_WINDOWS, keeping default behavior", e)
+        }
+    }
+
+    private fun pinUiDeviceServiceFlags(flags: Int) {
+        val uiDeviceClass = uiDevice.javaClass
+        uiDeviceClass.getDeclaredField("mCachedServiceFlags")
+            .apply { isAccessible = true }
+            .setInt(uiDevice, flags)
+        try {
+            uiDeviceClass.getDeclaredField("mLastServiceFlagsTime")
+                .apply { isAccessible = true }
+                .setLong(uiDevice, Long.MAX_VALUE)
+        } catch (e: NoSuchFieldException) {
+            Logger.i("mLastServiceFlagsTime not present, cache sync alone is enough")
+        }
     }
 
     private fun executeShellCommand(cmd: String) {

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/AutomatorServer.kt
@@ -42,7 +42,8 @@ class AutomatorServer(private val automation: Automator) : MobileAutomatorServer
     override fun configure(request: ConfigureRequest) {
         automation.configure(
             waitForSelectorTimeout = request.findTimeoutMillis,
-            dontSuppressAccessibilityServices = request.androidDontSuppressAccessibilityServices ?: true
+            dontSuppressAccessibilityServices = request.androidDontSuppressAccessibilityServices ?: true,
+            retrieveInteractiveWindows = request.androidRetrieveInteractiveWindows ?: true
         )
     }
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
@@ -217,10 +217,14 @@ class Contracts {
 
   data class ConfigureRequest (
     val findTimeoutMillis: Long,
-    val androidDontSuppressAccessibilityServices: Boolean? = null
+    val androidDontSuppressAccessibilityServices: Boolean? = null,
+    val androidRetrieveInteractiveWindows: Boolean? = null
   ){
     fun hasAndroidDontSuppressAccessibilityServices(): Boolean {
       return androidDontSuppressAccessibilityServices != null
+    }
+    fun hasAndroidRetrieveInteractiveWindows(): Boolean {
+      return androidRetrieveInteractiveWindows != null
     }
   }
 

--- a/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Contracts.swift
+++ b/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Contracts.swift
@@ -213,6 +213,7 @@ public struct RunDartTestResponse: Codable {
 public struct ConfigureRequest: Codable {
   public var findTimeoutMillis: Int
   public var androidDontSuppressAccessibilityServices: Bool?
+  public var androidRetrieveInteractiveWindows: Bool?
 }
 
 public struct OpenAppRequest: Codable {

--- a/packages/patrol/lib/src/platform/android/android_automator_config.dart
+++ b/packages/patrol/lib/src/platform/android/android_automator_config.dart
@@ -10,6 +10,7 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
     String? appName,
     KeyboardBehavior? keyboardBehavior,
     bool? dontSuppressAccessibilityServices,
+    bool? retrieveInteractiveWindows,
     super.host,
     super.port,
     super.connectionTimeout,
@@ -25,6 +26,12 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
            dontSuppressAccessibilityServices ??
            const bool.fromEnvironment(
              'PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES',
+             defaultValue: true,
+           ),
+       retrieveInteractiveWindows =
+           retrieveInteractiveWindows ??
+           const bool.fromEnvironment(
+             'PATROL_ANDROID_RETRIEVE_INTERACTIVE_WINDOWS',
              defaultValue: true,
            );
 
@@ -52,6 +59,18 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
   /// See https://github.com/leancodepl/patrol/issues/3201.
   final bool dontSuppressAccessibilityServices;
 
+  /// Whether Patrol keeps `FLAG_RETRIEVE_INTERACTIVE_WINDOWS` on its
+  /// `UiAutomation`.
+  ///
+  /// uiautomator 2.3.0 force-enables this flag, which stops some WebViews (e.g.
+  /// Plaid Link) from populating their accessibility tree, so `$.native`
+  /// selectors targeting text inside them fail. Set to `false` to clear it and
+  /// restore the pre-2.3.0 behavior. Defaults to `true`. Can also be set with
+  /// the `PATROL_ANDROID_RETRIEVE_INTERACTIVE_WINDOWS` dart-define.
+  ///
+  /// See https://github.com/leancodepl/patrol/issues/3178.
+  final bool retrieveInteractiveWindows;
+
   /// Creates a copy of this config but with the given fields replaced with the
   /// new values.
   AndroidAutomatorConfig copyWith({
@@ -63,6 +82,7 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
     Duration? findTimeout,
     KeyboardBehavior? keyboardBehavior,
     bool? dontSuppressAccessibilityServices,
+    bool? retrieveInteractiveWindows,
     void Function(String)? logger,
   }) {
     return AndroidAutomatorConfig(
@@ -76,6 +96,8 @@ class AndroidAutomatorConfig extends MobileAutomatorConfig {
       dontSuppressAccessibilityServices:
           dontSuppressAccessibilityServices ??
           this.dontSuppressAccessibilityServices,
+      retrieveInteractiveWindows:
+          retrieveInteractiveWindows ?? this.retrieveInteractiveWindows,
       logger: logger ?? this.logger,
     );
   }

--- a/packages/patrol/lib/src/platform/android/android_automator_native.dart
+++ b/packages/patrol/lib/src/platform/android/android_automator_native.dart
@@ -61,6 +61,7 @@ class AndroidAutomator extends NativeMobileAutomator
     findTimeoutMillis: _config.findTimeout.inMilliseconds,
     androidDontSuppressAccessibilityServices:
         _config.dontSuppressAccessibilityServices,
+    androidRetrieveInteractiveWindows: _config.retrieveInteractiveWindows,
   );
 
   /// Opens a platform-specific app.

--- a/packages/patrol/lib/src/platform/contracts/contracts.dart
+++ b/packages/patrol/lib/src/platform/contracts/contracts.dart
@@ -293,6 +293,7 @@ class ConfigureRequest with Equatable {
   const ConfigureRequest({
     required this.findTimeoutMillis,
     this.androidDontSuppressAccessibilityServices,
+    this.androidRetrieveInteractiveWindows,
   });
 
   factory ConfigureRequest.fromJson(Map<String, dynamic> json) =>
@@ -300,6 +301,7 @@ class ConfigureRequest with Equatable {
 
   final int findTimeoutMillis;
   final bool? androidDontSuppressAccessibilityServices;
+  final bool? androidRetrieveInteractiveWindows;
 
   Map<String, dynamic> toJson() => _$ConfigureRequestToJson(this);
 
@@ -307,6 +309,7 @@ class ConfigureRequest with Equatable {
   List<Object?> get props => [
     findTimeoutMillis,
     androidDontSuppressAccessibilityServices,
+    androidRetrieveInteractiveWindows,
   ];
 }
 

--- a/packages/patrol/lib/src/platform/contracts/contracts.g.dart
+++ b/packages/patrol/lib/src/platform/contracts/contracts.g.dart
@@ -71,6 +71,8 @@ ConfigureRequest _$ConfigureRequestFromJson(Map<String, dynamic> json) =>
       findTimeoutMillis: (json['findTimeoutMillis'] as num).toInt(),
       androidDontSuppressAccessibilityServices:
           json['androidDontSuppressAccessibilityServices'] as bool?,
+      androidRetrieveInteractiveWindows:
+          json['androidRetrieveInteractiveWindows'] as bool?,
     );
 
 Map<String, dynamic> _$ConfigureRequestToJson(ConfigureRequest instance) =>
@@ -78,6 +80,8 @@ Map<String, dynamic> _$ConfigureRequestToJson(ConfigureRequest instance) =>
       'findTimeoutMillis': instance.findTimeoutMillis,
       'androidDontSuppressAccessibilityServices':
           instance.androidDontSuppressAccessibilityServices,
+      'androidRetrieveInteractiveWindows':
+          instance.androidRetrieveInteractiveWindows,
     };
 
 OpenAppRequest _$OpenAppRequestFromJson(Map<String, dynamic> json) =>

--- a/packages/patrol/lib/src/platform/platform_automator.dart
+++ b/packages/patrol/lib/src/platform/platform_automator.dart
@@ -73,6 +73,12 @@ class PlatformAutomatorConfig {
     /// [AndroidAutomatorConfig.dontSuppressAccessibilityServices].
     bool? androidDontSuppressAccessibilityServices,
 
+    /// Whether Patrol keeps `FLAG_RETRIEVE_INTERACTIVE_WINDOWS` on its
+    /// `UiAutomation`.
+    ///
+    /// Android only. See [AndroidAutomatorConfig.retrieveInteractiveWindows].
+    bool? androidRetrieveInteractiveWindows,
+
     /// Called when a native action is performed.
     void Function(String)? logger,
 
@@ -89,6 +95,7 @@ class PlatformAutomatorConfig {
         keyboardBehavior: keyboardBehavior,
         dontSuppressAccessibilityServices:
             androidDontSuppressAccessibilityServices,
+        retrieveInteractiveWindows: androidRetrieveInteractiveWindows,
         connectionTimeout: connectionTimeout,
         findTimeout: findTimeout,
         logger: logger,

--- a/packages/patrol/test/android_automator_config_test.dart
+++ b/packages/patrol/test/android_automator_config_test.dart
@@ -4,38 +4,42 @@ import 'package:patrol/src/platform/android/android_automator_native.dart';
 
 void main() {
   group('AndroidAutomatorConfig', () {
-    test('dontSuppressAccessibilityServices defaults to true', () {
+    test('accessibility flags default to true', () {
       const config = AndroidAutomatorConfig();
 
       expect(config.dontSuppressAccessibilityServices, isTrue);
+      expect(config.retrieveInteractiveWindows, isTrue);
     });
 
-    test('copyWith overrides dontSuppressAccessibilityServices', () {
+    test('copyWith overrides the accessibility flags', () {
       const config = AndroidAutomatorConfig();
 
-      expect(
-        config
-            .copyWith(dontSuppressAccessibilityServices: false)
-            .dontSuppressAccessibilityServices,
-        isFalse,
+      final updated = config.copyWith(
+        dontSuppressAccessibilityServices: false,
+        retrieveInteractiveWindows: false,
       );
+
+      expect(updated.dontSuppressAccessibilityServices, isFalse);
+      expect(updated.retrieveInteractiveWindows, isFalse);
     });
   });
 
   group('AndroidAutomator.buildConfigureRequest()', () {
-    test('forwards the accessibility flag to the native side', () {
+    test('forwards the accessibility flags to the native side', () {
       final automator = AndroidAutomator(
         config: const AndroidAutomatorConfig(
           dontSuppressAccessibilityServices: false,
+          retrieveInteractiveWindows: false,
         ),
       );
 
       final request = automator.buildConfigureRequest();
 
       expect(request.androidDontSuppressAccessibilityServices, isFalse);
+      expect(request.androidRetrieveInteractiveWindows, isFalse);
     });
 
-    test('forwards the default (true)', () {
+    test('forwards the defaults (true)', () {
       final automator = AndroidAutomator(
         config: const AndroidAutomatorConfig(),
       );
@@ -43,6 +47,7 @@ void main() {
       final request = automator.buildConfigureRequest();
 
       expect(request.androidDontSuppressAccessibilityServices, isTrue);
+      expect(request.androidRetrieveInteractiveWindows, isTrue);
     });
   });
 }

--- a/packages/patrol_devtools_extension/CHANGELOG.md
+++ b/packages/patrol_devtools_extension/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Regenerate API contracts for the new Android `ConfigureRequest` accessibility flag. (#3227)
 - Regenerate API contracts (adds `AndroidTakeNativeScreenshotRequest`). (#3222)
+- Regenerate API contracts for the Android `retrieveInteractiveWindows` flag. (#3228)
 
 ## 0.4.1
 

--- a/packages/patrol_devtools_extension/CHANGELOG.md
+++ b/packages/patrol_devtools_extension/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Regenerate API contracts for the new Android `ConfigureRequest` accessibility flag. (#3227)
+- Regenerate API contracts for the Android `retrieveInteractiveWindows` flag. (#3228)
 
 ## 0.4.1
 

--- a/packages/patrol_devtools_extension/lib/api/contracts.dart
+++ b/packages/patrol_devtools_extension/lib/api/contracts.dart
@@ -292,6 +292,7 @@ class ConfigureRequest with Equatable {
   const ConfigureRequest({
     required this.findTimeoutMillis,
     this.androidDontSuppressAccessibilityServices,
+    this.androidRetrieveInteractiveWindows,
   });
 
   factory ConfigureRequest.fromJson(Map<String, dynamic> json) =>
@@ -299,6 +300,7 @@ class ConfigureRequest with Equatable {
 
   final int findTimeoutMillis;
   final bool? androidDontSuppressAccessibilityServices;
+  final bool? androidRetrieveInteractiveWindows;
 
   Map<String, dynamic> toJson() => _$ConfigureRequestToJson(this);
 
@@ -306,6 +308,7 @@ class ConfigureRequest with Equatable {
   List<Object?> get props => [
     findTimeoutMillis,
     androidDontSuppressAccessibilityServices,
+    androidRetrieveInteractiveWindows,
   ];
 }
 

--- a/packages/patrol_devtools_extension/lib/api/contracts.g.dart
+++ b/packages/patrol_devtools_extension/lib/api/contracts.g.dart
@@ -71,6 +71,8 @@ ConfigureRequest _$ConfigureRequestFromJson(Map<String, dynamic> json) =>
       findTimeoutMillis: (json['findTimeoutMillis'] as num).toInt(),
       androidDontSuppressAccessibilityServices:
           json['androidDontSuppressAccessibilityServices'] as bool?,
+      androidRetrieveInteractiveWindows:
+          json['androidRetrieveInteractiveWindows'] as bool?,
     );
 
 Map<String, dynamic> _$ConfigureRequestToJson(ConfigureRequest instance) =>
@@ -78,6 +80,8 @@ Map<String, dynamic> _$ConfigureRequestToJson(ConfigureRequest instance) =>
       'findTimeoutMillis': instance.findTimeoutMillis,
       'androidDontSuppressAccessibilityServices':
           instance.androidDontSuppressAccessibilityServices,
+      'androidRetrieveInteractiveWindows':
+          instance.androidRetrieveInteractiveWindows,
     };
 
 OpenAppRequest _$OpenAppRequestFromJson(Map<String, dynamic> json) =>

--- a/schema.dart
+++ b/schema.dart
@@ -42,6 +42,9 @@ class ConfigureRequest {
   // Android only. true (default) keeps third-party AccessibilityServices running
   // (FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES); false suppresses them.
   bool? androidDontSuppressAccessibilityServices;
+  // Android only. false clears the FLAG_RETRIEVE_INTERACTIVE_WINDOWS that
+  // uiautomator 2.3.0 force-enables, which breaks WebView native selectors.
+  bool? androidRetrieveInteractiveWindows;
 }
 
 class OpenAppRequest {


### PR DESCRIPTION
Let Android tests clear `FLAG_RETRIEVE_INTERACTIVE_WINDOWS` to fix WebView native selectors.

**Problem**
- uiautomator 2.3.0 force-enables `FLAG_RETRIEVE_INTERACTIVE_WINDOWS`.
- Some WebViews (e.g. Plaid Link SDK) then never populate their a11y tree → `$.native` selectors inside them fail 100% since patrol 4.0 (#3178).

**Change**
- Opt-in `AndroidAutomatorConfig.retrieveInteractiveWindows` (dart-define `PATROL_ANDROID_RETRIEVE_INTERACTIVE_WINDOWS`), default `true` = today's behavior.
- `false` clears the flag in `Automator.configure()`.
- Same config plumbing and style as #3227 (accessibility flag).

**Watch out**
- uiautomator re-adds the flag when `serviceInfo.flags != mCachedServiceFlags` or every `SERVICE_FLAGS_TIMEOUT` (2s), so a plain `setServiceInfo()` won't stick — `mCachedServiceFlags`/`mLastServiceFlagsTime` are pinned via reflection (guarded; degrades to default on failure).
- `FLAG_INCLUDE_NOT_IMPORTANT_VIEWS` is preserved so normal selectors keep working.
- Native action is opt-in only (runs when `false`); unlike #3227 it does not re-flip per test, so mixing `true`/`false` across a bundle keeps the last-cleared state.

**Result**
- Dart tests pass (config defaults + `ConfigureRequest` threading). Native flag effect (esp. the reflection path) needs on-device verification — couldn't run an emulator here.

Closes #3178
