### PR TITLE
Port the mainline --web-headless flag contract to web-develop

### DIFF
--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -313,7 +313,7 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
       viewport: stringArg('web-viewport'),
       globalTimeout: intArg('web-global-timeout'),
       shard: stringArg('web-shard'),
-      headless: stringArg('web-headless'),
+      headless: optionalBoolArg('web-headless'),
       webPort: intArg('web-port'),
       serverTimeout: intArg('web-server-timeout'),
       browserArgs: stringArg('web-browser-args'),

--- a/packages/patrol_cli/lib/src/crossplatform/app_options.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/app_options.dart
@@ -431,7 +431,7 @@ class WebAppOptions {
   final String? viewport;
   final int? globalTimeout;
   final String? shard;
-  final String? headless;
+  final bool? headless;
   final int? webPort;
   final String? browserArgs;
 

--- a/packages/patrol_cli/lib/src/runner/patrol_command.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command.dart
@@ -344,10 +344,10 @@ abstract class PatrolCommand extends Command<int> {
             'Specify in the format "current/total" (e.g., "1/4" for the first of 4 shards).',
         valueHelp: '1/4',
       )
-      ..addOption(
+      ..addFlag(
         'web-headless',
         help: 'Whether to run browser in headless mode.',
-        valueHelp: 'true | false',
+        defaultsTo: null,
       )
       ..addOption(
         'web-port',
@@ -373,6 +373,12 @@ abstract class PatrolCommand extends Command<int> {
   /// If no flag named [name] was added to the `ArgParser`, an [ArgumentError]
   /// will be thrown.
   bool boolArg(String name) => argResults![name] as bool;
+
+  /// Gets the parsed command-line flag named [name] as a nullable `bool`.
+  ///
+  /// Returns null if the flag was declared with a null default and wasn't
+  /// passed on the command line.
+  bool? optionalBoolArg(String name) => argResults![name] as bool?;
 
   /// Gets the parsed command-line option named [name] as a `String`.
   ///

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -321,7 +321,7 @@ To install a specific version of Patrol CLI, run:
     try {
       _handleFirstRun();
 
-      final topLevelResults = parse(args);
+      final topLevelResults = parse(_normalizeArgs(args));
       verbose = topLevelResults['verbose'] == true;
 
       if (verbose) {
@@ -370,6 +370,47 @@ To install a specific version of Patrol CLI, run:
     }
 
     return exitCode;
+  }
+
+  /// Rewrites the deprecated `--web-headless=<value>` and
+  /// `--web-headless <value>` forms to the `--web-headless`/`--no-web-headless`
+  /// flag syntax, warning about the deprecation.
+  List<String> _normalizeArgs(Iterable<String> args) {
+    final list = args.toList();
+    final result = <String>[];
+
+    for (var i = 0; i < list.length; i++) {
+      final arg = list[i];
+
+      // Everything after `--` is positional, not options.
+      if (arg == '--') {
+        result.addAll(list.sublist(i));
+        break;
+      }
+
+      bool? headless;
+      if (arg == '--web-headless' && i + 1 < list.length) {
+        headless = bool.tryParse(list[i + 1]);
+        if (headless != null) {
+          i++;
+        }
+      } else if (arg.startsWith('--web-headless=')) {
+        headless = bool.tryParse(arg.substring('--web-headless='.length));
+      }
+
+      if (headless == null) {
+        result.add(arg);
+        continue;
+      }
+
+      _logger.warn(
+        'Passing a value to --web-headless is deprecated. '
+        'Use --web-headless or --no-web-headless instead.',
+      );
+      result.add(headless ? '--web-headless' : '--no-web-headless');
+    }
+
+    return result;
   }
 
   @override


### PR DESCRIPTION
Ports mainline's `--web-headless` migration (4f0a61096 + tests 77fb6e62c) to this branch, which forked in April with the older option-with-value form. The drift bit us in CI: the bare flag — correct on mainline — silently consumed the next argument (`--web-viewport`) as its value, headless became `false`, and headed Chromium died on a display-less runner.

| form | before | after |
|---|---|---|
| `--web-headless` | silently eats the next argument | headless on |
| `--no-web-headless` | unknown option | headless off |
| `--web-headless=true/false` | works | works + mainline's deprecation warning |
| `--web-headless=garbage` | silently accepted | loud parser error |

Verbatim port, four pieces: `addFlag(..., defaultsTo: null)`, the `_normalizeArgs` rewriter, the `optionalBoolArg` helper, `headless` typed `bool?`.

Verified: `dart analyze` clean; all four forms exercised against this checkout — behavior matches mainline 4.6.0 exactly.
