### PR TITLE
Document the SauceLabs integration

### DIFF
--- a/docs/documentation/ci/platforms.mdx
+++ b/docs/documentation/ci/platforms.mdx
@@ -57,6 +57,19 @@ See also:
 
 - [emulator.wtf pricing]
 
+### SauceLabs
+
+[SauceLabs] offers both virtual devices (Android emulators, iOS simulators) and
+physical ones, on Android and iOS. You upload the app and test binaries with its
+`saucectl` CLI, and it returns results with a video recording and per-job logs.
+
+It runs Patrol tests as the native tests they are — Espresso and XCUITest — so no
+Flutter-specific support is required on its side. Sharding is available on both
+platforms, though on iOS it needs an explicit list of test identifiers.
+
+See the [SauceLabs guide](/documentation/integrations/saucelabs) for the configs and the
+platform-specific caveats.
+
 ### Xcode Cloud
 
 [Xcode Cloud] is a CI/CD platform built into Xcode and designed expressly for
@@ -150,6 +163,7 @@ about your experiences!
 [aws device farm]: https://aws.amazon.com/device-farm
 [emulator.wtf]: https://emulator.wtf
 [emulator.wtf pricing]: https://emulator.wtf/pricing
+[saucelabs]: https://saucelabs.com
 [firebase test lab]: https://firebase.google.com/docs/test-lab
 [firebase test lab pricing]: https://firebase.google.com/docs/test-lab/usage-quotas-pricing
 [xcode cloud]: https://developer.apple.com/xcode-cloud

--- a/docs/documentation/ci/platforms.mdx
+++ b/docs/documentation/ci/platforms.mdx
@@ -65,7 +65,8 @@ physical ones, on Android and iOS. You upload the app and test binaries with its
 
 It runs Patrol tests as the native tests they are — Espresso and XCUITest — so no
 Flutter-specific support is required on its side. Sharding is available on both
-platforms, though on iOS it needs an explicit list of test identifiers.
+platforms, though on iOS it needs
+[an explicit list of test identifiers](/documentation/integrations/saucelabs#sharding).
 
 See the [SauceLabs guide](/documentation/integrations/saucelabs) for the configs and the
 platform-specific caveats.

--- a/docs/documentation/integrations/meta.json
+++ b/docs/documentation/integrations/meta.json
@@ -5,7 +5,7 @@
     "marathon",
     "allure",
     "browserstack",
+    "saucelabs",
     "lambdatest"
   ]
 }
-

--- a/docs/documentation/integrations/saucelabs.mdx
+++ b/docs/documentation/integrations/saucelabs.mdx
@@ -1,0 +1,136 @@
+---
+title: SauceLabs
+---
+
+# SauceLabs overview
+
+[SauceLabs] is a popular cloud device farm, with virtual and real devices on both
+Android and iOS.
+
+Your Patrol tests are ordinary native tests (Espresso on Android, XCUITest on iOS),
+so this page only covers what is specific to Patrol. For the config format, device
+names, sharding options and everything else, follow [SauceLabs' Espresso and
+XCUITest docs][saucectl config].
+
+## Prerequisites
+
+- The standard Patrol setup. Unlike BrowserStack and LambdaTest, SauceLabs needs no
+  farm-specific `testInstrumentationRunner`, so keep the
+  `pl.leancode.patrol.PatrolJUnitRunner` you already have.
+- [saucectl] installed, with `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` exported.
+
+## Android
+
+<Steps>
+
+### Build
+
+```bash
+patrol build android
+```
+
+### Point a config at the two APKs
+
+The command prints both paths. If you use a flavor, both the directory and the file
+name carry it (`apk/staging/debug/app-staging-debug.apk`).
+
+```yaml title=".sauce/android.yml"
+apiVersion: v1alpha
+kind: espresso
+sauce:
+  region: us-west-1
+espresso:
+  app: build/app/outputs/apk/debug/app-debug.apk
+  testApp: build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+suites:
+  - name: "Android"
+    devices:
+      - name: "Google Pixel 9 Pro"
+```
+
+### Run
+
+```bash
+saucectl run --config .sauce/android.yml
+```
+
+</Steps>
+
+<Warning>
+  If every test executes twice, restrict the suite to the class that
+  [build-time test discovery](/documentation/ci/build-time-test-discovery) generated:
+
+  ```yaml
+      testOptions:
+        class:
+          - com.example.myapp.PatrolGeneratedTests
+  ```
+
+  Discovery *adds* that class to your APK rather than replacing the `MainActivityTest`
+  host from your setup. Both enumerate your whole Dart suite, and SauceLabs runs every
+  test class the APK contains. You won't see this under `patrol test`, which narrows
+  the class itself.
+</Warning>
+
+## iOS
+
+<Steps>
+
+### Build
+
+```bash
+patrol build ios --simulator   # or --release, for real devices
+```
+
+For **real devices**, XCUITest wants `.ipa` files rather than the `.app` bundles the
+build produces. Pack each one into an `.ipa` (a zip with the `.app` inside a
+`Payload/` directory) and point your config at the results.
+
+<Warning>
+  Do the [Setup for physical iOS devices] first. The test runner is a separate app
+  from the one under test, so it needs its own identifier, certificate and profile.
+</Warning>
+
+### Point a config at the two bundles
+
+```yaml title=".sauce/ios.yml"
+apiVersion: v1alpha
+kind: xcuitest
+sauce:
+  region: us-west-1
+xcuitest:
+  app: build/ios_integ/Build/Products/Debug-iphonesimulator/Runner.app
+  testApp: build/ios_integ/Build/Products/Debug-iphonesimulator/RunnerUITests-Runner.app
+suites:
+  - name: "iOS"
+    simulators:
+      - name: "iPhone 15 Simulator"
+        platformVersions:
+          - "17.0"
+```
+
+### Run
+
+```bash
+saucectl run --config .sauce/ios.yml
+```
+
+</Steps>
+
+<Info>
+  When a test fails, look for the Dart stack trace in the job's `xcodebuild.log`
+  asset. The JUnit report truncates the failure message.
+</Info>
+
+### Sharding
+
+SauceLabs shards XCUITest by splitting an explicit list of test identifiers
+(`shard: concurrency` with `testListFile`). To generate that list you need
+[build-time test discovery](/documentation/ci/build-time-test-discovery). That page
+has the one-liner that writes the file, and the caveat that the entry format differs
+between simulators and real devices.
+
+[SauceLabs]: https://saucelabs.com
+[saucectl]: https://docs.saucelabs.com/dev/cli/saucectl/
+[saucectl config]: https://docs.saucelabs.com/mobile-apps/automated-testing/espresso-xcuitest/
+[Setup for physical iOS devices]: /documentation/physical-ios-devices-setup

--- a/docs/documentation/integrations/saucelabs.mdx
+++ b/docs/documentation/integrations/saucelabs.mdx
@@ -2,8 +2,6 @@
 title: SauceLabs
 ---
 
-# SauceLabs overview
-
 [SauceLabs] is a popular cloud device farm, with virtual and real devices on both
 Android and iOS.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -39,6 +39,7 @@ With Patrol's native-like testing capabilities, you can  use popular device farm
  - Firebase Test Lab
  - BrowserStack
  - LambdaTest
+ - [SauceLabs](/documentation/integrations/saucelabs)
  - [Marathon](/documentation/integrations/marathon)
  - emulator.wtf
  - AWS Device Farm


### PR DESCRIPTION
Closes #2798.

Adds `documentation/integrations/saucelabs` and lists SauceLabs among the device
labs on `documentation/ci/platforms`.

The guide covers only what is specific to Patrol — where `patrol build` leaves the
binaries, packaging and signing a real-device build, the port pair, the generated
test class an Android suite has to be restricted to — and links to SauceLabs for
the config format, device names and sharding options.
