### PR TITLE
Hotfix/build ios xctestrun search not respecting current dir

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - Add `screenshot_on_failure` option to the pubspec's `patrol` section, forwarded to the app (via a dart-define) for `build` and `test` so patrol can capture native failure screenshots on Android device farms (e.g. BrowserStack, Firebase Test Lab). Not collected by `patrol develop`. Off by default. (#3222)
 - `patrol test` (Android) now pulls native screenshots (failure and on-demand) from the device into `<test-directory>/screenshots` after the run (override with `--screenshots-output-dir`), so they are available from local/emulator runs, not only device farms. (#3222)
-- Allow the latest `package_config` (3.x), `cli_completion` (0.6.x) and `pub_updater` (0.6.x), without raising the minimum Dart SDK.
+- Allow the latest `package_config` (3.x), `cli_completion` (0.6.x) and `pub_updater` (0.6.x), without raising the minimum Dart SDK. (#3225)
+- Fix an issue when building iOS tests from different directory than project's root - we were looking in a wrong place for .xctestrun file. (#3250)
 
 ## 4.7.0
 

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -258,7 +258,7 @@ class BuildIOSCommand extends PatrolCommand {
       real: !simulator,
       scheme: scheme,
       sdkVersion: sdkVersion,
-      absolutePath: false,
+      absolutePath: true,
     );
 
     _logger.info('$xcTestRunPath (xctestrun file)');

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -258,7 +258,6 @@ class BuildIOSCommand extends PatrolCommand {
       real: !simulator,
       scheme: scheme,
       sdkVersion: sdkVersion,
-      absolutePath: true,
     );
 
     _logger.info('$xcTestRunPath (xctestrun file)');

--- a/packages/patrol_cli/test/commands/build_ios_command_test.dart
+++ b/packages/patrol_cli/test/commands/build_ios_command_test.dart
@@ -1,6 +1,8 @@
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
+import 'package:dispose_scope/dispose_scope.dart';
+import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' show join;
@@ -9,6 +11,8 @@ import 'package:patrol_cli/src/crossplatform/app_options.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
 import 'package:patrol_cli/src/pubspec_reader.dart';
 import 'package:patrol_cli/src/runner/flutter_command.dart';
+import 'package:platform/platform.dart';
+import 'package:process/process.dart';
 import 'package:test/test.dart';
 
 import '../src/mocks.dart';
@@ -40,7 +44,7 @@ void main() {
       PatrolPubspecConfig.empty(flutterPackageName: 'test_app'),
     );
     registerFallbackValue(MemoryFileSystem().file('test'));
-    registerFallbackValue(Directory.current);
+    registerFallbackValue(io.Directory.current);
   });
 
   group('BuildIOSCommand', () {
@@ -540,6 +544,85 @@ void main() {
 
         verify(() => mockLogger.err('Exception: $error')).called(1);
       });
+
+      group('when invoked from a directory inside the project', () {
+        late FileSystem fs;
+
+        setUp(() {
+          fs = MemoryFileSystem.test();
+          final projectRoot = fs.directory('/example_app')..createSync();
+          fs.currentDirectory = projectRoot.path;
+          fs
+              .file(
+                'build/ios_integ/Build/Products/Runner_iphoneos16.2.xctestrun',
+              )
+              .createSync(recursive: true);
+          fs
+              .file(
+                'build/ios_integ/Build/Products/Runner_iphonesimulator16.2.xctestrun',
+              )
+              .createSync(recursive: true);
+
+          command = BuildIOSCommand(
+            testFinderFactory: mockTestFinderFactory,
+            testBundler: mockTestBundler,
+            dartDefinesReader: mockDartDefinesReader,
+            pubspecReader: mockPubspecReader,
+            iosTestBackend: _NoopBuildIOSTestBackend(
+              processManager: _FakeProcessManager(),
+              platform: FakePlatform(),
+              fs: fs,
+              rootDirectory: projectRoot,
+              parentDisposeScope: DisposeScope(),
+              logger: mockLogger,
+            ),
+            analytics: mockAnalytics,
+            logger: mockLogger,
+            compatibilityChecker: mockCompatibilityChecker,
+          );
+        });
+
+        void cd(String relativePath) {
+          fs.directory(relativePath).createSync(recursive: true);
+          fs.currentDirectory = relativePath;
+        }
+
+        test('succeeds when invoked from ios/', () async {
+          cd('ios');
+
+          expect(await runCommand(), 0);
+
+          verify(
+            () => mockLogger.info(
+              '/example_app/build/ios_integ/Build/Products/Runner_iphoneos16.2.xctestrun (xctestrun file)',
+            ),
+          ).called(1);
+        });
+
+        test('succeeds when invoked from ios/Runner', () async {
+          cd('ios/Runner');
+
+          expect(await runCommand(), 0);
+
+          verify(
+            () => mockLogger.info(
+              '/example_app/build/ios_integ/Build/Products/Runner_iphoneos16.2.xctestrun (xctestrun file)',
+            ),
+          ).called(1);
+        });
+
+        test('succeeds when invoked from ios/ with --simulator', () async {
+          cd('ios');
+
+          expect(await runCommand(['--simulator']), 0);
+
+          verify(
+            () => mockLogger.info(
+              '/example_app/build/ios_integ/Build/Products/Runner_iphonesimulator16.2.xctestrun (xctestrun file)',
+            ),
+          ).called(1);
+        });
+      });
     });
 
     group('printBinaryPaths', () {
@@ -600,3 +683,24 @@ void main() {
     });
   });
 }
+
+/// Skips the real `xcodebuild`/`flutter build` so command tests can exercise
+/// xctestrun lookup (which depends on CWD vs project root).
+class _NoopBuildIOSTestBackend extends IOSTestBackend {
+  _NoopBuildIOSTestBackend({
+    required super.processManager,
+    required super.platform,
+    required super.fs,
+    required super.rootDirectory,
+    required super.parentDisposeScope,
+    required super.logger,
+  });
+
+  @override
+  Future<void> build(IOSAppOptions options) async {}
+
+  @override
+  Future<String> getSdkVersion({required bool real}) async => '16.2';
+}
+
+class _FakeProcessManager extends Fake implements ProcessManager {}

--- a/packages/patrol_cli/test/ios/ios_test_backend_test.dart
+++ b/packages/patrol_cli/test/ios/ios_test_backend_test.dart
@@ -174,6 +174,42 @@ void main() {
         scheme: 'dev',
         testPlan: 'SomeTestPlan',
       );
+
+      test(
+        'finds xctestrun with absolutePath when cwd is the ios directory',
+        () async {
+          const name = 'Runner_iphoneos16.2.xctestrun';
+          fs
+              .file('build/ios_integ/Build/Products/$name')
+              .createSync(recursive: true);
+          fs.directory('ios').createSync();
+          fs.currentDirectory = 'ios';
+
+          final found = await iosTestBackend.xcTestRunPath(
+            real: true,
+            scheme: 'Runner',
+            sdkVersion: '16.2',
+          );
+
+          expect(found, '/example_app/build/ios_integ/Build/Products/$name');
+        },
+      );
+
+      test('returns a CWD-relative path when absolutePath is false', () async {
+        const name = 'Runner_iphoneos16.2.xctestrun';
+        fs
+            .file('build/ios_integ/Build/Products/$name')
+            .createSync(recursive: true);
+
+        final found = await iosTestBackend.xcTestRunPath(
+          real: true,
+          scheme: 'Runner',
+          sdkVersion: '16.2',
+          absolutePath: false,
+        );
+
+        expect(found, 'build/ios_integ/Build/Products/$name');
+      });
     });
 
     group('stripFlavorFromAppId', () {


### PR DESCRIPTION
What was wrong:

When running `patrol build ios` from eg `ios` directory in the project, the tests built successfully, but at the very end patrol searches for xctestrun file in the build artifacts. It was looking for it under a wrong path - not using project's root but CWD instead as base path.