### PR TITLE
fix: restore FlutterError.onError in a finally so a failing test always reports

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix the whole test shard hanging when a test fails while an asynchronous error source (e.g. a still-running `WebView` platform view) is active. `FlutterError.onError` is now restored in a `finally`, so a failing test reports its result immediately instead of leaving the native runner blocked on `runDartTest` until its timeout. (#3243)
 - Android: keep third-party `AccessibilityService`s running during the test session again. `AndroidAutomatorConfig.dontSuppressAccessibilityServices` now defaults to `true` (it was effectively `false` since 4.8.0) and is configurable, also via the `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` dart-define. (#3227)
 
 ## 4.9.0

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix a failing test hanging the whole shard: `FlutterError.onError` was not restored when a test body threw, so the native runner could block on `runDartTest` until its timeout and every test queued behind it never ran. The failure is now reported, with its details. (#3243)
 - Android: keep third-party `AccessibilityService`s running during the test session again. `AndroidAutomatorConfig.dontSuppressAccessibilityServices` now defaults to `true` (it was effectively `false` since 4.8.0) and is configurable, also via the `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` dart-define. (#3227)
 
 ## 4.9.0

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -243,9 +243,15 @@ class PatrolBinding extends LiveTestWidgetsFlutterBinding {
       }
     };
 
-    await testBody();
-
-    FlutterError.onError = previousOnError;
+    try {
+      await testBody();
+    } finally {
+      // Restore even if the body throws. Otherwise a later async error trips
+      // flutter_test's "overrode FlutterError.onError" invariant and the test
+      // never completes, blocking the native runner until the runDartTest
+      // timeout instead of reporting the failure.
+      FlutterError.onError = previousOnError;
+    }
   }
 
   @override

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -243,9 +243,37 @@ class PatrolBinding extends LiveTestWidgetsFlutterBinding {
       }
     };
 
-    await testBody();
-
-    FlutterError.onError = previousOnError;
+    try {
+      await testBody();
+    } catch (err, stackTrace) {
+      // Record the thrown error before the `finally` below uninstalls the
+      // handler. A thrown failure (a failed `expect`, a finder timeout, a
+      // PatrolActionException) is only reported by flutter_test after it has
+      // unwound out of the body, by which point our onError is gone — so
+      // without this the native side gets a result with no details at all.
+      //
+      // Deliberately not done via `reportTestException`: that hook receives
+      // flutter_test's `_pendingExceptionDetails`, which collapses to the
+      // "Multiple exceptions were thrown" placeholder as soon as a second
+      // error arrives. Recording that is exactly the regression #2362 fixed
+      // (#951). The thrown object is always the real one.
+      //
+      // A Failure already gathered by onError accumulates every framework
+      // error seen during the test, so it stays.
+      if (_currentDartTest case final testName?) {
+        _testResults[testName] = switch (_testResults[testName]) {
+          Failure(:final details?) => Failure(testName, details),
+          _ => Failure(testName, '$err\n$stackTrace'),
+        };
+      }
+      rethrow;
+    } finally {
+      // Restore even if the body throws. Otherwise a later async error trips
+      // flutter_test's "overrode FlutterError.onError" invariant and the test
+      // never completes, blocking the native runner until the runDartTest
+      // timeout instead of reporting the failure.
+      FlutterError.onError = previousOnError;
+    }
   }
 
   @override


### PR DESCRIPTION
Fixes a failing test being able to hang an entire test shard.

### The bug

`_wrapTestBodyWithExceptionGatherer` installs a `FlutterError.onError` override and restores it only *after* `await testBody()`:

```dart
await testBody();                        // throws here…
FlutterError.onError = previousOnError;  // …so this never runs
```

A body that throws leaves the override installed. A later async error then trips flutter_test's *"a test overrode FlutterError.onError but failed to return it to its original state"* invariant, the test never completes, the Dart side never replies, and the native runner blocks on `runDartTest` until its 2h timeout.

Two things make this expensive:

- **Every test queued behind it on that shard never runs.**
- **The dead shard reports zero failures**, so CI looks green.

The leaked override also belongs to whichever *earlier* test threw, so the test that appears to hang is often an innocent bystander.

### The fix

`try`/`finally` around the body, plus a `catch` that records the thrown error.

The `catch` is not optional. A thrown failure — a failed `expect`, a finder timeout, a `PatrolActionException` — is only reported by flutter_test *after* it has unwound out of the body, via the zone handler calling `FlutterError.reportError`. The `finally` has already run by then, so the override is gone and nothing records the details; the native side would print the test name followed by a bare `null`.

I deliberately did **not** restore the `reportTestException` hook removed in #2362. That hook receives `_pendingExceptionDetails`, which collapses to the `Multiple exceptions were thrown` placeholder as soon as a second error arrives — reintroducing exactly the regression #2362 fixed (#951). The thrown object is always the real one.

A `Failure` already gathered by `onError` accumulates every framework error seen during the test, so it keeps precedence; the `catch` only fills the gap where there was nothing.

Passing tests are unaffected — the `finally` runs at the same point the old assignment did. Develop mode is unchanged, as the gatherer is not installed there.

### Verification

Measured on a 359-test Android suite on BrowserStack (Galaxy S24 Ultra, 2 shards, espresso with orchestrator):

| | executed | reported |
|---|---|---|
| before | **45 / 359** | `failures="0"` (two dead shards, killed at the 2h cap) |
| after | **365** | 4 real failures, with messages and stack traces |

The four failures were pre-existing and had been invisible for days behind the hang.

**Controlled A/B on the same commit.** Same 10 test files, same device, same shard count and BrowserStack config; the only variable is the patrol version:

| patrol | executed | shards | wall clock |
|---|---|---|---|
| 4.7.1 (unfixed) | **0 / 10** | both dead, 1 `timedout` each | 2h (killed at the cap) |
| this PR | **10 / 10** | both clean | 18 min |

On the unfixed build each shard died on its *first* test, and in both cases that test was one of the four that legitimately fail — `classic_pair_first_then_ble_pairing_patrol` and `ble_pairing_requires_classical_connection_patrol`. The remaining four tests on each shard never ran.

This also rules out 4.9.0 as the cause: 4.7.1 carries the same unfixed code and hangs the same way.

### What I could not reproduce

I could not trigger the wedge on a local x86 emulator via `patrol test`. Four shapes against unfixed 4.9.0, all reported normally instead of hanging:

1. one-shot `Timer` firing after the throw
2. `Timer.periodic` every 100 ms
3. unawaited `Future.error` from a `tearDown` — this one *did* make the **next** test fail with no message, i.e. the cross-test contamination, but no wedge
4. failing while a live `WebView` platform view is mounted

