### PR TITLE
fix(patrol_cli): report a dead flutter attach or logs process

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix an issue when building iOS tests from different directory than project's root - we were looking in a wrong place for .xctestrun file. (#3250)
 - Fix hot restart dying on flavored `patrol develop` — `flutter attach` has no `--flavor`. Regressed in 4.6.1. (#3223)
 - Fix flavored iOS `patrol develop` losing logs — they now come from Patrol's own stream. Simulator unchanged. (#2465)
+- Report a dead `flutter attach` or `flutter logs` in `patrol develop` instead of waiting forever. (#3223)
 
 ## 4.7.0
 

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix hot restart silently doing nothing for the whole `patrol develop` session on flavored projects, by no longer passing `--flavor` to `flutter attach`, which defines no such option. Regressed in 4.6.1. (#3223)
 - Fix `patrol develop` printing "You must specify a --flavor option" and losing the app's logs on flavored iOS projects, by routing them through Patrol's own log stream instead of `flutter logs`. (#2465)
+- Report why hot restart or logs stopped working in `patrol develop` instead of waiting forever, by detecting that the `flutter attach` or `flutter logs` process exited. (#3223)
 
 ## 4.7.0
 

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix an issue when building iOS tests from different directory than project's root - we were looking in a wrong place for .xctestrun file. (#3250)
 - Fix hot restart dying on flavored `patrol develop` — `flutter attach` has no `--flavor`. Regressed in 4.6.1. (#3223)
 - Fix flavored iOS `patrol develop` losing logs — they now come from Patrol's own stream. Simulator unchanged. (#2465)
-- Report a dead `flutter attach` or `flutter logs` in `patrol develop` instead of waiting forever. (#3223)
+- Report a dead `flutter attach` or `flutter logs` in `patrol develop`. (#3234)
 
 ## 4.7.0
 

--- a/packages/patrol_cli/lib/src/commands/develop_service.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_service.dart
@@ -527,6 +527,8 @@ class DevelopService {
         reportTestsCompleted(TestCompletionResult(success: false, error: err));
         rethrow;
       }
+    } on ToolExit {
+      rethrow;
     } catch (err, st) {
       _logger
         ..err('$err')

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -5,6 +5,7 @@ import 'dart:io' show exit;
 import 'package:dispose_scope/dispose_scope.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' show basename;
+import 'package:patrol_cli/src/base/exceptions.dart';
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/base/process.dart';
 import 'package:patrol_cli/src/runner/flutter_command.dart';
@@ -328,7 +329,9 @@ class FlutterTool {
           if (observationUrlCompleter case final urlCompleter?
               when !urlCompleter.isCompleted) {
             urlCompleter.completeError(
-              StateError('flutter logs exited before reporting the VM service'),
+              const ToolExit(
+                'flutter logs exited before reporting the Dart VM service URL',
+              ),
             );
           }
         }),

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -41,6 +41,7 @@ class FlutterTool {
   var _logsActive = false;
   var _logsSkipped = false;
   var _devtoolsUrl = '';
+  String? _attachFailure;
 
   /// Forwards logs and hot restarts the app when "r" is pressed.
   Future<void> attachForHotRestart({
@@ -148,12 +149,36 @@ class FlutterTool {
         }
       });
 
+      // `flutter attach` reports a rejected option by exiting. Only its
+      // stdout completes the wait below.
+      final stderrLines = <String>[];
+      final stderrDone = Completer<void>();
+      unawaited(
+        process.exitCode.then((code) async {
+          // The lines explaining the exit can still be in flight when
+          // exitCode completes.
+          await _awaitStderr(stderrDone);
+          if (completer.isCompleted) {
+            return;
+          }
+
+          final failure =
+              'Hot Restart is not available: '
+              '${_describeExit('flutter attach', code, stderrLines)}';
+          _attachFailure = failure;
+          _logger.err(failure);
+          completer.complete();
+        }),
+      );
+
       _stdin
           .listen((event) async {
             final char = String.fromCharCode(event.first);
             if (char == 'r' || char == 'R') {
               if (!_hotRestartActive) {
-                _logger.warn('Hot Restart: not attached to the app yet!');
+                _logger.warn(
+                  _attachFailure ?? 'Hot Restart: not attached to the app yet!',
+                );
                 return;
               }
 
@@ -236,13 +261,21 @@ class FlutterTool {
           .disposedBy(scope);
 
       process
-          .listenStdErr((line) {
-            if (line.startsWith('Waiting for another flutter command')) {
-              // This is a warning that we can ignore
-              return;
-            }
-            _logger.err('\t$line');
-          })
+          .listenStdErr(
+            (line) {
+              if (line.startsWith('Waiting for another flutter command')) {
+                // This is a warning that we can ignore
+                return;
+              }
+              stderrLines.add(line);
+              _logger.err('\t$line');
+            },
+            onDone: () {
+              if (!stderrDone.isCompleted) {
+                stderrDone.complete();
+              }
+            },
+          )
           .disposedBy(scope);
 
       await completer.future;
@@ -276,6 +309,30 @@ class FlutterTool {
           completer.complete();
         }
       });
+
+      // `flutter logs` exits when it cannot resolve the project, and the
+      // caller awaits this.
+      final stderrLines = <String>[];
+      final stderrDone = Completer<void>();
+      unawaited(
+        process.exitCode.then((code) async {
+          await _awaitStderr(stderrDone);
+          if (!completer.isCompleted) {
+            _logger.err(
+              'Logs are not available: '
+              '${_describeExit('flutter logs', code, stderrLines)}',
+            );
+            completer.complete();
+          }
+
+          if (observationUrlCompleter case final urlCompleter?
+              when !urlCompleter.isCompleted) {
+            urlCompleter.completeError(
+              StateError('flutter logs exited before reporting the VM service'),
+            );
+          }
+        }),
+      );
 
       process
           .listenStdOut((line) {
@@ -314,10 +371,36 @@ class FlutterTool {
           })
           .disposedBy(scope);
 
-      process.listenStdErr((l) => _logger.err('\t$l')).disposedBy(scope);
+      process
+          .listenStdErr(
+            (line) {
+              stderrLines.add(line);
+              _logger.err('\t$line');
+            },
+            onDone: () {
+              if (!stderrDone.isCompleted) {
+                stderrDone.complete();
+              }
+            },
+          )
+          .disposedBy(scope);
 
       await completer.future;
     });
+  }
+
+  /// Waits for the stderr stream to drain, bounded so it cannot hang.
+  Future<void> _awaitStderr(Completer<void> stderrDone) async {
+    await stderrDone.future.timeout(
+      const Duration(seconds: 1),
+      onTimeout: () {},
+    );
+  }
+
+  String _describeExit(String command, int code, List<String> stderrLines) {
+    final lines = stderrLines.where((line) => line.trim().isNotEmpty);
+    final reason = lines.isEmpty ? '' : ':\n\t${lines.join('\n\t')}';
+    return '`$command` exited with code $code$reason';
   }
 
   /// Enables interactive mode. Returns the previous stdin modes.

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -41,6 +41,7 @@ class FlutterTool {
   var _logsActive = false;
   var _logsSkipped = false;
   var _devtoolsUrl = '';
+  String? _attachFailure;
 
   /// Forwards logs and hot restarts the app when "r" is pressed.
   Future<void> attachForHotRestart({
@@ -148,12 +149,36 @@ class FlutterTool {
         }
       });
 
+      // `flutter attach` reports a rejected option by exiting. Only its
+      // stdout completes the wait below.
+      final stderrLines = <String>[];
+      final stderrDone = Completer<void>();
+      unawaited(
+        process.exitCode.then((code) async {
+          // The lines explaining the exit can still be in flight when
+          // exitCode completes.
+          await _awaitStderr(stderrDone);
+          if (completer.isCompleted) {
+            return;
+          }
+
+          final failure =
+              'Hot Restart is not available: '
+              '${_describeExit('flutter attach', code, stderrLines)}';
+          _attachFailure = failure;
+          _logger.err(failure);
+          completer.complete();
+        }),
+      );
+
       _stdin
           .listen((event) async {
             final char = String.fromCharCode(event.first);
             if (char == 'r' || char == 'R') {
               if (!_hotRestartActive) {
-                _logger.warn('Hot Restart: not attached to the app yet!');
+                _logger.warn(
+                  _attachFailure ?? 'Hot Restart: not attached to the app yet!',
+                );
                 return;
               }
 
@@ -236,13 +261,21 @@ class FlutterTool {
           .disposedBy(scope);
 
       process
-          .listenStdErr((line) {
-            if (line.startsWith('Waiting for another flutter command')) {
-              // This is a warning that we can ignore
-              return;
-            }
-            _logger.err('\t$line');
-          })
+          .listenStdErr(
+            (line) {
+              if (line.startsWith('Waiting for another flutter command')) {
+                // This is a warning that we can ignore
+                return;
+              }
+              stderrLines.add(line);
+              _logger.err('\t$line');
+            },
+            onDone: () {
+              if (!stderrDone.isCompleted) {
+                stderrDone.complete();
+              }
+            },
+          )
           .disposedBy(scope);
 
       await completer.future;
@@ -276,6 +309,30 @@ class FlutterTool {
           completer.complete();
         }
       });
+
+      // `flutter logs` exits when it cannot resolve the project, and the
+      // caller awaits this.
+      final stderrLines = <String>[];
+      final stderrDone = Completer<void>();
+      unawaited(
+        process.exitCode.then((code) async {
+          await _awaitStderr(stderrDone);
+          if (!completer.isCompleted) {
+            _logger.err(
+              'Logs are not available: '
+              '${_describeExit('flutter logs', code, stderrLines)}',
+            );
+            completer.complete();
+          }
+
+          if (observationUrlCompleter case final urlCompleter?
+              when !urlCompleter.isCompleted) {
+            urlCompleter.completeError(
+              StateError('flutter logs exited before reporting the VM service'),
+            );
+          }
+        }),
+      );
 
       process
           .listenStdOut((line) {
@@ -316,10 +373,36 @@ class FlutterTool {
           })
           .disposedBy(scope);
 
-      process.listenStdErr((l) => _logger.err('\t$l')).disposedBy(scope);
+      process
+          .listenStdErr(
+            (line) {
+              stderrLines.add(line);
+              _logger.err('\t$line');
+            },
+            onDone: () {
+              if (!stderrDone.isCompleted) {
+                stderrDone.complete();
+              }
+            },
+          )
+          .disposedBy(scope);
 
       await completer.future;
     });
+  }
+
+  /// Waits for the stderr stream to drain, bounded so it cannot hang.
+  Future<void> _awaitStderr(Completer<void> stderrDone) async {
+    await stderrDone.future.timeout(
+      const Duration(seconds: 1),
+      onTimeout: () {},
+    );
+  }
+
+  String _describeExit(String command, int code, List<String> stderrLines) {
+    final lines = stderrLines.where((line) => line.trim().isNotEmpty);
+    final reason = lines.isEmpty ? '' : ':\n\t${lines.join('\n\t')}';
+    return '`$command` exited with code $code$reason';
   }
 
   /// Enables interactive mode. Returns the previous stdin modes.

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -75,6 +75,8 @@ class FlutterTool {
 
     if (attachUsingUrl) {
       final urlCompleter = Completer<String>();
+      // The error can be set before anything awaits this below.
+      urlCompleter.future.ignore();
       await logs(
         deviceId,
         flutterCommand: flutterCommand,
@@ -260,21 +262,14 @@ class FlutterTool {
           .disposedBy(scope);
 
       process
-          .listenStdErr(
-            (line) {
-              if (line.startsWith('Waiting for another flutter command')) {
-                // This is a warning that we can ignore
-                return;
-              }
-              stderrLines.add(line);
-              _logger.err('\t$line');
-            },
-            onDone: () {
-              if (!stderrDone.isCompleted) {
-                stderrDone.complete();
-              }
-            },
-          )
+          .listenStdErr((line) {
+            if (line.startsWith('Waiting for another flutter command')) {
+              // This is a warning that we can ignore
+              return;
+            }
+            _collectStderr(stderrLines, line);
+            _logger.err('\t$line');
+          }, onDone: stderrDone.maybeComplete)
           .disposedBy(scope);
 
       await completer.future;
@@ -322,8 +317,9 @@ class FlutterTool {
           if (observationUrlCompleter case final urlCompleter?
               when !urlCompleter.isCompleted) {
             urlCompleter.completeError(
-              const ToolExit(
-                'flutter logs exited before reporting the Dart VM service URL',
+              ToolExit(
+                'flutter logs exited before reporting the Dart VM service '
+                'URL: ${_describeExit('flutter logs', code, stderrLines)}',
               ),
             );
           }
@@ -370,22 +366,30 @@ class FlutterTool {
           .disposedBy(scope);
 
       process
-          .listenStdErr(
-            (line) {
-              stderrLines.add(line);
-              _logger.err('\t$line');
-            },
-            onDone: () {
-              if (!stderrDone.isCompleted) {
-                stderrDone.complete();
-              }
-            },
-          )
+          .listenStdErr((line) {
+            if (line.startsWith('Waiting for another flutter command')) {
+              // This is a warning that we can ignore
+              return;
+            }
+            _collectStderr(stderrLines, line);
+            _logger.err('\t$line');
+          }, onDone: stderrDone.maybeComplete)
           .disposedBy(scope);
 
       await completer.future;
     });
   }
+
+  /// Keeps the tail of stderr: only the lines around the exit explain it, and
+  /// a long session can produce thousands.
+  void _collectStderr(List<String> lines, String line) {
+    lines.add(line);
+    if (lines.length > _maxStderrLines) {
+      lines.removeAt(0);
+    }
+  }
+
+  static const _maxStderrLines = 20;
 
   /// Waits for the stderr stream to drain, bounded so it cannot hang.
   Future<void> _awaitStderr(Completer<void> stderrDone) async {

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -153,26 +153,15 @@ class FlutterTool {
         completer.maybeComplete();
       });
 
-      // `flutter attach` can exit without ever writing to stdout.
-      final stderrLines = <String>[];
-      final stderrDone = Completer<void>();
-      unawaited(
-        process.exitCode.then((code) async {
-          // The lines explaining the exit can still be in flight when
-          // exitCode completes.
-          await _awaitStderr(stderrDone);
-          if (completer.isCompleted) {
-            return;
-          }
-
-          final failure =
-              'Hot Restart is not available: '
-              '${_describeExit('flutter attach', code, stderrLines)}';
-          _attachFailure = failure;
-          _logger.err(failure);
-          completer.maybeComplete();
-        }),
-      );
+      _reportExit(process, scope, 'flutter attach', (reason) {
+        if (completer.isCompleted) {
+          return;
+        }
+        final failure = 'Hot Restart is not available: $reason';
+        _attachFailure = failure;
+        _logger.err(failure);
+        completer.maybeComplete();
+      });
 
       _stdin
           .listen((event) async {
@@ -261,17 +250,6 @@ class FlutterTool {
           })
           .disposedBy(scope);
 
-      process
-          .listenStdErr((line) {
-            if (line.startsWith('Waiting for another flutter command')) {
-              // This is a warning that we can ignore
-              return;
-            }
-            _collectStderr(stderrLines, line);
-            _logger.err('\t$line');
-          }, onDone: stderrDone.maybeComplete)
-          .disposedBy(scope);
-
       await completer.future;
     });
   }
@@ -300,31 +278,22 @@ class FlutterTool {
       final completer = Completer<void>();
       scope.addDispose(completer.maybeComplete);
 
-      // `flutter logs` can exit without ever writing to stdout.
-      final stderrLines = <String>[];
-      final stderrDone = Completer<void>();
-      unawaited(
-        process.exitCode.then((code) async {
-          await _awaitStderr(stderrDone);
-          if (!completer.isCompleted) {
-            _logger.err(
-              'Logs are not available: '
-              '${_describeExit('flutter logs', code, stderrLines)}',
-            );
-            completer.maybeComplete();
-          }
+      _reportExit(process, scope, 'flutter logs', (reason) {
+        if (!completer.isCompleted) {
+          _logger.err('Logs are not available: $reason');
+          completer.maybeComplete();
+        }
 
-          if (observationUrlCompleter case final urlCompleter?
-              when !urlCompleter.isCompleted) {
-            urlCompleter.completeError(
-              ToolExit(
-                'flutter logs exited before reporting the Dart VM service '
-                'URL: ${_describeExit('flutter logs', code, stderrLines)}',
-              ),
-            );
-          }
-        }),
-      );
+        if (observationUrlCompleter case final urlCompleter?
+            when !urlCompleter.isCompleted) {
+          urlCompleter.completeError(
+            ToolExit(
+              'flutter logs exited before reporting the Dart VM service '
+              'URL: $reason',
+            ),
+          );
+        }
+      });
 
       process
           .listenStdOut((line) {
@@ -365,39 +334,51 @@ class FlutterTool {
           })
           .disposedBy(scope);
 
-      process
-          .listenStdErr((line) {
-            if (line.startsWith('Waiting for another flutter command')) {
-              // This is a warning that we can ignore
-              return;
-            }
-            _collectStderr(stderrLines, line);
-            _logger.err('\t$line');
-          }, onDone: stderrDone.maybeComplete)
-          .disposedBy(scope);
-
       await completer.future;
     });
   }
 
-  /// Keeps the tail of stderr: only the lines around the exit explain it, and
-  /// a long session can produce thousands.
-  void _collectStderr(List<String> lines, String line) {
-    lines.add(line);
-    if (lines.length > _maxStderrLines) {
-      lines.removeAt(0);
-    }
+  /// Forwards the process stderr and, once it exits, hands [onExit] a
+  /// description of that exit.
+  ///
+  /// The lines explaining an exit can still be in flight when its exit code
+  /// arrives, so the description is built once stderr drains. Only the tail is
+  /// kept: a long session can produce thousands of lines.
+  void _reportExit(
+    io.Process process,
+    DisposeScope scope,
+    String command,
+    void Function(String reason) onExit,
+  ) {
+    final stderrLines = <String>[];
+    final drained = Completer<void>();
+
+    process
+        .listenStdErr((line) {
+          if (line.startsWith('Waiting for another flutter command')) {
+            // This is a warning that we can ignore
+            return;
+          }
+          stderrLines.add(line);
+          if (stderrLines.length > _maxStderrLines) {
+            stderrLines.removeAt(0);
+          }
+          _logger.err('\t$line');
+        }, onDone: drained.maybeComplete)
+        .disposedBy(scope);
+
+    unawaited(
+      process.exitCode.then((code) async {
+        await drained.future.timeout(
+          const Duration(seconds: 1),
+          onTimeout: () {},
+        );
+        onExit(_describeExit(command, code, stderrLines));
+      }),
+    );
   }
 
   static const _maxStderrLines = 20;
-
-  /// Waits for the stderr stream to drain, bounded so it cannot hang.
-  Future<void> _awaitStderr(Completer<void> stderrDone) async {
-    await stderrDone.future.timeout(
-      const Duration(seconds: 1),
-      onTimeout: () {},
-    );
-  }
 
   String _describeExit(String command, int code, List<String> stderrLines) {
     final lines = stderrLines.where((line) => line.trim().isNotEmpty);

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -6,6 +6,7 @@ import 'package:dispose_scope/dispose_scope.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' show basename;
 import 'package:patrol_cli/src/base/exceptions.dart';
+import 'package:patrol_cli/src/base/extensions/completer.dart';
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/base/process.dart';
 import 'package:patrol_cli/src/runner/flutter_command.dart';
@@ -146,12 +147,11 @@ class FlutterTool {
       scope.addDispose(() {
         if (!completer.isCompleted) {
           _logger.detail('Killed before attached to the app');
-          completer.complete();
         }
+        completer.maybeComplete();
       });
 
-      // `flutter attach` reports a rejected option by exiting. Only its
-      // stdout completes the wait below.
+      // `flutter attach` can exit without ever writing to stdout.
       final stderrLines = <String>[];
       final stderrDone = Completer<void>();
       unawaited(
@@ -168,7 +168,7 @@ class FlutterTool {
               '${_describeExit('flutter attach', code, stderrLines)}';
           _attachFailure = failure;
           _logger.err(failure);
-          completer.complete();
+          completer.maybeComplete();
         }),
       );
 
@@ -205,9 +205,7 @@ class FlutterTool {
             } else if (char == 'q' || char == 'Q') {
               _logger.success('Quitting process...');
               process.kill();
-              if (!completer.isCompleted) {
-                completer.complete();
-              }
+              completer.maybeComplete();
 
               // Call the uninstall function if provided
               if (onQuit != null) {
@@ -243,7 +241,7 @@ class FlutterTool {
               if (!_logsActive && !_logsSkipped) {
                 _logger.warn('Hot Restart: logs are not connected yet');
               }
-              completer.complete();
+              completer.maybeComplete();
             }
 
             if (line.startsWith('The Flutter DevTools debugger and profiler')) {
@@ -305,14 +303,9 @@ class FlutterTool {
             ..disposedBy(scope);
 
       final completer = Completer<void>();
-      scope.addDispose(() {
-        if (!completer.isCompleted) {
-          completer.complete();
-        }
-      });
+      scope.addDispose(completer.maybeComplete);
 
-      // `flutter logs` exits when it cannot resolve the project, and the
-      // caller awaits this.
+      // `flutter logs` can exit without ever writing to stdout.
       final stderrLines = <String>[];
       final stderrDone = Completer<void>();
       unawaited(
@@ -323,7 +316,7 @@ class FlutterTool {
               'Logs are not available: '
               '${_describeExit('flutter logs', code, stderrLines)}',
             );
-            completer.complete();
+            completer.maybeComplete();
           }
 
           if (observationUrlCompleter case final urlCompleter?
@@ -352,7 +345,7 @@ class FlutterTool {
               if (!_hotRestartActive) {
                 _logger.warn('Hot Restart: not attached to the app yet');
               }
-              completer.complete();
+              completer.maybeComplete();
             }
 
             // Skip the log line that contains "PATROL_LOG" prefix

--- a/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:dispose_scope/dispose_scope.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:patrol_cli/src/base/exceptions.dart';
 import 'package:patrol_cli/src/crossplatform/flutter_tool.dart';
 import 'package:patrol_cli/src/runner/flutter_command.dart';
 import 'package:platform/platform.dart';
@@ -156,7 +157,7 @@ void main() {
         observationUrlCompleter: observationUrl,
       );
 
-      await expectLater(observationUrl.future, throwsStateError);
+      await expectLater(observationUrl.future, throwsA(isA<ToolExit>()));
     });
   });
 

--- a/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:dispose_scope/dispose_scope.dart';
 import 'package:mocktail/mocktail.dart';
@@ -14,16 +15,18 @@ void main() {
 
   late FlutterTool flutterTool;
   late MockProcessManager processManager;
+  late MockLogger logger;
   late Platform platform;
 
   setUp(() {
     final disposeScope = DisposeScope();
     final stdin = StreamController<List<int>>();
     processManager = MockProcessManager();
+    logger = MockLogger();
     platform = FakePlatform();
 
     flutterTool = FlutterTool(
-      logger: MockLogger(),
+      logger: logger,
       parentDisposeScope: disposeScope,
       processManager: processManager,
       platform: platform,
@@ -31,16 +34,35 @@ void main() {
     );
   });
 
+  /// Defaults to a process that neither prints anything nor exits.
+  MockProcess stubProcess({
+    List<String> stderr = const [],
+    Future<int>? exitCode,
+  }) {
+    final process = MockProcess();
+    when(
+      () => process.stdout,
+    ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
+    when(() => process.stderr).thenAnswer(
+      (_) => Stream<List<int>>.fromIterable(
+        stderr.map((line) => utf8.encode('$line\n')),
+      ),
+    );
+    when(
+      () => process.exitCode,
+    ).thenAnswer((_) => exitCode ?? Completer<int>().future);
+    when(() => processManager.start(any())).thenAnswer((_) async => process);
+    // `logs` starts its process with `runInShell`, which is a separate
+    // invocation as far as mocktail is concerned.
+    when(
+      () => processManager.start(any(), runInShell: any(named: 'runInShell')),
+    ).thenAnswer((_) async => process);
+    return process;
+  }
+
   group('FlutterTool', () {
     test('attach passes deviceId correctly', () {
-      final process = MockProcess();
-      when(
-        () => process.stdout,
-      ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
-      when(
-        () => process.stderr,
-      ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
-      when(() => processManager.start(any())).thenAnswer((_) async => process);
+      stubProcess();
 
       flutterTool.attach(
         flutterCommand: flutterCommand,
@@ -57,14 +79,7 @@ void main() {
     // `flutter attach` exits with a usage error on an option it does not
     // define. Check `flutter attach --help` before extending this set.
     test('attach passes only options flutter attach defines', () {
-      final process = MockProcess();
-      when(
-        () => process.stdout,
-      ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
-      when(
-        () => process.stderr,
-      ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
-      when(() => processManager.start(any())).thenAnswer((_) async => process);
+      stubProcess();
 
       flutterTool.attach(
         flutterCommand: flutterCommand,
@@ -91,6 +106,57 @@ void main() {
         '--target',
         '--dart-define',
       });
+    });
+
+    test('attach returns and reports why when the process exits', () async {
+      stubProcess(
+        stderr: ['Could not find an option named "--flavor".'],
+        exitCode: Future.value(64),
+      );
+
+      await flutterTool.attach(
+        flutterCommand: flutterCommand,
+        deviceId: 'testDeviceId',
+        target: 'target',
+        appId: 'appId',
+        dartDefines: {},
+        openBrowser: false,
+      );
+
+      final reported = verify(
+        () => logger.err(captureAny()),
+      ).captured.map((message) => message.toString()).join('\n');
+      expect(reported, contains('Hot Restart is not available'));
+      expect(reported, contains('exited with code 64'));
+      expect(reported, contains('Could not find an option named "--flavor".'));
+    });
+
+    test('logs returns and reports why when the process exits', () async {
+      stubProcess(
+        stderr: ['You must specify a --flavor option to select one.'],
+        exitCode: Future.value(1),
+      );
+
+      await flutterTool.logs('testDeviceId', flutterCommand: flutterCommand);
+
+      final reported = verify(
+        () => logger.err(captureAny()),
+      ).captured.map((message) => message.toString()).join('\n');
+      expect(reported, contains('Logs are not available'));
+      expect(reported, contains('exited with code 1'));
+    });
+
+    test('logs does not leave the observation URL pending on exit', () async {
+      stubProcess(exitCode: Future.value(1));
+      final observationUrl = Completer<String>();
+
+      await flutterTool.logs(
+        'testDeviceId',
+        flutterCommand: flutterCommand,
+        observationUrlCompleter: observationUrl,
+      );
+
+      await expectLater(observationUrl.future, throwsStateError);
     });
   });
 

--- a/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
@@ -18,10 +18,11 @@ void main() {
   late MockProcessManager processManager;
   late MockLogger logger;
   late Platform platform;
+  late StreamController<List<int>> stdin;
 
   setUp(() {
     final disposeScope = DisposeScope();
-    final stdin = StreamController<List<int>>();
+    stdin = StreamController<List<int>>();
     processManager = MockProcessManager();
     logger = MockLogger();
     platform = FakePlatform();
@@ -44,10 +45,16 @@ void main() {
     when(
       () => process.stdout,
     ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
+    // Emitted late on purpose: a process that has already exited still has
+    // its last stderr lines in flight.
     when(() => process.stderr).thenAnswer(
-      (_) => Stream<List<int>>.fromIterable(
-        stderr.map((line) => utf8.encode('$line\n')),
-      ),
+      (_) =>
+          Stream<List<int>>.fromIterable(
+            stderr.map((line) => utf8.encode('$line\n')),
+          ).asyncMap((chunk) async {
+            await Future<void>.delayed(const Duration(milliseconds: 20));
+            return chunk;
+          }),
     );
     when(
       () => process.exitCode,
@@ -145,6 +152,31 @@ void main() {
       ).captured.map((message) => message.toString()).join('\n');
       expect(reported, contains('Logs are not available'));
       expect(reported, contains('exited with code 1'));
+      expect(reported, contains('You must specify a --flavor option'));
+    });
+
+    test('r reports why the attach died', () async {
+      stubProcess(
+        stderr: ['Could not find an option named "--flavor".'],
+        exitCode: Future.value(64),
+      );
+
+      await flutterTool.attach(
+        flutterCommand: flutterCommand,
+        deviceId: 'testDeviceId',
+        target: 'target',
+        appId: 'appId',
+        dartDefines: {},
+        openBrowser: false,
+      );
+      stdin.add('r'.codeUnits);
+      await Future<void>.delayed(Duration.zero);
+
+      final warned = verify(
+        () => logger.warn(captureAny()),
+      ).captured.map((message) => message.toString()).join('\n');
+      expect(warned, contains('Hot Restart is not available'));
+      expect(warned, isNot(contains('not attached to the app yet')));
     });
 
     test('logs does not leave the observation URL pending on exit', () async {

--- a/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
@@ -38,15 +38,21 @@ void main() {
 
   /// Defaults to a process that neither prints anything nor exits.
   MockProcess stubProcess({
+    List<String> stdout = const [],
     List<String> stderr = const [],
     Future<int>? exitCode,
   }) {
     final process = MockProcess();
-    when(
-      () => process.stdout,
-    ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
-    // Emitted late on purpose: a process that has already exited still has
-    // its last stderr lines in flight.
+    when(() => process.stdout).thenAnswer(
+      (_) =>
+          Stream<List<int>>.fromIterable(
+            stdout.map((line) => utf8.encode('$line\n')),
+          ).asyncMap((chunk) async {
+            await Future<void>.delayed(const Duration(milliseconds: 40));
+            return chunk;
+          }),
+    );
+    // A process that has already exited still has its last lines in flight.
     when(() => process.stderr).thenAnswer(
       (_) =>
           Stream<List<int>>.fromIterable(
@@ -177,6 +183,13 @@ void main() {
       ).captured.map((message) => message.toString()).join('\n');
       expect(warned, contains('Hot Restart is not available'));
       expect(warned, isNot(contains('not attached to the app yet')));
+    });
+
+    test('logs survives stdout arriving after the process exits', () async {
+      stubProcess(stdout: ['Showing logs:'], exitCode: Future.value(1));
+
+      await flutterTool.logs('testDeviceId', flutterCommand: flutterCommand);
+      await Future<void>.delayed(const Duration(milliseconds: 80));
     });
 
     test('logs does not leave the observation URL pending on exit', () async {


### PR DESCRIPTION
## Summary

`flutter attach` and `flutter logs` report a rejected option, or a project they cannot resolve, by exiting rather than by writing to stdout. Both were awaited on a completer only stdout could complete, so nothing noticed.

That is why #3223 survived two releases: `r` kept answering "not attached to the app yet" with no reason given. #3235 fixed that particular cause; this makes the next one announce itself.

## Changes

- Watch the exit code of `flutter attach` and `flutter logs`, and complete the wait with the collected stderr.
- `r` reports that reason instead of the generic "not attached to the app yet".
- Where attach reads the VM service URL from `flutter logs`, its death now ends the session with a `ToolExit` carrying the exit code and stderr, and `_execute` lets a `ToolExit` through instead of appending "it's a bug - please report it" to it.

## Verification

Unit tests for both exit paths, for `r` reporting the reason, for stdout arriving after the process exits, and for a `flutter logs` exit not leaving the observation URL pending. Their stubs deliver output after the exit code, so removing either drain, or completing either wait unguarded, fails them. `patrol_cli` suite, `dart analyze` and `dart format` clean.

On a flavored `packages/patrol/example` the session ends with ``Logs are not available: `flutter logs` exited with code 1: You must specify a --flavor option…`` instead of hanging — measured against `master`, where the same run sat silent for 5+ minutes with `flutter logs` already dead and `flutter attach` never started.

## Scope

Only a death *before* the wait completes is reported. A process that dies later — mid-session — still goes unnoticed: `_hotRestartActive` stays set, so `r` still answers as if the session were healthy.

Only stderr is collected, so a failure a tool prints on stdout yields the exit code without the reason.

`_logger.err` reaches the terminal, not `patrol_mcp`, which captures stdout only; there the `ToolExit` above is what carries the reason.

Two other waits in `patrol_cli` are left alone: `coverage_tool.dart` completes one from `onDone` unguarded while the dispose scope completes the same one, and `compatibility_checker.dart` throws from `onDone` instead of completing, so its `await` never resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
