### PR TITLE
fix(patrol_mcp): require adb ^0.6.1

### DIFF
--- a/dev/e2e_app/pubspec.lock
+++ b/dev/e2e_app/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: adb
-      sha256: "1c1d53b356bc9a7b89e7abcbb8b7b941f6d6ab0fc61a77eb8a4928befa294202"
+      sha256: ff7324138e3df9dcd8fab54050f9f74a224928321ae50161256109414a87f1d4
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   analyzer:
     dependency: transitive
     description:

--- a/packages/patrol_mcp/CHANGELOG.md
+++ b/packages/patrol_mcp/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Require `adb ^0.6.1`: earlier versions don't have `Adb.pull`/`Adb.remove`,
+  which the `patrol_cli` dependency uses (#TBD).
+
 ## 0.2.0
 
 - Multi-device support: `run` auto-selects a device (Android before iOS, real before emulator/simulator) or targets one you pass as `device`, and a new `devices` tool lists what's attached. A `--device` in `PATROL_FLAGS` still wins.

--- a/packages/patrol_mcp/CHANGELOG.md
+++ b/packages/patrol_mcp/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Require `adb ^0.6.1`: earlier versions don't have `Adb.pull`/`Adb.remove`,
-  which the `patrol_cli` dependency uses (#TBD).
+  which the `patrol_cli` dependency uses (#3258).
 
 ## 0.2.0
 

--- a/packages/patrol_mcp/pubspec.yaml
+++ b/packages/patrol_mcp/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  adb: ^0.6.0
+  adb: ^0.6.1
   args: ^2.7.0
   dispose_scope: ^2.1.0
   image: ^4.5.4


### PR DESCRIPTION
`patrol_cli` calls `Adb.pull`/`Adb.remove`, added in `adb` 0.6.1 (#3222, released in #3255). Not required for a fresh install — `^0.6.0` already resolves to 0.6.1 there — but a checkout with a `pubspec.lock` predating 0.6.1 keeps the old `adb` on a plain `pub get`, and `patrol_mcp` then fails to compile, surfacing only as `CONNECTION_CLOSED` on the MCP client side.

- Bump `patrol_mcp`'s `adb` constraint to `^0.6.1`, so a stale lock is forced to update.
- `dev/e2e_app` hit exactly this; bumped its lockfile too.