### PR TITLE
Add description parameter to Flutter actions

### DIFF
--- a/packages/patrol_finders/CHANGELOG.md
+++ b/packages/patrol_finders/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add optional `description` parameter to Flutter actions (`tap`, `enterText`, `scrollTo`, etc.). When set, it replaces the auto-generated patrol log step text and wraps failures as `failed on: <description>`.
 - Add a regression test for finding widgets by keys containing special characters (diacritics, symbols, emoji). (#3169)
 
 ## 3.6.0

--- a/packages/patrol_finders/lib/src/custom_finders/exceptions.dart
+++ b/packages/patrol_finders/lib/src/custom_finders/exceptions.dart
@@ -3,6 +3,24 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol_finders/patrol_finders.dart';
 
+/// Thrown when a Patrol action with a [description] fails.
+///
+/// Preserves the underlying [cause] while surfacing the user-provided step
+/// description, e.g. `failed on: Clicking payment button to submit`.
+class PatrolStepException implements Exception {
+  /// Creates a new [PatrolStepException].
+  PatrolStepException({required this.description, required this.cause});
+
+  /// User-provided description of what the action was trying to do.
+  final String description;
+
+  /// Original exception thrown by the action.
+  final Object cause;
+
+  @override
+  String toString() => 'failed on: $description\n$cause';
+}
+
 /// Thrown when some Patrol method fails to complete within the allowed time.
 class PatrolTimeoutException extends TimeoutException {
   /// Creates a new [PatrolTimeoutException].

--- a/packages/patrol_finders/lib/src/custom_finders/patrol_finder.dart
+++ b/packages/patrol_finders/lib/src/custom_finders/patrol_finder.dart
@@ -368,7 +368,6 @@ class PatrolFinder implements MatchFinder {
     String? description,
   }) => wrapWithPatrolLog(
     action: 'enterText',
-    value: text,
     color: AnsiCodes.magenta,
     description: description,
     function: () => tester.enterText(

--- a/packages/patrol_finders/lib/src/custom_finders/patrol_finder.dart
+++ b/packages/patrol_finders/lib/src/custom_finders/patrol_finder.dart
@@ -170,17 +170,60 @@ class PatrolFinder implements MatchFinder {
   final PatrolTester tester;
 
   /// Wraps a function with a log entry for the start and end of the function.
+  ///
+  /// If [description] is provided, it replaces the auto-generated step text in
+  /// the patrol log. On failure, the error is wrapped in [PatrolStepException]
+  /// with that description (e.g. `failed on: …`).
   Future<T> wrapWithPatrolLog<T>({
     required String action,
     String? value,
+    String? description,
     required String color,
     required Future<T> Function() function,
     bool enablePatrolLog = true,
   }) async {
-    if (!(tester.config.printLogs && enablePatrolLog)) {
+    final shouldLog = tester.config.printLogs && enablePatrolLog;
+    if (!shouldLog && description == null) {
       return function();
     }
 
+    final text =
+        description ??
+        _defaultStepText(action: action, value: value, color: color);
+    if (shouldLog) {
+      tester.patrolLog.log(
+        StepEntry(action: text, status: StepEntryStatus.start),
+      );
+    }
+    try {
+      final result = await function();
+      if (shouldLog) {
+        tester.patrolLog.log(
+          StepEntry(action: text, status: StepEntryStatus.success),
+        );
+      }
+      return result;
+    } catch (err, st) {
+      if (shouldLog) {
+        tester.patrolLog.log(
+          StepEntry(action: text, status: StepEntryStatus.failure),
+        );
+      }
+      if (description != null) {
+        Error.throwWithStackTrace(
+          PatrolStepException(description: description, cause: err),
+          st,
+        );
+      }
+      rethrow;
+    }
+  }
+
+  String _defaultStepText({
+    required String action,
+    String? value,
+    required String color,
+  }) {
     final finderText = finder
         .toString(describeSelf: true)
         .replaceAll('A finder that searches for', '')
@@ -188,22 +231,7 @@ class PatrolFinder implements MatchFinder {
         .replaceAll(' (ignoring all but first)', '');
 
     final valueText = value != null ? ' "$value"' : '';
-    final text = '$color$action${AnsiCodes.reset}$valueText$finderText';
-    tester.patrolLog.log(
-      StepEntry(action: text, status: StepEntryStatus.start),
-    );
-    try {
-      final result = await function();
-      tester.patrolLog.log(
-        StepEntry(action: text, status: StepEntryStatus.success),
-      );
-      return result;
-    } catch (err) {
-      tester.patrolLog.log(
-        StepEntry(action: text, status: StepEntryStatus.failure),
-      );
-      rethrow;
-    }
+    return '$color$action${AnsiCodes.reset}$valueText$finderText';
   }
 
   /// Waits until this finder finds at least 1 visible widget and then taps on
@@ -231,14 +259,19 @@ class PatrolFinder implements MatchFinder {
   ///  - [PatrolFinder.waitUntilVisible], which is used to wait for the widget
   ///    to appear
   ///  - [WidgetController.tap]
+  ///
+  /// If [description] is provided, it replaces the auto-generated step text in
+  /// the patrol log and is included in the error message on failure.
   Future<void> tap({
     SettlePolicy? settlePolicy,
     Duration? visibleTimeout,
     Duration? settleTimeout,
     Alignment alignment = Alignment.center,
+    String? description,
   }) => wrapWithPatrolLog(
     action: 'tap',
     color: AnsiCodes.yellow,
+    description: description,
     function: () => tester.tap(
       this,
       settlePolicy: settlePolicy,
@@ -274,14 +307,19 @@ class PatrolFinder implements MatchFinder {
   ///  - [PatrolFinder.waitUntilVisible], which is used to wait for the widget
   ///    to appear
   ///  - [WidgetController.longPress]
+  ///
+  /// If [description] is provided, it replaces the auto-generated step text in
+  /// the patrol log and is included in the error message on failure.
   Future<void> longPress({
     SettlePolicy? settlePolicy,
     Duration? visibleTimeout,
     Duration? settleTimeout,
     Alignment alignment = Alignment.center,
+    String? description,
   }) => wrapWithPatrolLog(
     action: 'longPress',
     color: AnsiCodes.yellow,
+    description: description,
     function: () => tester.longPress(
       this,
       settlePolicy: settlePolicy,
@@ -317,6 +355,9 @@ class PatrolFinder implements MatchFinder {
   ///  - [PatrolFinder.waitUntilVisible], which is used to wait for the widget
   ///    to appear
   ///  - [WidgetTester.enterText]
+  ///
+  /// If [description] is provided, it replaces the auto-generated step text in
+  /// the patrol log and is included in the error message on failure.
   Future<void> enterText(
     String text, {
     SettlePolicy? settlePolicy,
@@ -324,9 +365,12 @@ class PatrolFinder implements MatchFinder {
     Duration? settleTimeout,
     Alignment alignment = Alignment.center,
     bool hideKeyboard = true,
+    String? description,
   }) => wrapWithPatrolLog(
     action: 'enterText',
+    value: text,
     color: AnsiCodes.magenta,
+    description: description,
     function: () => tester.enterText(
       this,
       text,
@@ -349,6 +393,9 @@ class PatrolFinder implements MatchFinder {
   ///
   /// See also:
   ///  - [PatrolTester.scrollUntilVisible], which this method wraps
+  ///
+  /// If [description] is provided, it replaces the auto-generated step text in
+  /// the patrol log and is included in the error message on failure.
   Future<PatrolFinder> scrollTo({
     Finder? view,
     double step = defaultScrollDelta,
@@ -358,10 +405,12 @@ class PatrolFinder implements MatchFinder {
     Duration? dragDuration,
     SettlePolicy? settlePolicy,
     Alignment alignment = Alignment.center,
+    String? description,
   }) {
     return wrapWithPatrolLog(
       action: 'scrollTo',
       color: AnsiCodes.green,
+      description: description,
       function: () {
         return tester.scrollUntilVisible(
           finder: this,
@@ -386,16 +435,18 @@ class PatrolFinder implements MatchFinder {
   /// Timeout is globally set by [PatrolTesterConfig.visibleTimeout] inside
   /// [PatrolTester.config]. If you want to override this global setting, set
   /// [timeout].
-  Future<PatrolFinder> waitUntilExists({Duration? timeout}) =>
-      wrapWithPatrolLog(
-        action: 'waitUntilExists',
-        color: AnsiCodes.cyan,
-        function: () => tester.waitUntilExists(
-          this,
-          timeout: timeout,
-          enablePatrolLog: false,
-        ),
-      );
+  /// If [description] is provided, it replaces the auto-generated step text in
+  /// the patrol log and is included in the error message on failure.
+  Future<PatrolFinder> waitUntilExists({
+    Duration? timeout,
+    String? description,
+  }) => wrapWithPatrolLog(
+    action: 'waitUntilExists',
+    color: AnsiCodes.cyan,
+    description: description,
+    function: () =>
+        tester.waitUntilExists(this, timeout: timeout, enablePatrolLog: false),
+  );
 
   /// Waits until this finder finds at least one visible widget.
   ///
@@ -407,13 +458,17 @@ class PatrolFinder implements MatchFinder {
   /// [PatrolTester.config]. If you want to override this global setting, set
   /// [timeout].
   /// {@macro patrol_tester.alignment_on_visible_check}
+  /// If [description] is provided, it replaces the auto-generated step text in
+  /// the patrol log and is included in the error message on failure.
   Future<PatrolFinder> waitUntilVisible({
     Duration? timeout,
     bool enablePatrolLog = true,
     Alignment alignment = Alignment.center,
+    String? description,
   }) => wrapWithPatrolLog(
     action: 'waitUntilVisible',
     color: AnsiCodes.cyan,
+    description: description,
     function: () => tester.waitUntilVisible(
       this,
       timeout: timeout,
@@ -678,12 +733,14 @@ extension ActionCombiner on Future<PatrolFinder> {
     Duration? visibleTimeout,
     Duration? settleTimeout,
     Alignment alignment = Alignment.center,
+    String? description,
   }) async {
     await (await this).tap(
       settlePolicy: settlePolicy,
       visibleTimeout: visibleTimeout,
       settleTimeout: settleTimeout,
       alignment: alignment,
+      description: description,
     );
   }
 
@@ -696,6 +753,7 @@ extension ActionCombiner on Future<PatrolFinder> {
     Duration? settleTimeout,
     Alignment alignment = Alignment.center,
     bool hideKeyboard = true,
+    String? description,
   }) async {
     await (await this).enterText(
       text,
@@ -704,6 +762,7 @@ extension ActionCombiner on Future<PatrolFinder> {
       settleTimeout: settleTimeout,
       alignment: alignment,
       hideKeyboard: hideKeyboard,
+      description: description,
     );
   }
 }

--- a/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart
+++ b/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart
@@ -127,8 +127,11 @@ const defaultScrollMaxIteration = 15;
 /// <https://dart.dev/guides/language/language-tour#callable-classes>
 class PatrolTester {
   /// Creates a new [PatrolTester] which wraps [tester].
-  PatrolTester({required this.tester, required this.config})
-    : patrolLog = PatrolLogWriter();
+  PatrolTester({
+    required this.tester,
+    required this.config,
+    PatrolLogWriter? patrolLog,
+  }) : patrolLog = patrolLog ?? PatrolLogWriter();
 
   /// Global configuration of this tester.
   final PatrolTesterConfig config;
@@ -155,18 +158,61 @@ class PatrolTester {
       !kIsWeb && defaultTargetPlatform == platform;
 
   /// Wraps a function with a log entry for the start and end of the function.
+  ///
+  /// If [description] is provided, it replaces the auto-generated step text in
+  /// the patrol log. On failure, the error is wrapped in [PatrolStepException]
+  /// with that description (e.g. `failed on: …`).
   Future<T> wrapWithPatrolLog<T>({
     required String action,
     String? value,
     Finder? finder,
+    String? description,
     required String color,
     required Future<T> Function() function,
     bool enablePatrolLog = true,
   }) async {
-    if (!(config.printLogs && enablePatrolLog)) {
+    final shouldLog = config.printLogs && enablePatrolLog;
+    if (!shouldLog && description == null) {
       return function();
     }
 
+    final text =
+        description ??
+        _defaultStepText(
+          action: action,
+          value: value,
+          finder: finder,
+          color: color,
+        );
+    if (shouldLog) {
+      patrolLog.log(StepEntry(action: text, status: StepEntryStatus.start));
+    }
+    try {
+      final result = await function();
+      if (shouldLog) {
+        patrolLog.log(StepEntry(action: text, status: StepEntryStatus.success));
+      }
+      return result;
+    } catch (err, st) {
+      if (shouldLog) {
+        patrolLog.log(StepEntry(action: text, status: StepEntryStatus.failure));
+      }
+      if (description != null) {
+        Error.throwWithStackTrace(
+          PatrolStepException(description: description, cause: err),
+          st,
+        );
+      }
+      rethrow;
+    }
+  }
+
+  String _defaultStepText({
+    required String action,
+    String? value,
+    Finder? finder,
+    required String color,
+  }) {
     final finderText =
         finder
             ?.toString(describeSelf: true)
@@ -175,16 +221,7 @@ class PatrolTester {
             .replaceAll(' (ignoring all but first)', '') ??
         '';
     final valueText = value != null ? ' "$value"' : '';
-    final text = '$color$action${AnsiCodes.reset}$valueText$finderText';
-    patrolLog.log(StepEntry(action: text, status: StepEntryStatus.start));
-    try {
-      final result = await function();
-      patrolLog.log(StepEntry(action: text, status: StepEntryStatus.success));
-      return result;
-    } catch (err) {
-      patrolLog.log(StepEntry(action: text, status: StepEntryStatus.failure));
-      rethrow;
-    }
+    return '$color$action${AnsiCodes.reset}$valueText$finderText';
   }
 
   /// Returns a [PatrolFinder] that matches [matching].
@@ -298,6 +335,9 @@ class PatrolTester {
   ///  - [PatrolFinder.waitUntilVisible], which is used to wait for the widget
   ///    to appear
   ///  - [WidgetController.tap]
+  ///
+  /// If [description] is provided, it replaces the auto-generated step text in
+  /// the patrol log and is included in the error message on failure.
   Future<void> tap(
     Finder finder, {
     SettlePolicy? settlePolicy,
@@ -305,6 +345,7 @@ class PatrolTester {
     Duration? settleTimeout,
     Alignment alignment = Alignment.center,
     bool enablePatrolLog = true,
+    String? description,
   }) {
     return TestAsyncUtils.guard(
       () => wrapWithPatrolLog(
@@ -312,6 +353,7 @@ class PatrolTester {
         finder: finder,
         color: AnsiCodes.yellow,
         enablePatrolLog: enablePatrolLog,
+        description: description,
         function: () async {
           final resolvedFinder = await waitUntilVisible(
             finder,
@@ -355,6 +397,9 @@ class PatrolTester {
   ///  - [PatrolFinder.waitUntilVisible], which is used to wait for the widget
   ///    to appear
   ///  - [WidgetController.longPress]
+  ///
+  /// If [description] is provided, it replaces the auto-generated step text in
+  /// the patrol log and is included in the error message on failure.
   Future<void> longPress(
     Finder finder, {
     SettlePolicy? settlePolicy,
@@ -362,6 +407,7 @@ class PatrolTester {
     Duration? settleTimeout,
     Alignment alignment = Alignment.center,
     bool enablePatrolLog = true,
+    String? description,
   }) {
     return TestAsyncUtils.guard(
       () => wrapWithPatrolLog(
@@ -369,6 +415,7 @@ class PatrolTester {
         finder: finder,
         color: AnsiCodes.yellow,
         enablePatrolLog: enablePatrolLog,
+        description: description,
         function: () async {
           final resolvedFinder = await waitUntilVisible(
             finder,
@@ -412,6 +459,9 @@ class PatrolTester {
   ///  - [PatrolFinder.waitUntilVisible], which is used to wait for the widget
   ///    to appear
   ///  - [WidgetTester.enterText]
+  ///
+  /// If [description] is provided, it replaces the auto-generated step text in
+  /// the patrol log and is included in the error message on failure.
   Future<void> enterText(
     Finder finder,
     String text, {
@@ -421,6 +471,7 @@ class PatrolTester {
     Alignment alignment = Alignment.center,
     bool enablePatrolLog = true,
     bool hideKeyboard = true,
+    String? description,
   }) {
     return TestAsyncUtils.guard(
       () => wrapWithPatrolLog(
@@ -429,6 +480,7 @@ class PatrolTester {
         finder: finder,
         color: AnsiCodes.magenta,
         enablePatrolLog: enablePatrolLog,
+        description: description,
         function: () async {
           final resolvedFinder = await waitUntilVisible(
             finder,
@@ -538,6 +590,7 @@ class PatrolTester {
     PatrolFinder finder, {
     Duration? timeout,
     bool enablePatrolLog = true,
+    String? description,
   }) {
     return TestAsyncUtils.guard(
       () => wrapWithPatrolLog<PatrolFinder>(
@@ -545,6 +598,7 @@ class PatrolTester {
         finder: finder,
         color: AnsiCodes.cyan,
         enablePatrolLog: enablePatrolLog,
+        description: description,
         function: () async {
           final duration = timeout ?? config.existsTimeout;
           final end = tester.binding.clock.now().add(duration);
@@ -617,6 +671,7 @@ class PatrolTester {
     Duration? timeout,
     Alignment alignment = Alignment.center,
     bool enablePatrolLog = true,
+    String? description,
   }) {
     return TestAsyncUtils.guard(
       () => wrapWithPatrolLog(
@@ -624,6 +679,7 @@ class PatrolTester {
         finder: finder,
         color: AnsiCodes.cyan,
         enablePatrolLog: enablePatrolLog,
+        description: description,
         function: () async {
           final duration = timeout ?? config.visibleTimeout;
           final end = tester.binding.clock.now().add(duration);
@@ -690,6 +746,7 @@ class PatrolTester {
     Duration? dragDuration,
     SettlePolicy? settlePolicy,
     bool enablePatrolLog = true,
+    String? description,
   }) {
     return TestAsyncUtils.guard(
       () => wrapWithPatrolLog<PatrolFinder>(
@@ -697,6 +754,7 @@ class PatrolTester {
         finder: view,
         color: AnsiCodes.blue,
         enablePatrolLog: enablePatrolLog,
+        description: description,
         function: () async {
           var viewPatrolFinder = PatrolFinder(finder: view, tester: this);
           await viewPatrolFinder.waitUntilVisible(enablePatrolLog: false);
@@ -769,6 +827,7 @@ class PatrolTester {
     SettlePolicy? settlePolicy,
     Alignment alignment = Alignment.center,
     bool enablePatrolLog = true,
+    String? description,
   }) {
     return TestAsyncUtils.guard(
       () => wrapWithPatrolLog<PatrolFinder>(
@@ -776,6 +835,7 @@ class PatrolTester {
         finder: view,
         color: AnsiCodes.blue,
         enablePatrolLog: enablePatrolLog,
+        description: description,
         function: () async {
           final viewPatrolFinder = (await waitUntilVisible(
             PatrolFinder(finder: view, tester: this),
@@ -827,6 +887,7 @@ class PatrolTester {
     Duration? dragDuration,
     SettlePolicy? settlePolicy,
     bool enablePatrolLog = true,
+    String? description,
   }) {
     assert(maxScrolls > 0, 'maxScrolls must be positive number');
     return wrapWithPatrolLog<PatrolFinder>(
@@ -834,6 +895,7 @@ class PatrolTester {
       finder: view,
       color: AnsiCodes.green,
       enablePatrolLog: enablePatrolLog,
+      description: description,
       function: () async {
         final finderView = view ?? find.byType(Scrollable);
 
@@ -901,6 +963,7 @@ class PatrolTester {
     SettlePolicy? settlePolicy,
     Alignment alignment = Alignment.center,
     bool enablePatrolLog = true,
+    String? description,
   }) {
     assert(maxScrolls > 0, 'maxScrolls must be positive number');
     return wrapWithPatrolLog(
@@ -908,6 +971,7 @@ class PatrolTester {
       finder: view,
       color: AnsiCodes.green,
       enablePatrolLog: enablePatrolLog,
+      description: description,
       function: () async {
         final finderView = view ?? find.byType(Scrollable);
         final scrollablePatrolFinder = await PatrolFinder(

--- a/packages/patrol_finders/test/action_description_test.dart
+++ b/packages/patrol_finders/test/action_description_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol_finders/src/custom_finders/custom_finders.dart';
+import 'package:patrol_log/patrol_log.dart';
+
+class _CapturingLogWriter extends PatrolLogWriter {
+  final steps = <StepEntry>[];
+
+  @override
+  void log(Entry entry) {
+    if (entry is StepEntry) {
+      steps.add(entry);
+    }
+  }
+}
+
+void main() {
+  group('action description', () {
+    patrolWidgetTest(
+      'wraps failure with PatrolStepException including description',
+      config: const PatrolTesterConfig(
+        visibleTimeout: Duration(milliseconds: 100),
+      ),
+      ($) async {
+        await $.pumpWidget(const MaterialApp(home: SizedBox()));
+
+        await expectLater(
+          () => $(
+            'Missing',
+          ).tap(description: 'Clicking payment button to submit'),
+          throwsA(
+            isA<PatrolStepException>()
+                .having(
+                  (e) => e.description,
+                  'description',
+                  'Clicking payment button to submit',
+                )
+                .having(
+                  (e) => e.cause,
+                  'cause',
+                  isA<WaitUntilVisibleTimeoutException>(),
+                )
+                .having(
+                  (e) => e.toString(),
+                  'toString',
+                  contains('failed on: Clicking payment button to submit'),
+                ),
+          ),
+        );
+      },
+    );
+
+    patrolWidgetTest(
+      'still throws original timeout when description is omitted',
+      config: const PatrolTesterConfig(
+        visibleTimeout: Duration(milliseconds: 100),
+      ),
+      ($) async {
+        await $.pumpWidget(const MaterialApp(home: SizedBox()));
+
+        await expectLater(
+          () => $('Missing').tap(),
+          throwsA(isA<WaitUntilVisibleTimeoutException>()),
+        );
+      },
+    );
+
+    testWidgets('overrides patrol log step text with description', (
+      widgetTester,
+    ) async {
+      final logWriter = _CapturingLogWriter();
+      final $ = PatrolTester(
+        tester: widgetTester,
+        config: const PatrolTesterConfig(printLogs: true),
+        patrolLog: logWriter,
+      );
+
+      var count = 0;
+      await $.pumpWidget(
+        MaterialApp(
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              return GestureDetector(
+                onTap: () => setState(() => count++),
+                child: Text('Tap me, count: $count'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await $(
+        'Tap me, count: 0',
+      ).tap(description: 'Clicking payment button to submit');
+
+      expect(find.text('Tap me, count: 1'), findsOneWidget);
+
+      expect(logWriter.steps, isNotEmpty);
+      expect(
+        logWriter.steps.every(
+          (step) => step.action == 'Clicking payment button to submit',
+        ),
+        isTrue,
+      );
+      expect(
+        logWriter.steps.any((step) => step.action.contains('widgets with')),
+        isFalse,
+      );
+      expect(
+        logWriter.steps.map((step) => step.status),
+        containsAll([StepEntryStatus.start, StepEntryStatus.success]),
+      );
+    });
+
+    patrolWidgetTest('works with enterText description on success', ($) async {
+      await $.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: TextField(
+              key: Key('email'),
+              decoration: InputDecoration(labelText: 'Email'),
+            ),
+          ),
+        ),
+      );
+
+      await $(
+        #email,
+      ).enterText('user@example.com', description: 'Entering email address');
+
+      expect(find.text('user@example.com'), findsOneWidget);
+    });
+
+    testWidgets('logs failure status with description on failed tap', (
+      widgetTester,
+    ) async {
+      final logWriter = _CapturingLogWriter();
+      final $ = PatrolTester(
+        tester: widgetTester,
+        config: const PatrolTesterConfig(
+          printLogs: true,
+          visibleTimeout: Duration(milliseconds: 100),
+        ),
+        patrolLog: logWriter,
+      );
+
+      await $.pumpWidget(const MaterialApp(home: SizedBox()));
+
+      await expectLater(
+        () =>
+            $('Missing').tap(description: 'Clicking payment button to submit'),
+        throwsA(isA<PatrolStepException>()),
+      );
+
+      expect(
+        logWriter.steps.map((step) => step.action).toSet(),
+        equals({'Clicking payment button to submit'}),
+      );
+      expect(
+        logWriter.steps.map((step) => step.status),
+        containsAll([StepEntryStatus.start, StepEntryStatus.failure]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Add optional `description` parameter to Flutter actions (`tap`, `enterText`, `scrollTo`, etc.). When set, it replaces the auto-generated patrol log step text and wraps failures as `failed on: <description>`.