### PR TITLE
fix(patrol): stop applying KGP on AGP 9

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Android: stop applying the Kotlin Gradle Plugin on AGP 9+ so that Patrol uses built-in Kotlin without triggering Flutter's incompatible-plugin warning. AGP 8 and older continue to use KGP. (#3238)
 - Android: keep third-party `AccessibilityService`s running during the test session again. `AndroidAutomatorConfig.dontSuppressAccessibilityServices` now defaults to `true` (it was effectively `false` since 4.8.0) and is configurable, also via the `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` dart-define. (#3227)
 
 ## 4.9.0

--- a/packages/patrol/android/build.gradle
+++ b/packages/patrol/android/build.gradle
@@ -19,13 +19,8 @@ buildscript {
 apply plugin: "com.android.library"
 
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-// Host apps control Kotlin compilation mode via gradle.properties (android.builtInKotlin).
-// false (Flutter default for unmigrated apps): apply KGP on AGP 9+.
-// true (fully migrated apps): skip KGP and rely on AGP built-in Kotlin on AGP 9+.
-// AGP < 9 always uses KGP regardless of the flag. This plugin supports both paths.
-def usesBuiltInKotlin = project.findProperty("android.builtInKotlin") == "true"
-if (agpMajor < 9 || !usesBuiltInKotlin) {
-    apply plugin: "kotlin-android"
+if (agpMajor < 9) {
+    pluginManager.apply("kotlin-android")
 }
 
 apply plugin: "org.jlleitschuh.gradle.ktlint"
@@ -52,8 +47,8 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    sourceSets {
-        main.java.srcDirs += "src/main/kotlin"
+    sourceSets.named("main") {
+        kotlin.directories.add("src/main/kotlin")
     }
 
     defaultConfig {


### PR DESCRIPTION
## Summary

- stop applying KGP in Patrol's Android module on AGP 9+
- keep the KGP fallback for AGP 8 and older without triggering Flutter 3.47's source scanner
- register Kotlin sources through `AndroidSourceSet.kotlin`, which works with both KGP and built-in Kotlin

Closes #3238.

## Why

Flutter 3.47 generated projects use AGP 9 while temporarily setting `android.builtInKotlin=false`. Patrol 4.9 treats that host-wide opt-out as a reason to apply KGP inside the Patrol module, so Flutter reports Patrol as an incompatible plugin.

Flutter's current plugin-author migration guide says the compatibility fallback should apply KGP only on AGP versions below 9. Flutter supplies the transitional KGP path while a host opts out, and AGP supplies built-in Kotlin after the host opts in.

`pluginManager.apply` is equivalent to the legacy Groovy `apply plugin` call, but it avoids Flutter 3.47's current regex false-positive for the documented conditional fallback.

## Verification

Verified in generated projects independent of any application codebase:

- Flutter 3.47.0 / AGP 9.1.0 / `android.builtInKotlin=false`: debug APK builds without the Patrol KGP warning
- Flutter 3.47.0 / AGP 9.1.0 / `android.builtInKotlin=true`: debug APK builds
- Flutter 3.44.0 / AGP 8.7.3 / Gradle 8.12 / KGP 2.1.0: debug APK builds
- Patrol `testDebugUnitTest` passes in all three configurations
- Patrol `ktlintCheck` passes
- `./gradlew help` and `:patrol:build --dry-run` pass on AGP 9
