### PR TITLE
fix(patrol_finders): report drag time on dragUntil timeouts #2103

### DIFF
--- a/packages/patrol_finders/CHANGELOG.md
+++ b/packages/patrol_finders/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Report drag time on `dragUntilExists` / `dragUntilVisible` timeouts instead of `settleBetweenScrollsTimeout`. (#2103)
 - Add a regression test for finding widgets by keys containing special characters (diacritics, symbols, emoji). (#3169)
 
 ## 3.6.0

--- a/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart
@@ -717,8 +717,7 @@ class PatrolTester {
           if (iterationsLeft <= 0) {
             throw WaitUntilExistsTimeoutException(
               finder: finder,
-              // TODO: set reasonable duration or create new exception for this case
-              duration: settleBetweenScrollsTimeout!,
+              duration: dragDuration! * maxIteration,
             );
           }
 
@@ -799,8 +798,7 @@ class PatrolTester {
           if (iterationsLeft <= 0) {
             throw WaitUntilVisibleTimeoutException(
               finder: hitTestableFinder,
-              // TODO: set reasonable duration or create new exception for this case
-              duration: settleBetweenScrollsTimeout!,
+              duration: dragDuration! * maxIteration,
             );
           }
 

--- a/packages/patrol_finders/test/patrol_tester_test.dart
+++ b/packages/patrol_finders/test/patrol_tester_test.dart
@@ -470,6 +470,40 @@ void main() {
         },
       );
 
+      patrolWidgetTest(
+        'timeout duration is drag time, not settleBetweenScrollsTimeout',
+        (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: ListView(children: const [Text('one'), Text('two')]),
+            ),
+          );
+
+          const dragDuration = Duration(milliseconds: 40);
+          const maxIteration = 2;
+          const settleBetweenScrollsTimeout = Duration(seconds: 20);
+
+          await expectLater(
+            () => tester.dragUntilExists(
+              finder: find.text('three'),
+              view: find.byType(Scrollable),
+              moveStep: const Offset(0, defaultScrollDelta),
+              dragDuration: dragDuration,
+              maxIteration: maxIteration,
+              settleBetweenScrollsTimeout: settleBetweenScrollsTimeout,
+              settlePolicy: SettlePolicy.noSettle,
+            ),
+            throwsA(
+              isA<WaitUntilExistsTimeoutException>().having(
+                (e) => e.duration,
+                'duration',
+                dragDuration * maxIteration,
+              ),
+            ),
+          );
+        },
+      );
+
       patrolWidgetTest('drags to existing and visible widget', (tester) async {
         await tester.pumpWidget(
           const MaterialApp(
@@ -637,6 +671,40 @@ void main() {
               moveStep: const Offset(0, defaultScrollDelta),
             ),
             throwsA(isA<WaitUntilVisibleTimeoutException>()),
+          );
+        },
+      );
+
+      patrolWidgetTest(
+        'timeout duration is drag time, not settleBetweenScrollsTimeout',
+        (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: ListView(children: const [Text('one'), Text('two')]),
+            ),
+          );
+
+          const dragDuration = Duration(milliseconds: 40);
+          const maxIteration = 2;
+          const settleBetweenScrollsTimeout = Duration(seconds: 20);
+
+          await expectLater(
+            () => tester.dragUntilVisible(
+              finder: find.text('three'),
+              view: find.byType(Scrollable),
+              moveStep: const Offset(0, defaultScrollDelta),
+              dragDuration: dragDuration,
+              maxIteration: maxIteration,
+              settleBetweenScrollsTimeout: settleBetweenScrollsTimeout,
+              settlePolicy: SettlePolicy.noSettle,
+            ),
+            throwsA(
+              isA<WaitUntilVisibleTimeoutException>().having(
+                (e) => e.duration,
+                'duration',
+                dragDuration * maxIteration,
+              ),
+            ),
           );
         },
       );


### PR DESCRIPTION
The timeout on `dragUntilExists` / `dragUntilVisible` used `settleBetweenScrollsTimeout`. That is the pump gap, not how long we dragged.

I set the reported duration to `dragDuration * maxIteration` and added a test that fails if we go back to the settle timeout.

Fixes #2103