### PR TITLE
Prepare patrol 4.9.0 and patrol_cli 4.7.0 release

### DIFF
--- a/dev/e2e_app/pubspec.lock
+++ b/dev/e2e_app/pubspec.lock
@@ -870,14 +870,14 @@ packages:
       path: "../../packages/patrol"
       relative: true
     source: path
-    version: "4.8.0"
+    version: "4.9.0"
   patrol_cli:
     dependency: "direct dev"
     description:
       path: "../../packages/patrol_cli"
       relative: true
     source: path
-    version: "4.6.1"
+    version: "4.7.0"
   patrol_finders:
     dependency: transitive
     description:
@@ -890,17 +890,17 @@ packages:
     dependency: transitive
     description:
       name: patrol_log
-      sha256: "1f5b6f7e1d9feaab7a60eef31e34a83a6168d754e5c0336006a4f50fb5f27526"
+      sha256: "3d91c93e8d0ed19cb12d4b27aa24eca7294e0a48d9d8445505c9775feb5fde2d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.0"
+    version: "0.10.1"
   patrol_mcp:
     dependency: "direct dev"
     description:
       path: "../../packages/patrol_mcp"
       relative: true
     source: path
-    version: "0.1.4"
+    version: "0.2.0"
   permission_handler:
     dependency: "direct main"
     description:

--- a/docs/documentation/compatibility-table.mdx
+++ b/docs/documentation/compatibility-table.mdx
@@ -13,7 +13,8 @@ This table shows the compatible versions between patrol_cli and patrol packages.
 
 | patrol_cli version | patrol version | Minimum Flutter version |
 |-------------------|----------------|------------------------|
-| 4.5.0+ | 4.7.0+ | 3.32.0 |
+| 4.7.0+ | 4.9.0+ | 3.32.0 |
+| 4.5.0 - 4.6.1 | 4.7.0 - 4.8.0 | 3.32.0 |
 | 4.4.0 | 4.6.0 - 4.6.1 | 3.32.0 |
 | 4.3.0 - 4.3.1 | 4.5.0 | 3.32.0 |
 | 4.2.0 | 4.2.0 - 4.4.0 | 3.32.0 |

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 4.9.0
 
 - Fix macOS builds failing with `module 'PatrolImpl' not found` under Swift Package Manager (#3177). The public `patrol` module no longer `@import`s the Swift implementation; `PatrolPlugin` is ObjC and macro-facing types are declared as ObjC interfaces in the umbrella, so app builds and RunnerUITests keep working with a single `@import patrol` / `import patrol`.
 - Add Marathon integration for running Patrol tests on Android and iOS simulators. See the [Marathon integration guide](https://patrol.leancode.co/documentation/integrations/marathon).

--- a/packages/patrol/pubspec.yaml
+++ b/packages/patrol/pubspec.yaml
@@ -2,7 +2,7 @@ name: patrol
 description: >
   A powerful, multiplatform E2E UI testing framework for Flutter apps that
   overcomes the limitations of integration_test by handling native interactions.
-version: 4.8.0
+version: 4.9.0
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol
 issue_tracker: https://github.com/leancodepl/patrol/issues
@@ -33,7 +33,7 @@ dependencies:
   json_annotation: ^4.9.0
   meta: ^1.10.0
   patrol_finders: ^3.6.0
-  patrol_log: ^0.10.0
+  patrol_log: ^0.10.1
   shelf: ^1.4.1
   test_api: '^0.7.0'
   web: ^1.0.0

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,10 +1,6 @@
-## 4.6.1
+## 4.7.0
 
-- Fix `patrol develop` printing "You must specify a --flavor option" on iOS/macOS projects with schemes, by passing the flavor to `flutter attach`.
-- Fail fast with a clear error instead of hanging on gradlew when the Android SDK can't be located (`sdk.dir` missing from `android/local.properties` after the config-only build). (#3168)
-
-## Unreleased
-
+- **Requires `patrol` 4.9.0 or newer.**
 - Pass `-Ppatrol-enabled=true` to Android Gradle builds so apps can detect a Patrol build.
 - Support running Patrol tests on multiple iOS simulators in parallel, by reading the native automation ports at runtime in the generated test bundle. See the [Marathon integration guide](https://patrol.leancode.co/documentation/integrations/marathon).
 - Add experimental build-time test discovery, enabled with `patrol.emit_test_manifest` in
@@ -16,6 +12,11 @@
   discovery. (#3197)
 - Add `--record-video` flag to `patrol test` and `patrol develop` to record a video per test case (Android and iOS simulators). (#2741)
 - Fix `patrol test`/`patrol develop` not reading logs from iOS simulators, by streaming the simulator's log via `simctl spawn`. (#3198)
+
+## 4.6.1
+
+- Fix `patrol develop` printing "You must specify a --flavor option" on iOS/macOS projects with schemes, by passing the flavor to `flutter attach`.
+- Fail fast with a clear error instead of hanging on gradlew when the Android SDK can't be located (`sdk.dir` missing from `android/local.properties` after the config-only build). (#3168)
 
 ## 4.6.0
 

--- a/packages/patrol_cli/lib/src/base/constants.dart
+++ b/packages/patrol_cli/lib/src/base/constants.dart
@@ -1,3 +1,3 @@
 /// Version of Patrol CLI. Must be kept in sync with pubspec.yaml.
 /// If you update this, make sure that compatibility-table.mdx is updated (if needed)
-const version = '4.6.1';
+const version = '4.7.0';

--- a/packages/patrol_cli/lib/src/compatibility_checker/version_compatibility.dart
+++ b/packages/patrol_cli/lib/src/compatibility_checker/version_compatibility.dart
@@ -89,8 +89,13 @@ class VersionCompatibility {
 final versionCompatibilityList =
     <VersionCompatibility>[
       VersionCompatibility.fromRangeString(
-        patrolCliVersion: '4.5.0+',
-        patrolVersion: '4.7.0+',
+        patrolCliVersion: '4.7.0+',
+        patrolVersion: '4.9.0+',
+        minFlutterVersion: '3.32.0',
+      ),
+      VersionCompatibility.fromRangeString(
+        patrolCliVersion: '4.5.0 - 4.6.1',
+        patrolVersion: '4.7.0 - 4.8.0',
         minFlutterVersion: '3.32.0',
       ),
       VersionCompatibility.fromRangeString(

--- a/packages/patrol_cli/pubspec.yaml
+++ b/packages/patrol_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: patrol_cli
 description: >
   Command-line tool for Patrol, a powerful Flutter-native UI testing framework.
-version: 4.6.1  # Must be kept in sync with constants.dart
+version: 4.7.0  # Must be kept in sync with constants.dart
 homepage: https://patrol.leancode.co
 repository: https://github.com/leancodepl/patrol/tree/master/packages/patrol_cli
 issue_tracker: https://github.com/leancodepl/patrol/issues?q=is%3Aopen+is%3Aissue+label%3A%22package%3A+patrol_cli%22
@@ -31,7 +31,7 @@ dependencies:
   meta: ^1.10.0
   package_config: ^2.1.1
   path: ^1.8.3
-  patrol_log: ^0.10.0
+  patrol_log: ^0.10.1
   platform: ^3.1.3
   process: ^5.0.1
   pub_updater: ^0.5.0

--- a/packages/patrol_cli/test/compatibility_checker/version_compatibility_test.dart
+++ b/packages/patrol_cli/test/compatibility_checker/version_compatibility_test.dart
@@ -164,6 +164,32 @@ void main() {
       );
     });
 
+    group('patrol_cli 4.7.0 / patrol 4.9.0 split', () {
+      test('patrol_cli 4.7.0 requires patrol 4.9.0 or newer', () {
+        expect(
+          areVersionsCompatible(Version.parse('4.7.0'), Version.parse('4.9.0')),
+          isTrue,
+        );
+        expect(
+          areVersionsCompatible(Version.parse('4.7.0'), Version.parse('4.8.0')),
+          isFalse,
+          reason:
+              'The generated test bundle imports libraries added in patrol 4.9.0',
+        );
+      });
+
+      test('patrol 4.9.0 requires patrol_cli 4.7.0 or newer', () {
+        expect(
+          areVersionsCompatible(Version.parse('4.6.1'), Version.parse('4.9.0')),
+          isFalse,
+        );
+        expect(
+          areVersionsCompatible(Version.parse('4.6.1'), Version.parse('4.8.0')),
+          isTrue,
+        );
+      });
+    });
+
     test('current patrol_cli is compatible with listed patrol versions', () {
       final currentCliVersion = Version.parse(constants.version);
 

--- a/packages/patrol_devtools_extension/CHANGELOG.md
+++ b/packages/patrol_devtools_extension/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.4.1
 
 - Bump `equatable` to `^2.1.0` and migrate API contract types from deprecated `EquatableMixin` to `with Equatable`.
 

--- a/packages/patrol_devtools_extension/pubspec.yaml
+++ b/packages/patrol_devtools_extension/pubspec.yaml
@@ -2,7 +2,7 @@ name: patrol_devtools_extension
 description: A new Flutter project.
 publish_to: none
 
-version: 0.4.0
+version: 0.4.1
 
 environment:
   sdk: ">=3.8.0 <4.0.0"


### PR DESCRIPTION
Releases patrol 4.9.0 and patrol_cli 4.7.0 together: the CLI's generated test bundle imports libraries that only exist in patrol 4.9.0, so the two must ship as a pair.

- Bump patrol to 4.9.0 and patrol_cli to 4.7.0 (pubspec, `constants.dart`, CHANGELOG headings), both now on `patrol_log: ^0.10.1`.
- Move the patrol_cli `Unreleased` section above 4.6.1, where it belonged, and note that 4.7.0 requires patrol 4.9.0.
- Close the `4.5.0+ / 4.7.0+` compatibility row at `4.5.0 - 4.6.1 / 4.7.0 - 4.8.0` and add `4.7.0+ / 4.9.0+`, in the checker and in the docs table.
- Bump patrol_devtools_extension to 0.4.1; it ships inside the patrol package.

Tags `patrol-v4.9.0` and `patrol_cli-v4.7.0` go out after the merge.