### PR TITLE
Release adb 0.6.1

### DIFF
--- a/packages/adb/CHANGELOG.md
+++ b/packages/adb/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.6.1
 
 - Add `pull` and `remove` methods to `Adb`, so callers use one place for adb resolution and device handling instead of raw `adb` invocations. (#3222)
 

--- a/packages/adb/pubspec.yaml
+++ b/packages/adb/pubspec.yaml
@@ -1,6 +1,6 @@
 name: adb
 description: Simple Dart wrapper around Android Debug Bridge.
-version: 0.6.0
+version: 0.6.1
 repository: https://github.com/leancodepl/patrol/tree/master/packages/adb
 issue_tracker: https://github.com/leancodepl/patrol/issues?q=is%3Aopen+is%3Aissue+label%3A%22package%3A+adb%22
 


### PR DESCRIPTION
Releases the `pull` and `remove` methods added in #3222, which `patrol_cli` already calls.

- Bump `adb` to 0.6.1 and move the `Unreleased` changelog entry under it.
- Patch bump on purpose: `patrol_cli` and `patrol_mcp` pin `adb: ^0.6.0`, so they pick 0.6.1 up without a constraint change.

Tag `adb-v0.6.1` after merge to publish.