### PR TITLE
Run patrol_finders tests on web in CI

### DIFF
--- a/.github/workflows/patrol_finders-prepare.yaml
+++ b/.github/workflows/patrol_finders-prepare.yaml
@@ -44,6 +44,10 @@ jobs:
         if: success() || failure()
         run: flutter test
 
+      - name: flutter test (web)
+        if: success() || failure()
+        run: flutter test --platform chrome
+
       - name: Run analyzer
         if: success() || failure()
         run: |

--- a/packages/patrol_finders/test/patrol_tester_test.dart
+++ b/packages/patrol_finders/test/patrol_tester_test.dart
@@ -2,6 +2,7 @@
 // ignore_for_file: avoid_single_child_in_multi_child_widgets
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol_finders/src/custom_finders/custom_finders.dart';
@@ -214,6 +215,8 @@ void main() {
         expect(find.text('content: some input'), findsOneWidget);
       });
 
+      // The unfocus and testTextInput assertions in the three tests below don't
+      // hold on web, where enterText() skips that path.
       patrolWidgetTest('unfocuses already focused field after entering text', (
         tester,
       ) async {
@@ -249,7 +252,7 @@ void main() {
         expect(valuesOnUnfocus, isNotEmpty);
         expect(valuesOnUnfocus.first, 'updated input');
         expect(valuesOnUnfocus, isNot(contains('initial input')));
-      });
+      }, skip: kIsWeb);
 
       patrolWidgetTest('runs on-unfocus validation after entering text', (
         tester,
@@ -285,10 +288,11 @@ void main() {
         expect(validatedValues, isNotEmpty);
         expect(validatedValues.first, 'updated input');
         expect(validatedValues, isNot(contains('initial input')));
-      });
+      }, skip: kIsWeb);
 
       patrolWidgetTest(
         'keeps already focused field focused when hideKeyboard is false',
+        skip: kIsWeb,
         (tester) async {
           final controller = TextEditingController(text: 'initial input');
           final focusNode = FocusNode();


### PR DESCRIPTION
`patrol_finders` declares `platforms: web:` but its prepare workflow never compiled it for web, so a `dart:io` import could land and keep that job green. Closes #1607.

- Added a `flutter test --platform chrome` step to `patrol_finders prepare`. It runs the existing suite in headless Chrome in about 10 seconds.
- Skipped three `enterText()` tests on web. They assert the unfocus and `testTextInput` behaviour that `PatrolTester.enterText` intentionally guards behind `!kIsWeb`.

The `test web` workflow already covers finders driving a real app in a browser. This step is the missing compile-and-run guard inside the package's own CI.