### PR TITLE
Relate Marathon docs to build-time test discovery

### DIFF
--- a/docs/documentation/integrations/marathon.mdx
+++ b/docs/documentation/integrations/marathon.mdx
@@ -29,7 +29,12 @@ brew install malinskiy/tap/marathon
 
 Patrol emits standard instrumentation APKs. Set `testParserConfiguration.type` to
 `remote` so Marathon discovers Dart tests at runtime through `PatrolJUnitRunner`
-(the same mechanism Android Test Orchestrator uses).
+(the same mechanism Android Test Orchestrator uses). Marathon's default `local`
+parser reads the bytecode without a device, and your Dart tests are not in there.
+
+`remote` already reports one entry per Dart test, so there is nothing here that
+[build-time test discovery](/documentation/ci/build-time-test-discovery) needs to
+fix.
 
 ### 1. Add Marathonfile
 
@@ -61,8 +66,17 @@ Marathon discovers connected emulators automatically. Reports are written to
 ## iOS (simulator)
 
 Patrol registers XCTest methods at runtime, so set
-`testParserConfiguration.type` to `xctest`. Marathon's default parser will not
-find any tests.
+`testParserConfiguration.type` to `xctest`. Marathon's default `nm` parser reads
+the compiled bundle, where none of your Dart tests exist yet, and finds nothing.
+
+<Info>
+  On iOS, [build-time test discovery](/documentation/ci/build-time-test-discovery)
+  is the better setup for Marathon. It compiles a real XCTest method per Dart test,
+  so Marathon lists them straight off the bundle with its default `nm` parser,
+  without booting a simulator and launching your app to enumerate them, and it's
+  what per-test sharding across machines needs. The config below keeps the `xctest`
+  parser, so it works either way.
+</Info>
 
 Set `batchingStrategy` to run multiple Patrol tests per `xcodebuild` invocation
 — Marathon's default is one test per batch, which is significantly slower.


### PR DESCRIPTION
Feedback from Marathon Labs: the page never said how build-time test discovery relates to running Patrol tests under Marathon.

- iOS recommends build-time test discovery: tests are compiled into the bundle, so Marathon's default `nm` parser lists them without booting a simulator, and per-test sharding becomes possible. The example config keeps the `xctest` parser, so it works with or without discovery.
- Android says `remote` already reports one entry per Dart test, so discovery buys nothing there.
- Both parser sections now say why Marathon's default parser (`nm`, `local`) finds nothing under runtime discovery.

Checked on the e2e app: `marathon parse` lists all 8 smoke tests under runtime discovery with the `xctest` parser, and build-time discovery with the default `nm` parser lists them without booting a simulator.