### PR TITLE
fix: restore FlutterError.onError in a finally so a failing test always reports (prevents shard hang)

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix the whole test shard hanging when a test fails while an asynchronous error source (e.g. a still-running `WebView` platform view) is active. `FlutterError.onError` is now restored in a `finally`, so a failing test reports its result immediately instead of leaving the native runner blocked on `runDartTest` until its timeout. (#3243)
 - Android: keep third-party `AccessibilityService`s running during the test session again. `AndroidAutomatorConfig.dontSuppressAccessibilityServices` now defaults to `true` (it was effectively `false` since 4.8.0) and is configurable, also via the `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` dart-define. (#3227)
 
 ## 4.9.0

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -243,9 +243,15 @@ class PatrolBinding extends LiveTestWidgetsFlutterBinding {
       }
     };
 
-    await testBody();
-
-    FlutterError.onError = previousOnError;
+    try {
+      await testBody();
+    } finally {
+      // Restore even if the body throws. Otherwise a later async error trips
+      // flutter_test's "overrode FlutterError.onError" invariant and the test
+      // never completes, blocking the native runner until the runDartTest
+      // timeout instead of reporting the failure.
+      FlutterError.onError = previousOnError;
+    }
   }
 
   @override


### PR DESCRIPTION
Restore `FlutterError.onError` in a `finally` so a failing test always reports its result instead of hanging the whole shard.

**Problem**
- When a test fails while an asynchronous error source is still live (e.g. a running `WebView` platform view), the whole shard hangs for the full `runDartTest` timeout; the build reads `timedout` with `Failures: 0` and later tests silently never run.
- `_wrapTestBodyWithExceptionGatherer` overrides `FlutterError.onError` and restores it *after* `await testBody()`, so when the body throws the restore is skipped.
- A later async error then trips flutter_test's "a test overrode FlutterError.onError…" invariant in the zone error handler; the test never completes and the native runner blocks on `runDartTest`.
- The restore step (added in #2362) was never exception-safe.

**Change**
- Wrap `await testBody()` in `try/finally` so `onError` is restored even when the body throws.

**Result**
- Minimal repro (open a page with a live `WebView`, then fail, run twice in one shard): `2h` `timedout`, 1 test executed → `62s` `failed`, both tests executed and reported.
- Passing tests unchanged (the `finally` runs at the same point as before); develop mode unaffected.

**Note**
- On the failure path, errors thrown *after* the body (during teardown) are no longer appended to the report details; the test still reports as failed.
- Validated manually (repro above). I couldn't add an automated regression test cleanly — the failure path isn't reachable from the e2e suite (no expected-fail harness) and `PatrolBinding` isn't instantiable in a widget test. Happy to add one if you can point me to the right harness.
