### PR TITLE
[patrol_log] Prepare release 0.10.1

### DIFF
--- a/packages/patrol_log/CHANGELOG.md
+++ b/packages/patrol_log/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.10.1
 
 - Fix first word of a test description being displayed as the test file name when the finished test entry name has no file prefix. (#3167)
 

--- a/packages/patrol_log/pubspec.yaml
+++ b/packages/patrol_log/pubspec.yaml
@@ -1,7 +1,7 @@
 name: patrol_log
 description: >
   Log package for Patrol, a powerful Flutter-native UI testing framework.
-version: 0.10.0
+version: 0.10.1
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol_log
 issue_tracker: https://github.com/leancodepl/patrol/issues


### PR DESCRIPTION
Releases patrol_log 0.10.1 with the test description fix from #3167.

- Bump the version to 0.10.1 and rename the `Unreleased` CHANGELOG heading to `0.10.1`.

Tag `patrol_log-v0.10.1` goes out after the merge. The follow-up PR (patrol 4.9.0 + patrol_cli 4.7.0) raises the constraint to `^0.10.1`, so it waits for this release to land on pub.dev.