### PR TITLE
Fix `patrol develop` leaving Gradle and logcat processes behind on quit

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix an issue when building iOS tests from different directory than project's root - we were looking in a wrong place for .xctestrun file. (#3250)
 - Fix hot restart dying on flavored `patrol develop` — `flutter attach` has no `--flavor`. Regressed in 4.6.1. (#3223)
 - Fix flavored iOS `patrol develop` losing logs — they now come from Patrol's own stream. Simulator unchanged. (#2465)
+- Fix `patrol develop` leaving processes behind after quitting with `q`: the session now stops the instrumentation on the device and disposes what it started, instead of exiting straight away. On Windows the leftover Gradle Test Platform process used to keep holding `utp.0.log.lck`, which made the next run fail on `:app:connectedAndroidTest`. (#3209)
 
 ## 4.7.0
 

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix an issue when building iOS tests from different directory than project's root - we were looking in a wrong place for .xctestrun file. (#3250)
 - Fix hot restart dying on flavored `patrol develop` — `flutter attach` has no `--flavor`. Regressed in 4.6.1. (#3223)
 - Fix flavored iOS `patrol develop` losing logs — they now come from Patrol's own stream. Simulator unchanged. (#2465)
-- Fix `patrol develop` leaving processes behind after quitting with `q`: the session now stops the instrumentation on the device and disposes what it started, instead of exiting straight away. On Windows the leftover Gradle Test Platform process used to keep holding `utp.0.log.lck`, which made the next run fail on `:app:connectedAndroidTest`. (#3209)
+- Fix `patrol develop` leaving Gradle and logcat processes behind after quitting with `q` (#3249)
 
 ## 4.7.0
 

--- a/packages/patrol_cli/lib/src/android/android_test_backend.dart
+++ b/packages/patrol_cli/lib/src/android/android_test_backend.dart
@@ -3,7 +3,7 @@ import 'dart:convert' show LineSplitter;
 import 'dart:io' show Process;
 
 import 'package:adb/adb.dart';
-import 'package:dispose_scope/dispose_scope.dart';
+import 'package:dispose_scope/dispose_scope.dart' hide ProcessDisposed;
 import 'package:file/file.dart';
 import 'package:meta/meta.dart';
 import 'package:patrol_cli/src/android/android_test_codegen.dart';
@@ -886,6 +886,47 @@ class AndroidTestBackend {
       }
     } catch (err) {
       _logger.warn('Failed to pull screenshots from device: $err');
+    }
+  }
+
+  /// Stops [appId] and its instrumentation on [device].
+  ///
+  /// The Gradle Test Platform process waits for `am instrument` to return, and
+  /// in develop mode the instrumentation stays alive on purpose so Hot Restart
+  /// has something to restart. Quitting therefore has to end it explicitly, or
+  /// that process outlives the session - on Windows holding `utp.0.log.lck` and
+  /// failing the next `connectedAndroidTest`. (#3209)
+  Future<void> stopInstrumentation(String appId, Device device) async {
+    // Resolved rather than assumed to be `$appId.test`, so a custom
+    // testApplicationId is stopped too - otherwise the instrumentation keeps
+    // running in exactly the setups that need this most. Never let the lookup
+    // itself abort the shutdown; the conventional name is a good enough guess.
+    var testPackageName = '$appId.test';
+    try {
+      (testPackageName, _) = await _resolveInstrumentationComponent(
+        appId,
+        device,
+      );
+    } catch (err) {
+      _logger.detail('Could not resolve the instrumentation package: $err');
+    }
+
+    for (final packageName in {appId, testPackageName}) {
+      _logger.detail('Stopping $packageName on ${device.name}');
+      try {
+        await _processManager.run([
+          'adb',
+          '-s',
+          device.id,
+          'shell',
+          'am',
+          'force-stop',
+          packageName,
+        ], runInShell: true);
+      } catch (err) {
+        // Best effort - the app or the device may already be gone.
+        _logger.detail('Failed to stop $packageName: $err');
+      }
     }
   }
 

--- a/packages/patrol_cli/lib/src/android/android_test_backend.dart
+++ b/packages/patrol_cli/lib/src/android/android_test_backend.dart
@@ -122,7 +122,7 @@ class AndroidTestBackend {
                 _ => {},
               },
             )
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
       process.listenStdOut((l) => _logger.detail('\t: $l')).disposedBy(scope);
       process.listenStdErr((l) => _logger.err('\t$l')).disposedBy(scope);
       exitCode = await process.exitCode;
@@ -150,7 +150,7 @@ class AndroidTestBackend {
                 _ => {},
               },
             )
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
       process.listenStdOut((l) => _logger.detail('\t: $l')).disposedBy(scope);
       process.listenStdErr((l) => _logger.err('\t$l')).disposedBy(scope);
 
@@ -256,7 +256,7 @@ class AndroidTestBackend {
               'doctor',
               '--verbose',
             ], runInShell: true)
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
 
       process
           .listenStdOut(
@@ -312,7 +312,7 @@ class AndroidTestBackend {
               '-t',
               options.target,
             ], runInShell: true)
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
 
       process.listenStdOut((l) => _logger.detail('\t: $l')).disposedBy(scope);
       process.listenStdErr((l) => _logger.err('\t$l')).disposedBy(scope);
@@ -340,7 +340,7 @@ class AndroidTestBackend {
                 _ => {},
               },
             )
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
       process
           .listenStdOut((l) {
             if (l.contains('androidx.test:orchestrator:1.5.0')) {
@@ -400,7 +400,7 @@ class AndroidTestBackend {
               arguments: {'-T': '1'},
               filter: 'PatrolServer:I Patrol:I flutter:I *:S',
             )
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
 
       final path = generateTestReportPath(
         rootPath: _rootDirectory.path,
@@ -463,7 +463,7 @@ class AndroidTestBackend {
               },
               workingDirectory: _rootDirectory.childDirectory('android').path,
             )
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
       process.listenStdOut((l) => _logger.detail('\t: $l')).disposedBy(scope);
       process
           .listenStdErr((l) {
@@ -571,7 +571,7 @@ class AndroidTestBackend {
               arguments: {'-T': '1'},
               filter: 'PatrolServer:I Patrol:I flutter:I *:S',
             )
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
 
       final path = generateTestReportPath(
         rootPath: _rootDirectory.path,
@@ -609,7 +609,7 @@ class AndroidTestBackend {
               device: device.id,
               arguments: {'class': classArg},
             )
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
       process
           .listenStdOut((l) {
             if (l.contains('FAILURES!!!') ||
@@ -891,22 +891,18 @@ class AndroidTestBackend {
 
   /// Stops [appId] and its instrumentation on [device].
   ///
-  /// The Gradle Test Platform process waits for `am instrument` to return, and
-  /// in develop mode the instrumentation stays alive on purpose so Hot Restart
-  /// has something to restart. Quitting therefore has to end it explicitly, or
-  /// that process outlives the session - on Windows holding `utp.0.log.lck` and
-  /// failing the next `connectedAndroidTest`. (#3209)
+  /// In develop mode the instrumentation stays alive so Hot Restart has
+  /// something to restart, and the Gradle Test Platform waits for it to
+  /// return - so quitting has to end it explicitly.
   Future<void> stopInstrumentation(String appId, Device device) async {
-    // Resolved rather than assumed to be `$appId.test`, so a custom
-    // testApplicationId is stopped too - otherwise the instrumentation keeps
-    // running in exactly the setups that need this most. Never let the lookup
-    // itself abort the shutdown; the conventional name is a good enough guess.
+    // A custom `testApplicationId` changes the test package name. The lookup
+    // must not abort the shutdown; the conventional name is the fallback.
     var testPackageName = '$appId.test';
     try {
       (testPackageName, _) = await _resolveInstrumentationComponent(
         appId,
         device,
-      );
+      ).timeout(const Duration(seconds: 10));
     } catch (err) {
       _logger.detail('Could not resolve the instrumentation package: $err');
     }
@@ -914,15 +910,17 @@ class AndroidTestBackend {
     for (final packageName in {appId, testPackageName}) {
       _logger.detail('Stopping $packageName on ${device.name}');
       try {
-        await _processManager.run([
-          'adb',
-          '-s',
-          device.id,
-          'shell',
-          'am',
-          'force-stop',
-          packageName,
-        ], runInShell: true);
+        await _processManager
+            .run([
+              'adb',
+              '-s',
+              device.id,
+              'shell',
+              'am',
+              'force-stop',
+              packageName,
+            ], runInShell: true)
+            .timeout(const Duration(seconds: 10));
       } catch (err) {
         // Best effort - the app or the device may already be gone.
         _logger.detail('Failed to stop $packageName: $err');

--- a/packages/patrol_cli/lib/src/android/android_video_recording_manager.dart
+++ b/packages/patrol_cli/lib/src/android/android_video_recording_manager.dart
@@ -82,7 +82,7 @@ class AndroidVideoRecordingManager extends VideoRecordingManager {
         ],
         _currentDeviceVideoPath!,
       ], runInShell: true);
-      _currentRecordingProcess!.disposedBy(_scope);
+      _currentRecordingProcess!.disposedByTree(_scope);
 
       // Capture screenrecord output so startup failures surface instead of
       // silently producing no file (later failing on `adb pull`).

--- a/packages/patrol_cli/lib/src/android/android_video_recording_manager.dart
+++ b/packages/patrol_cli/lib/src/android/android_video_recording_manager.dart
@@ -2,9 +2,10 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:adb/adb.dart';
-import 'package:dispose_scope/dispose_scope.dart';
+import 'package:dispose_scope/dispose_scope.dart' hide ProcessDisposed;
 import 'package:file/file.dart';
 import 'package:patrol_cli/src/base/logger.dart';
+import 'package:patrol_cli/src/base/process.dart';
 import 'package:patrol_cli/src/crossplatform/video_recording_config.dart';
 import 'package:patrol_cli/src/crossplatform/video_recording_manager.dart';
 import 'package:patrol_cli/src/devices.dart';

--- a/packages/patrol_cli/lib/src/base/process.dart
+++ b/packages/patrol_cli/lib/src/base/process.dart
@@ -112,8 +112,8 @@ extension ProcessTreeDisposers on Process {
     unawaited(exitCode.then((_) => exited = true));
 
     disposeScope.addDispose(() async {
-      // A dead PID may already belong to another process; taskkill would
-      // escalate that into killing an unrelated tree.
+      // A PID is reused once its process is gone, so killing by PID after that
+      // can hit an unrelated process - and `taskkill /T` its whole tree.
       if (exited) {
         return;
       }

--- a/packages/patrol_cli/lib/src/base/process.dart
+++ b/packages/patrol_cli/lib/src/base/process.dart
@@ -4,6 +4,7 @@ import 'dart:io' show Process, ProcessResult, ProcessStartMode, systemEncoding;
 
 import 'package:dispose_scope/dispose_scope.dart';
 import 'package:patrol_cli/src/base/logger.dart';
+import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 
 class LoggingLocalProcessManager extends LocalProcessManager {
@@ -99,6 +100,45 @@ extension ProcessListeners on Process {
 extension ProcessDisposers on Process {
   void disposed(DisposeScope disposeScope) {
     disposeScope.addDispose(kill);
+  }
+}
+
+/// Shadows `dispose_scope`'s `ProcessDisposed.disposedBy`, which kills only the
+/// process itself. Import `dispose_scope` with `hide ProcessDisposed` to use it.
+extension ProcessTreeDisposers on Process {
+  /// Adds this process to [disposeScope], to be killed together with any
+  /// processes it spawned.
+  ///
+  /// On Windows `runInShell: true` means `cmd.exe /c <command>`, so killing the
+  /// process we hold orphans the rest of the tree instead of ending it. There
+  /// are no process groups to signal, hence `taskkill /T`. Elsewhere `sh -c`
+  /// execs into the command, so our PID is already the real process. (#3209)
+  void disposedBy(DisposeScope disposeScope, {Platform? platform}) {
+    final isWindows = (platform ?? const LocalPlatform()).isWindows;
+
+    disposeScope.addDispose(() async {
+      if (!isWindows) {
+        kill();
+        return;
+      }
+
+      // /F because gradlew.bat and friends ignore the graceful request.
+      // taskkill reports refusals (e.g. access denied) through its exit code
+      // rather than by throwing, so fall back on those too.
+      var killedTree = false;
+      try {
+        final result = await Process.run('taskkill', [
+          ...['/PID', '$pid'],
+          '/T',
+          '/F',
+        ]);
+        killedTree = result.exitCode == 0;
+      } catch (_) {}
+
+      if (!killedTree) {
+        kill();
+      }
+    });
   }
 }
 

--- a/packages/patrol_cli/lib/src/base/process.dart
+++ b/packages/patrol_cli/lib/src/base/process.dart
@@ -97,41 +97,45 @@ extension ProcessListeners on Process {
   }
 }
 
-extension ProcessDisposers on Process {
-  void disposed(DisposeScope disposeScope) {
-    disposeScope.addDispose(kill);
-  }
-}
-
-/// Shadows `dispose_scope`'s `ProcessDisposed.disposedBy`, which kills only the
-/// process itself. Import `dispose_scope` with `hide ProcessDisposed` to use it.
+/// Import `dispose_scope` with `hide ProcessDisposed`, so that a `Process`
+/// cannot be registered with the single-process `disposedBy` by accident.
 extension ProcessTreeDisposers on Process {
   /// Adds this process to [disposeScope], to be killed together with any
   /// processes it spawned.
   ///
-  /// On Windows `runInShell: true` means `cmd.exe /c <command>`, so killing the
-  /// process we hold orphans the rest of the tree instead of ending it. There
-  /// are no process groups to signal, hence `taskkill /T`. Elsewhere `sh -c`
-  /// execs into the command, so our PID is already the real process. (#3209)
-  void disposedBy(DisposeScope disposeScope, {Platform? platform}) {
-    final isWindows = (platform ?? const LocalPlatform()).isWindows;
+  /// The process we hold is often a wrapper - `cmd.exe /c` on Windows, `fvm` or
+  /// a `flutter` shell script elsewhere - and its children outlive it. There is
+  /// no process group to signal, so the descendants have to be named: `taskkill
+  /// /T` walks them on Windows, `pgrep -P` elsewhere.
+  void disposedByTree(DisposeScope disposeScope) {
+    var exited = false;
+    unawaited(exitCode.then((_) => exited = true));
 
     disposeScope.addDispose(() async {
-      if (!isWindows) {
+      // A dead PID may already belong to another process; taskkill would
+      // escalate that into killing an unrelated tree.
+      if (exited) {
+        return;
+      }
+
+      if (!const LocalPlatform().isWindows) {
+        // Collected before anything dies; once the parent is gone its children
+        // are reparented and `pgrep -P` no longer reports them.
+        (await _descendants(pid)).forEach(Process.killPid);
         kill();
         return;
       }
 
       // /F because gradlew.bat and friends ignore the graceful request.
-      // taskkill reports refusals (e.g. access denied) through its exit code
-      // rather than by throwing, so fall back on those too.
+      // taskkill reports refusals (e.g. access denied) through its exit code,
+      // so fall back on those too.
       var killedTree = false;
       try {
         final result = await Process.run('taskkill', [
           ...['/PID', '$pid'],
           '/T',
           '/F',
-        ]);
+        ]).timeout(const Duration(seconds: 10));
         killedTree = result.exitCode == 0;
       } catch (_) {}
 
@@ -140,6 +144,35 @@ extension ProcessTreeDisposers on Process {
       }
     });
   }
+}
+
+/// PIDs spawned below [pid], deepest first.
+Future<List<int>> _descendants(int pid) async {
+  final found = <int>[];
+  final pending = <int>[pid];
+
+  while (pending.isNotEmpty) {
+    final parent = pending.removeLast();
+    final ProcessResult result;
+    try {
+      result = await Process.run('pgrep', [
+        ...['-P', '$parent'],
+      ]).timeout(const Duration(seconds: 5));
+    } catch (_) {
+      continue;
+    }
+    if (result.exitCode != 0) {
+      continue;
+    }
+
+    final children = LineSplitter.split(
+      result.stdout as String,
+    ).map((line) => int.tryParse(line.trim())).nonNulls;
+    found.addAll(children);
+    pending.addAll(children);
+  }
+
+  return found.reversed.toList();
 }
 
 extension ProcessResultX on ProcessResult {

--- a/packages/patrol_cli/lib/src/commands/develop_service.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_service.dart
@@ -419,7 +419,7 @@ class DevelopService {
     Future<void> Function() action;
     Future<void> Function()? finalizer;
 
-    // Ends what is still running on the device when the user quits. (#3209)
+    // Ends what is still running on the device when the user quits.
     Future<void> Function()? stopOnDevice;
     String? appId;
 
@@ -523,11 +523,14 @@ class DevelopService {
           openDevtools: openDevtools,
           attachUsingUrl: shouldAttachUsingUrl(device),
           forwardFlutterLogs: flutterLogs.forwardFlutterLogs,
-          // Stop the device side first, so the processes running the tests can
-          // finish on their own before the backend is torn down.
+          // Stop the device side first, so the Gradle process waiting on
+          // `am instrument` can end before the backend is torn down.
           onQuit: () async {
-            await onQuitCleanup();
-            await stopOnDevice?.call();
+            try {
+              await stopOnDevice?.call();
+            } finally {
+              await onQuitCleanup();
+            }
           },
         );
       }

--- a/packages/patrol_cli/lib/src/commands/develop_service.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_service.dart
@@ -418,6 +418,9 @@ class DevelopService {
   }) async {
     Future<void> Function() action;
     Future<void> Function()? finalizer;
+
+    // Ends what is still running on the device when the user quits. (#3209)
+    Future<void> Function()? stopOnDevice;
     String? appId;
 
     final flutterLogs = resolveFlutterLogs(
@@ -442,8 +445,12 @@ class DevelopService {
           videoConfig: videoConfig,
         );
         final package = android.packageName;
-        if (package != null && uninstall) {
-          finalizer = () => _androidTestBackend.uninstall(package, device);
+        if (package != null) {
+          stopOnDevice = () =>
+              _androidTestBackend.stopInstrumentation(package, device);
+          if (uninstall) {
+            finalizer = () => _androidTestBackend.uninstall(package, device);
+          }
         }
       case TargetPlatform.macOS:
         appId = macos.bundleId;
@@ -516,7 +523,12 @@ class DevelopService {
           openDevtools: openDevtools,
           attachUsingUrl: shouldAttachUsingUrl(device),
           forwardFlutterLogs: flutterLogs.forwardFlutterLogs,
-          onQuit: onQuitCleanup,
+          // Stop the device side first, so the processes running the tests can
+          // finish on their own before the backend is torn down.
+          onQuit: () async {
+            await onQuitCleanup();
+            await stopOnDevice?.call();
+          },
         );
       }
 

--- a/packages/patrol_cli/lib/src/compatibility_checker/compatibility_checker.dart
+++ b/packages/patrol_cli/lib/src/compatibility_checker/compatibility_checker.dart
@@ -87,7 +87,7 @@ Check the compatibility table at: https://patrol.leancode.co/documentation/compa
               workingDirectory: _projectRoot.path,
               runInShell: true,
             )
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
 
       process
           .listenStdOut(
@@ -182,7 +182,7 @@ Future<void> _checkJavaVersion(
             workingDirectory: projectRoot.path,
             runInShell: true,
           )
-          ..disposedBy(scope);
+          ..disposedByTree(scope);
 
     processFlutter
         .listenStdOut(
@@ -200,7 +200,7 @@ Future<void> _checkJavaVersion(
                       workingDirectory: projectRoot.path,
                       runInShell: true,
                     )
-                    ..disposedBy(scope);
+                    ..disposedByTree(scope);
 
               processJava
                   .listenStdOut(

--- a/packages/patrol_cli/lib/src/compatibility_checker/compatibility_checker.dart
+++ b/packages/patrol_cli/lib/src/compatibility_checker/compatibility_checker.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:dispose_scope/dispose_scope.dart';
+import 'package:dispose_scope/dispose_scope.dart' hide ProcessDisposed;
 import 'package:file/file.dart';
 import 'package:patrol_cli/src/base/constants.dart' as constants;
 import 'package:patrol_cli/src/base/exceptions.dart';

--- a/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
+++ b/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
@@ -4,10 +4,11 @@ import 'dart:io' as io;
 
 import 'package:adb/adb.dart';
 import 'package:coverage/coverage.dart' as coverage;
-import 'package:dispose_scope/dispose_scope.dart';
+import 'package:dispose_scope/dispose_scope.dart' hide ProcessDisposed;
 import 'package:file/file.dart';
 import 'package:glob/glob.dart';
 import 'package:patrol_cli/src/base/logger.dart';
+import 'package:patrol_cli/src/base/process.dart';
 import 'package:patrol_cli/src/coverage/coverage_common.dart';
 import 'package:patrol_cli/src/coverage/device_to_host_port_transformer.dart';
 import 'package:patrol_cli/src/coverage/vm_connection_details.dart';

--- a/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
+++ b/packages/patrol_cli/lib/src/coverage/coverage_tool.dart
@@ -81,7 +81,7 @@ class CoverageTool {
               workingDirectory: homeDirectory,
               runInShell: true,
             )
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
 
       final vmConnectionDetailsStream = logsProcess.stdout
           .transform(utf8.decoder)

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:io' as io;
 import 'dart:io' show exit;
 
-import 'package:dispose_scope/dispose_scope.dart';
+import 'package:dispose_scope/dispose_scope.dart' hide ProcessDisposed;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' show basename;
 import 'package:patrol_cli/src/base/logger.dart';

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -62,14 +62,17 @@ class FlutterTool {
     }
 
     Future<void> onQuitWithRevertInteractiveMode() async {
-      try {
-        if (previousStdinModes != null) {
+      if (previousStdinModes != null) {
+        try {
           revertInteractiveMode(previousStdinModes);
+        } catch (err) {
+          // The terminal outlives us; failing to restore it must not stop the
+          // cleanup below, nor be reported as the cleanup failing.
+          _logger.detail('Could not restore the terminal: $err');
         }
-      } finally {
-        if (onQuit != null) {
-          await onQuit();
-        }
+      }
+      if (onQuit != null) {
+        await onQuit();
       }
     }
 

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -62,11 +62,14 @@ class FlutterTool {
     }
 
     Future<void> onQuitWithRevertInteractiveMode() async {
-      if (previousStdinModes != null) {
-        revertInteractiveMode(previousStdinModes);
-      }
-      if (onQuit != null) {
-        await onQuit();
+      try {
+        if (previousStdinModes != null) {
+          revertInteractiveMode(previousStdinModes);
+        }
+      } finally {
+        if (onQuit != null) {
+          await onQuit();
+        }
       }
     }
 
@@ -138,7 +141,7 @@ class FlutterTool {
                 '${dartDefine.key}=${dartDefine.value}',
               ],
             ])
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
 
       final completer = Completer<void>();
       scope.addDispose(() {
@@ -178,7 +181,6 @@ class FlutterTool {
               _logger.success(helpText.toString());
             } else if (char == 'q' || char == 'Q') {
               _logger.success('Quitting process...');
-              process.kill();
               if (!completer.isCompleted) {
                 completer.complete();
               }
@@ -268,7 +270,7 @@ class FlutterTool {
               '--device-id',
               deviceId,
             ], runInShell: true)
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
 
       final completer = Completer<void>();
       scope.addDispose(() {
@@ -343,8 +345,9 @@ class FlutterTool {
   }
 
   void revertInteractiveMode(StdinModes stdinModes) {
-    io.stdin.echoMode = stdinModes.echoMode;
+    // Windows allows setting echoMode only while lineMode is enabled.
     io.stdin.lineMode = stdinModes.lineMode;
+    io.stdin.echoMode = stdinModes.echoMode;
 
     _logger.detail('Interactive shell mode disabled.');
   }

--- a/packages/patrol_cli/lib/src/crossplatform/test_manifest_generator.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/test_manifest_generator.dart
@@ -56,7 +56,7 @@ class TestManifestGenerator {
             runInShell: true,
             workingDirectory: _rootDirectory.path,
           )
-          ..disposedBy(scope);
+          ..disposedByTree(scope);
     process.listenStdOut((l) => _logger.detail('\t$l')).disposedBy(scope);
     process.listenStdErr((l) => _logger.detail('\t$l')).disposedBy(scope);
     final exitCode = await process.exitCode;

--- a/packages/patrol_cli/lib/src/crossplatform/test_manifest_generator.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/test_manifest_generator.dart
@@ -1,4 +1,4 @@
-import 'package:dispose_scope/dispose_scope.dart';
+import 'package:dispose_scope/dispose_scope.dart' hide ProcessDisposed;
 import 'package:file/file.dart';
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/base/process.dart';

--- a/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
+++ b/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
@@ -163,7 +163,7 @@ class IOSTestBackend {
               runInShell: true,
               workingDirectory: _rootDirectory.childDirectory('ios').path,
             )
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
       process.listenStdOut((l) => _logger.detail('\t$l')).disposedBy(scope);
       process.listenStdErr((l) => _logger.err('\t$l')).disposedBy(scope);
       exitCode = await process.exitCode;
@@ -339,7 +339,7 @@ class IOSTestBackend {
       // Read patrol logs from log stream
       final processLogs =
           await _processManager.start(patrolLogCommand, runInShell: true)
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
 
       final reportPath = resultBundlePath(
         timestamp: DateTime.now().millisecondsSinceEpoch,
@@ -387,7 +387,7 @@ class IOSTestBackend {
               },
               workingDirectory: _rootDirectory.childDirectory('ios').path,
             )
-            ..disposedBy(_disposeScope);
+            ..disposedByTree(_disposeScope);
       process.listenStdOut((l) => _logger.detail('\t$l')).disposedBy(scope);
       process.listenStdErr((l) => _logger.detail('\t$l')).disposedBy(scope);
 

--- a/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
+++ b/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:io' show Process;
 
-import 'package:dispose_scope/dispose_scope.dart';
+import 'package:dispose_scope/dispose_scope.dart' hide ProcessDisposed;
 import 'package:file/file.dart';
 import 'package:glob/glob.dart';
 import 'package:meta/meta.dart';

--- a/packages/patrol_cli/lib/src/ios/ios_video_recording_manager.dart
+++ b/packages/patrol_cli/lib/src/ios/ios_video_recording_manager.dart
@@ -122,7 +122,7 @@ class IOSVideoRecordingManager extends VideoRecordingManager {
     try {
       // No shell: the stop SIGINT must reach `simctl` directly, not a wrapper.
       _currentRecordingProcess = await _processManager.start(command);
-      _currentRecordingProcess!.disposedBy(_scope);
+      _currentRecordingProcess!.disposedByTree(_scope);
 
       // Listen to stderr for any errors
       _currentRecordingProcess!.stderr.listen((data) {

--- a/packages/patrol_cli/lib/src/ios/ios_video_recording_manager.dart
+++ b/packages/patrol_cli/lib/src/ios/ios_video_recording_manager.dart
@@ -1,8 +1,9 @@
 import 'dart:io' as io;
 
-import 'package:dispose_scope/dispose_scope.dart';
+import 'package:dispose_scope/dispose_scope.dart' hide ProcessDisposed;
 import 'package:file/file.dart';
 import 'package:patrol_cli/src/base/logger.dart';
+import 'package:patrol_cli/src/base/process.dart';
 import 'package:patrol_cli/src/crossplatform/video_recording_config.dart';
 import 'package:patrol_cli/src/crossplatform/video_recording_manager.dart';
 import 'package:patrol_cli/src/devices.dart';

--- a/packages/patrol_cli/lib/src/macos/macos_test_backend.dart
+++ b/packages/patrol_cli/lib/src/macos/macos_test_backend.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show Process;
 
-import 'package:dispose_scope/dispose_scope.dart';
+import 'package:dispose_scope/dispose_scope.dart' hide ProcessDisposed;
 import 'package:file/file.dart';
 import 'package:glob/glob.dart';
 import 'package:path/path.dart' show join;

--- a/packages/patrol_cli/lib/src/macos/macos_test_backend.dart
+++ b/packages/patrol_cli/lib/src/macos/macos_test_backend.dart
@@ -120,7 +120,7 @@ class MacOSTestBackend {
               runInShell: true,
               workingDirectory: _rootDirectory.childDirectory('macos').path,
             )
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
       process.listenStdOut((l) => _logger.detail('\t$l')).disposedBy(scope);
       process.listenStdErr((l) => _logger.err('\t$l')).disposedBy(scope);
       exitCode = await process.exitCode;
@@ -177,7 +177,7 @@ class MacOSTestBackend {
               },
               workingDirectory: _rootDirectory.childDirectory('macos').path,
             )
-            ..disposedBy(_disposeScope);
+            ..disposedByTree(_disposeScope);
       process.listenStdOut((l) => _logger.detail('\t$l')).disposedBy(scope);
       process.listenStdErr((l) => _logger.err('\t$l')).disposedBy(scope);
 

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -214,9 +214,8 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
           platform: _platform,
           parentDisposeScope: _disposeScope,
           logger: _logger,
-          // Without this, "q" falls back to a bare exit(0) and we terminate
-          // before the dispose scope runs, leaving the Gradle and logcat
-          // processes behind. (#3209)
+          // The dispose scope has to run before the process exits, so the
+          // processes it started die with it.
           onExit: () async {
             await dispose();
             exit(0);

--- a/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command_runner.dart
@@ -1,5 +1,5 @@
 import 'dart:io' as p show Platform;
-import 'dart:io' show ProcessSignal, stdin;
+import 'dart:io' show ProcessSignal, exit, stdin;
 
 import 'package:adb/adb.dart';
 import 'package:args/args.dart';
@@ -214,6 +214,13 @@ class PatrolCommandRunner extends CompletionCommandRunner<int> {
           platform: _platform,
           parentDisposeScope: _disposeScope,
           logger: _logger,
+          // Without this, "q" falls back to a bare exit(0) and we terminate
+          // before the dispose scope runs, leaving the Gradle and logcat
+          // processes behind. (#3209)
+          onExit: () async {
+            await dispose();
+            exit(0);
+          },
         ),
         androidTestBackend: androidTestBackend,
         iosTestBackend: iosTestBackend,

--- a/packages/patrol_cli/lib/src/web/web_test_backend.dart
+++ b/packages/patrol_cli/lib/src/web/web_test_backend.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:io' as io;
 import 'dart:io';
 
-import 'package:dispose_scope/dispose_scope.dart';
+import 'package:dispose_scope/dispose_scope.dart' hide ProcessDisposed;
 import 'package:package_config/package_config.dart';
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/base/process.dart';

--- a/packages/patrol_cli/lib/src/web/web_test_backend.dart
+++ b/packages/patrol_cli/lib/src/web/web_test_backend.dart
@@ -458,7 +458,7 @@ class WebTestBackend {
               },
               runInShell: true,
             )
-            ..disposedBy(scope);
+            ..disposedByTree(scope);
 
       final isShardedRun = (options.workers ?? 0) > 1;
       if (isShardedRun) {

--- a/packages/patrol_cli/test/base/process_test.dart
+++ b/packages/patrol_cli/test/base/process_test.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dispose_scope/dispose_scope.dart' hide ProcessDisposed;
+import 'package:patrol_cli/src/base/process.dart';
+import 'package:test/test.dart';
+
+/// Starts a process that stays alive until killed. On Windows that is
+/// `cmd.exe` with `ping` as a child - the shape of every `runInShell: true`
+/// process patrol starts.
+Future<Process> _startSleeper() {
+  if (Platform.isWindows) {
+    return Process.start('cmd.exe', ['/c', 'ping -n 120 127.0.0.1']);
+  }
+  return Process.start('sh', ['-c', 'sleep 120']);
+}
+
+Future<List<int>> _pidsFrom(String powershellCommand) async {
+  final result = await Process.run('powershell.exe', [
+    '-NoProfile',
+    '-Command',
+    powershellCommand,
+  ]);
+
+  return LineSplitter.split(
+    result.stdout as String,
+  ).map((line) => int.tryParse(line.trim())).nonNulls.toList();
+}
+
+/// PIDs of the processes [pid] spawned, as reported by the OS.
+Future<List<int>> _childrenOf(int pid) {
+  const select = '| Select-Object -ExpandProperty ProcessId';
+  return _pidsFrom(
+    'Get-CimInstance Win32_Process -Filter "ParentProcessId = $pid" $select',
+  );
+}
+
+Future<bool> _isAlive(int pid) async {
+  const select = '| Select-Object -ExpandProperty Id';
+  final alive = await _pidsFrom(
+    'Get-Process -Id $pid -ErrorAction SilentlyContinue $select',
+  );
+
+  return alive.contains(pid);
+}
+
+void main() {
+  group('disposedBy', () {
+    test('kills the process when the scope is disposed', () async {
+      final scope = DisposeScope();
+      final process = await _startSleeper();
+      addTearDown(process.kill);
+
+      process.disposedBy(scope);
+      await scope.dispose();
+
+      await expectLater(process.exitCode, completes);
+    });
+
+    test(
+      'kills the processes that the process spawned',
+      () async {
+        final scope = DisposeScope();
+        final process = await _startSleeper();
+        addTearDown(process.kill);
+        process.disposedBy(scope);
+
+        // cmd.exe needs a moment before its child shows up in the process list.
+        var children = <int>[];
+        for (var i = 0; i < 50 && children.isEmpty; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          children = await _childrenOf(process.pid);
+        }
+        expect(
+          children,
+          isNotEmpty,
+          reason: 'no child was spawned, so this proves nothing',
+        );
+
+        await scope.dispose();
+
+        for (final child in children) {
+          expect(
+            await _isAlive(child),
+            isFalse,
+            reason: 'child $child is still running (#3209)',
+          );
+        }
+      },
+      skip: Platform.isWindows
+          ? null
+          : 'elsewhere `sh -c` execs, so there is no child to leak',
+    );
+  });
+}

--- a/packages/patrol_cli/test/base/process_test.dart
+++ b/packages/patrol_cli/test/base/process_test.dart
@@ -5,22 +5,17 @@ import 'package:dispose_scope/dispose_scope.dart' hide ProcessDisposed;
 import 'package:patrol_cli/src/base/process.dart';
 import 'package:test/test.dart';
 
-/// Starts a process that stays alive until killed. On Windows that is
-/// `cmd.exe` with `ping` as a child - the shape of every `runInShell: true`
-/// process patrol starts.
+/// Starts a process that stays alive until killed and keeps a child of its own -
+/// the shape of every wrapped process patrol starts (`cmd.exe /c`, `fvm`).
 Future<Process> _startSleeper() {
   if (Platform.isWindows) {
     return Process.start('cmd.exe', ['/c', 'ping -n 120 127.0.0.1']);
   }
-  return Process.start('sh', ['-c', 'sleep 120']);
+  return Process.start('sh', ['-c', 'sleep 120 & wait']);
 }
 
-Future<List<int>> _pidsFrom(String powershellCommand) async {
-  final result = await Process.run('powershell.exe', [
-    '-NoProfile',
-    '-Command',
-    powershellCommand,
-  ]);
+Future<List<int>> _pidsFrom(String executable, List<String> arguments) async {
+  final result = await Process.run(executable, arguments);
 
   return LineSplitter.split(
     result.stdout as String,
@@ -29,67 +24,86 @@ Future<List<int>> _pidsFrom(String powershellCommand) async {
 
 /// PIDs of the processes [pid] spawned, as reported by the OS.
 Future<List<int>> _childrenOf(int pid) {
-  const select = '| Select-Object -ExpandProperty ProcessId';
-  return _pidsFrom(
-    'Get-CimInstance Win32_Process -Filter "ParentProcessId = $pid" $select',
-  );
+  if (!Platform.isWindows) {
+    return _pidsFrom('pgrep', ['-P', '$pid']);
+  }
+  final command =
+      'Get-CimInstance Win32_Process -Filter "ParentProcessId = $pid"'
+      ' | Select-Object -ExpandProperty ProcessId';
+
+  return _pidsFrom('powershell.exe', ['-NoProfile', '-Command', command]);
 }
 
 Future<bool> _isAlive(int pid) async {
-  const select = '| Select-Object -ExpandProperty Id';
-  final alive = await _pidsFrom(
-    'Get-Process -Id $pid -ErrorAction SilentlyContinue $select',
-  );
+  if (!Platform.isWindows) {
+    final result = await Process.run('kill', ['-0', '$pid']);
+    return result.exitCode == 0;
+  }
+  final command =
+      'Get-Process -Id $pid -ErrorAction SilentlyContinue'
+      ' | Select-Object -ExpandProperty Id';
+  final alive = await _pidsFrom('powershell.exe', [
+    '-NoProfile',
+    '-Command',
+    command,
+  ]);
 
   return alive.contains(pid);
 }
 
 void main() {
-  group('disposedBy', () {
+  group('disposedByTree', () {
     test('kills the process when the scope is disposed', () async {
       final scope = DisposeScope();
       final process = await _startSleeper();
       addTearDown(process.kill);
 
-      process.disposedBy(scope);
+      process.disposedByTree(scope);
       await scope.dispose();
 
       await expectLater(process.exitCode, completes);
     });
 
-    test(
-      'kills the processes that the process spawned',
-      () async {
-        final scope = DisposeScope();
-        final process = await _startSleeper();
-        addTearDown(process.kill);
-        process.disposedBy(scope);
+    test('does nothing when the process has already exited', () async {
+      final scope = DisposeScope();
+      final process = Platform.isWindows
+          ? await Process.start('cmd.exe', ['/c', 'exit 0'])
+          : await Process.start('sh', ['-c', 'true']);
 
-        // cmd.exe needs a moment before its child shows up in the process list.
-        var children = <int>[];
-        for (var i = 0; i < 50 && children.isEmpty; i++) {
-          await Future<void>.delayed(const Duration(milliseconds: 100));
-          children = await _childrenOf(process.pid);
-        }
+      final exitCode = process.exitCode;
+      process.disposedByTree(scope);
+
+      await expectLater(exitCode, completes);
+      await expectLater(scope.dispose(), completes);
+    });
+
+    test('kills the processes that the process spawned', () async {
+      final scope = DisposeScope();
+      final process = await _startSleeper();
+      addTearDown(process.kill);
+      process.disposedByTree(scope);
+
+      // The shell needs a moment before its child shows up in the process list.
+      var children = <int>[];
+      for (var i = 0; i < 50 && children.isEmpty; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        children = await _childrenOf(process.pid);
+      }
+      expect(
+        children,
+        isNotEmpty,
+        reason: 'no child was spawned, so this proves nothing',
+      );
+
+      await scope.dispose();
+
+      for (final child in children) {
         expect(
-          children,
-          isNotEmpty,
-          reason: 'no child was spawned, so this proves nothing',
+          await _isAlive(child),
+          isFalse,
+          reason: 'child $child is still running',
         );
-
-        await scope.dispose();
-
-        for (final child in children) {
-          expect(
-            await _isAlive(child),
-            isFalse,
-            reason: 'child $child is still running (#3209)',
-          );
-        }
-      },
-      skip: Platform.isWindows
-          ? null
-          : 'elsewhere `sh -c` execs, so there is no child to leak',
-    );
+      }
+    });
   });
 }

--- a/packages/patrol_cli/test/commands/develop_service_test.dart
+++ b/packages/patrol_cli/test/commands/develop_service_test.dart
@@ -277,8 +277,6 @@ void main() {
     test(
       'stops the app and its instrumentation on the device on quit',
       () async {
-        // Otherwise the process Gradle spawned to drive the instrumentation
-        // keeps running and holds onto the test results directory. (#3209)
         final backendNeverExits = Completer<void>();
         when(
           () => androidTestBackend.execute(

--- a/packages/patrol_cli/test/commands/develop_service_test.dart
+++ b/packages/patrol_cli/test/commands/develop_service_test.dart
@@ -274,6 +274,80 @@ void main() {
       },
     );
 
+    test(
+      'stops the app and its instrumentation on the device on quit',
+      () async {
+        // Otherwise the process Gradle spawned to drive the instrumentation
+        // keeps running and holds onto the test results directory. (#3209)
+        final backendNeverExits = Completer<void>();
+        when(
+          () => androidTestBackend.execute(
+            any(),
+            any(),
+            interruptible: any(named: 'interruptible'),
+            showFlutterLogs: any(named: 'showFlutterLogs'),
+            hideTestSteps: any(named: 'hideTestSteps'),
+            flavor: any(named: 'flavor'),
+            clearTestSteps: any(named: 'clearTestSteps'),
+            onLogEntry: any(named: 'onLogEntry'),
+            videoConfig: any(named: 'videoConfig'),
+          ),
+        ).thenAnswer((_) => backendNeverExits.future);
+
+        when(
+          () => androidTestBackend.stopInstrumentation(any(), any()),
+        ).thenAnswer((_) async {});
+
+        // onQuit is what pressing "q" ends up running.
+        Future<void> Function()? onQuit;
+        final attachNeverCompletes = Completer<void>();
+        when(
+          () => flutterTool.attachForHotRestart(
+            flutterCommand: any(named: 'flutterCommand'),
+            deviceId: any(named: 'deviceId'),
+            target: any(named: 'target'),
+            appId: any(named: 'appId'),
+            dartDefines: any(named: 'dartDefines'),
+            openDevtools: any(named: 'openDevtools'),
+            attachUsingUrl: any(named: 'attachUsingUrl'),
+            forwardFlutterLogs: any(named: 'forwardFlutterLogs'),
+            onQuit: any(named: 'onQuit'),
+          ),
+        ).thenAnswer((invocation) {
+          onQuit =
+              invocation.namedArguments[const Symbol('onQuit')]
+                  as Future<void> Function()?;
+          return attachNeverCompletes.future;
+        });
+
+        unawaited(
+          buildService().run(
+            const DevelopOptions(
+              target: 'onboarding_test.dart',
+              flutterCommand: FlutterCommand('flutter'),
+              buildMode: BuildMode.debug,
+              testServerPort: 8081,
+              appServerPort: 8080,
+              generateBundle: false,
+              uninstall: false,
+              checkCompatibility: false,
+              packageName: 'com.example.app',
+            ),
+          ),
+        );
+
+        await _waitFor(() => onQuit != null);
+        await onQuit!();
+
+        verify(
+          () => androidTestBackend.stopInstrumentation(
+            'com.example.app',
+            androidDevice,
+          ),
+        ).called(1);
+      },
+    );
+
     group('iOS logs', () {
       /// Runs a develop session on [iosDevice] and reports where the app's
       /// logs were routed. The simulator keeps `flutter logs` whatever the

--- a/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
@@ -40,6 +40,7 @@ void main() {
       when(
         () => process.stderr,
       ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
+      when(() => process.exitCode).thenAnswer((_) => Completer<int>().future);
       when(() => processManager.start(any())).thenAnswer((_) async => process);
 
       flutterTool.attach(
@@ -64,6 +65,7 @@ void main() {
       when(
         () => process.stderr,
       ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
+      when(() => process.exitCode).thenAnswer((_) => Completer<int>().future);
       when(() => processManager.start(any())).thenAnswer((_) async => process);
 
       flutterTool.attach(


### PR DESCRIPTION
Press `q` in `patrol develop` and the session goes away, but its processes don't. On Windows you find out the hard way: the next run fails on `:app:connectedAndroidTest`, because something is still holding `utp.0.log.lck`.

Left running on macOS after quitting, both reparented to init:

```
dartvm ... flutter_tools.snapshot attach --device-id emulator-5554 ...
adb -s emulator-5554 shell -x logcat -v time
```

**Problem**
- `q` exited the process before the dispose scope ran, so nothing was cleaned up, on any platform.
- On Windows it stopped even earlier, on the failed terminal restore that #3209 notes in step 6 and sets aside. That failure is what aborts the cleanup.
- Disposal ended only the process patrol holds. Its tools run behind wrappers (`cmd.exe /c`, the `fvm` and `flutter` scripts), so the real tool and the log readers stayed behind.
- Nothing stopped the instrumentation on the device, and the process holding the lock waits for it. Develop keeps it alive on purpose for Hot Restart.

**Change**
- `q` routes through the dispose scope (`onExit` from `patrol_command_runner`), and a failed terminal restore is logged instead of aborting it. Line mode is restored before echo mode, the order Windows accepts.
- `disposedByTree` ends the whole tree: `taskkill /T /F` on Windows, a `pgrep -P` walk elsewhere, collected before anything dies. Already-exited processes are skipped, so a reused PID can't be hit.
- `stopInstrumentation` force-stops the app and its test package, resolving a custom `testApplicationId`. The `adb` and `taskkill` calls are bounded, so `q` can't hang on an unresponsive device.
- Renamed from `disposedBy` at every `Process` call site; `dispose_scope` stays imported with `hide ProcessDisposed`, so the single-process version can't be reached by accident.

Windows-specific: the `taskkill` branch and the stdin mode order. The rest fixed the same leak on macOS.

**Verification**
- `develop` then `q` against an Android emulator, processes watched for 20s: Windows 10 had six survivors before and none after, macOS two before and none after.
- 422 unit tests pass on Windows and macOS. The tree-kill test in `process_test.dart` used to be skipped off Windows and runs on both now.
- Not covered: Linux past the unit tests, the timeout paths, and the iOS/macOS/web backends, which only see the rename. MCP sessions quit through the same handler, so they get this too.

Fixes #3209.
