### PR TITLE
Remove redundant macOS build phases from example apps and docs

### DIFF
--- a/dev/e2e_app/macos/Runner.xcodeproj/project.pbxproj
+++ b/dev/e2e_app/macos/Runner.xcodeproj/project.pbxproj
@@ -215,13 +215,11 @@
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
 				6EA83E54978260DA823337B5 /* [CP] Check Pods Manifest.lock */,
-				94AA3E082A7BD03700E8815C /* macos_assemble build */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* Run Script */,
-				94AA3E092A7BD06200E8815C /* macos_assemble embed */,
 				D28DBAE5EB03426D2BF2F8E3 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
@@ -423,42 +421,6 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
-		};
-		94AA3E082A7BD03700E8815C /* macos_assemble build */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "macos_assemble build";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo \"Runner macos_assemble build\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/macos_assemble.sh\" build\n";
-		};
-		94AA3E092A7BD06200E8815C /* macos_assemble embed */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "macos_assemble embed";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo \"Runner macos_assemble embed\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/macos_assemble.sh\" embed\n";
 		};
 		D28DBAE5EB03426D2BF2F8E3 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/docs/documentation/index.mdx
+++ b/docs/documentation/index.mdx
@@ -612,36 +612,6 @@ Check out our video version of this tutorial on YouTube!
           ```
         </Step>
 
-        <Step id="add-build-phases">
-          Go to **RunnerUITests** -> **Build Phases** and add 2 new "Run Script Phase" Build Phases.
-            Rename them to `xcode_backend build` and `xcode_backend embed_and_thin` by double clicking
-            on their names.
-
-          ![Xcode config setup](/assets/macos_runner_build_phases_create.png)
-        </Step>
-
-        <Step id="order-build-phases">
-          Arrange the newly created Build Phases in the order shown in the screenshot below.
-
-          ![Xcode config setup](/assets/macos_runner_build_phases.png)
-        </Step>
-
-        <Step id="set-macos-assemble-build">
-          Paste this code into the first `macos_assemble build` Build Phase:
-
-          ```
-          /bin/sh "$FLUTTER_ROOT/packages/flutter_tools/bin/macos_assemble.sh" build
-          ```
-        </Step>
-
-        <Step id="set-macos-assemble-embed">
-          Paste this code into the second `macos_assemble embed` Build Phase:
-
-          ```
-          /bin/sh "$FLUTTER_ROOT/packages/flutter_tools/bin/macos_assemble.sh" embed
-          ```
-        </Step>
-
         <Step id="disable-parallel-execution">
           Xcode by default also enables a "parallel execution" setting, which
             breaks Patrol. Disable it **for all schemes** (if you have more than one):

--- a/packages/patrol/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/patrol/example/macos/Runner.xcodeproj/project.pbxproj
@@ -215,13 +215,11 @@
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
 				6EA83E54978260DA823337B5 /* [CP] Check Pods Manifest.lock */,
-				94AA3E082A7BD03700E8815C /* macos_assemble build */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* Run Script */,
-				94AA3E092A7BD06200E8815C /* macos_assemble embed */,
 				D28DBAE5EB03426D2BF2F8E3 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
@@ -423,42 +421,6 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
-		};
-		94AA3E082A7BD03700E8815C /* macos_assemble build */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "macos_assemble build";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo \"Runner macos_assemble build\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/macos_assemble.sh\" build\n";
-		};
-		94AA3E092A7BD06200E8815C /* macos_assemble embed */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "macos_assemble embed";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo \"Runner macos_assemble embed\"\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/macos_assemble.sh\" embed\n";
 		};
 		D28DBAE5EB03426D2BF2F8E3 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
**What**
- Drop the custom `macos_assemble build` / `macos_assemble embed` Run Script phases from the Runner target in both macOS example projects (`dev/e2e_app`, `packages/patrol/example`).
- Drop the matching "add build phases" steps from the macOS setup docs.

**Why**
- These phases duplicate the standard `flutter create` macOS template 1:1: build already runs via the `Flutter Assemble` aggregate target (a Runner dependency), embed via the existing `Run Script` phase (`macos_assemble.sh embed`).
- Nothing in `patrol_cli` or the native code (`packages/patrol/macos`, `packages/patrol/darwin`) reads these phases or their artifacts.
- `patrol develop` doesn't support macOS (hard guard in `develop_service.dart`), so it can't depend on them either.

**Status**
- Draft — using the macOS CI pipeline to confirm build-for-testing + the integration test still pass without these phases.
- Local cold build (fresh `build/`) + `taps around` already passed, exit 0.