### PR TITLE
fix(patrol): Wait to restore original FlutterError.onError until teardown

### DIFF
--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix `Failure.details` being `null` for tests that fail due to an exception thrown after the test body finishes but before/during teardown (e.g. a widget's `dispose()` throwing). Patrol now keeps gathering exceptions until its own `tearDown()` callback has read the results. (#3252)
 - Add Korean (ko) language support for native OS interactions. Permission dialog strings were captured from a real Korean iOS 26 device; Android strings follow the official AOSP localizations (`values-ko`). (#2303)
 - Fix `pickImageFromGallery` on Android API 36: when the photo picker keeps the picker open after selecting a single image, tap the confirm button to finish. The tap is best-effort, so devices/emulators whose picker auto-confirms (no confirm button) keep working. The button label is resolved per device language (en/de/fr/pl/ja) so it works beyond English. (#3254)
 - Android: keep third-party `AccessibilityService`s running during the test session again. `AndroidAutomatorConfig.dontSuppressAccessibilityServices` now defaults to `true` (it was effectively `false` since 4.8.0) and is configurable, also via the `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` dart-define. (#3227)

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -59,61 +59,78 @@ class PatrolBinding extends LiveTestWidgetsFlutterBinding {
     });
 
     tearDown(() async {
-      if (_isDevelopMode) {
-        // Sending results ends the test, which we don't want for Hot Restart
-        return;
-      }
-
-      final testName = global_state.currentTestIndividualName;
-      if (testName == 'patrol_test_explorer') {
-        return;
-      } else {
-        logger(
-          'tearDown(): count: ${_testResults.length}, results: $_testResults',
-        );
-      }
-
-      final nameOfRequestedTest = await patrolAppService.testExecutionRequested;
-
-      if (nameOfRequestedTest == _currentDartTest) {
-        if (const bool.fromEnvironment('COVERAGE_ENABLED')) {
-          postEvent('waitForCoverageCollection', {
-            'mainIsolateId': Service.getIsolateId(Isolate.current),
-          });
-
-          final testCompleter = Completer<void>();
-
-          registerExtension('ext.patrol.markTestCompleted', (
-            method,
-            parameters,
-          ) async {
-            testCompleter.complete();
-            return ServiceExtensionResponse.result(jsonEncode({}));
-          });
-
-          await testCompleter.future;
+      // _wrapTestBodyWithExceptionGatherer() intentionally leaves its
+      // FlutterError.onError override installed past the end of the test
+      // body: errors can still be reported asynchronously while the test
+      // framework tears down the widget tree (e.g. a widget's dispose()
+      // throwing, or an unmanaged RestorationBucket assertion firing once
+      // its owner is unmounted). package:test's own LiveTest result already
+      // reflects such late errors (see global_state.isCurrentTestPassing
+      // below), but until this callback runs, Patrol's _testResults map -
+      // used only to produce a human-readable `details` message - would
+      // have missed them, silently reporting `details: null` for a test
+      // that (correctly) failed. So we only stop gathering exceptions once
+      // we're done reading _testResults, right before returning.
+      try {
+        if (_isDevelopMode) {
+          // Sending results ends the test, which we don't want for Hot Restart
+          return;
         }
 
-        logger(
-          'finished test $_currentDartTest. Will report its status back to the native side',
-        );
+        final testName = global_state.currentTestIndividualName;
+        if (testName == 'patrol_test_explorer') {
+          return;
+        } else {
+          logger(
+            'tearDown(): count: ${_testResults.length}, results: $_testResults',
+          );
+        }
 
-        final passed = global_state.isCurrentTestPassing;
-        logger(
-          'tearDown(): test "$testName" in group "$_currentDartTest", passed: $passed',
-        );
+        final nameOfRequestedTest =
+            await patrolAppService.testExecutionRequested;
 
-        await patrolAppService.markDartTestAsCompleted(
-          dartFileName: _currentDartTest!,
-          passed: passed,
-          details: _testResults[_currentDartTest!] is Failure
-              ? (_testResults[_currentDartTest!] as Failure?)?.details
-              : null,
-        );
-      } else {
-        logger(
-          'finished test $_currentDartTest, but it was not requested, so its status will not be reported back to the native side',
-        );
+        if (nameOfRequestedTest == _currentDartTest) {
+          if (const bool.fromEnvironment('COVERAGE_ENABLED')) {
+            postEvent('waitForCoverageCollection', {
+              'mainIsolateId': Service.getIsolateId(Isolate.current),
+            });
+
+            final testCompleter = Completer<void>();
+
+            registerExtension('ext.patrol.markTestCompleted', (
+              method,
+              parameters,
+            ) async {
+              testCompleter.complete();
+              return ServiceExtensionResponse.result(jsonEncode({}));
+            });
+
+            await testCompleter.future;
+          }
+
+          logger(
+            'finished test $_currentDartTest. Will report its status back to the native side',
+          );
+
+          final passed = global_state.isCurrentTestPassing;
+          logger(
+            'tearDown(): test "$testName" in group "$_currentDartTest", passed: $passed',
+          );
+
+          await patrolAppService.markDartTestAsCompleted(
+            dartFileName: _currentDartTest!,
+            passed: passed,
+            details: _testResults[_currentDartTest!] is Failure
+                ? (_testResults[_currentDartTest!] as Failure?)?.details
+                : null,
+          );
+        } else {
+          logger(
+            'finished test $_currentDartTest, but it was not requested, so its status will not be reported back to the native side',
+          );
+        }
+      } finally {
+        _stopGatheringExceptions();
       }
     });
   }
@@ -154,6 +171,13 @@ class PatrolBinding extends LiveTestWidgetsFlutterBinding {
   /// Keys are the test descriptions, and values are either [_success] or a
   /// [Failure].
   final _testResults = <String, Object>{};
+
+  /// Restores whatever [FlutterError.onError] handler was installed before
+  /// [_wrapTestBodyWithExceptionGatherer] ran for the current test.
+  ///
+  /// Defaults to a no-op because in Hot Restart / develop mode
+  /// [_wrapTestBodyWithExceptionGatherer] is never invoked (see [runTest]).
+  void Function() _stopGatheringExceptions = () {};
 
   final DevtoolsServiceExtensions _serviceExtensions;
 
@@ -220,6 +244,12 @@ class PatrolBinding extends LiveTestWidgetsFlutterBinding {
 
   /// Wraps the test body with a function that gathers exceptions and reports
   /// them to the native side of Patrol.
+  ///
+  /// The installed [FlutterError.onError] override is deliberately *not*
+  /// restored when [testBody] returns: errors reported after that point but
+  /// before our `tearDown()` callback runs (e.g. during widget-tree
+  /// disposal) must still be captured, or [Failure.details] silently ends up
+  /// null for a test that otherwise correctly failed. See [_stopGatheringExceptions].
   Future<void> _wrapTestBodyWithExceptionGatherer(
     Future<void> Function() testBody,
   ) async {
@@ -242,10 +272,9 @@ class PatrolBinding extends LiveTestWidgetsFlutterBinding {
         previousOnError?.call(details);
       }
     };
+    _stopGatheringExceptions = () => FlutterError.onError = previousOnError;
 
     await testBody();
-
-    FlutterError.onError = previousOnError;
   }
 
   @override


### PR DESCRIPTION
I had a bug in my app where I forgot to dispose of a `RestorationBucket`, and this in turn would throw an exception sometime after test body finishes and before/during teardown. This resulted in Patrol being unable to provide any error details, since it already restored the original `FlutterError.onError` callback. Such an error would look like this on iOS, with no stack trace:

```
error: -[RunnerUITests smoke_test can sign in] : ((passed) is true) failed - (null)
```

and on Android, quite similarly, there would just be something along the lines of `null: java.lang.AssertionError`.

Here's an app with a minimal reproduction, see its readme for more details: https://github.com/kotertom/repro-patrol-null-error

Edited to add: I have to go now, but I'll open an issue and provide more details on Monday