### PR TITLE
fix: make flutter/tests customer tests pass on Flutter main

### DIFF
--- a/packages/patrol_finders/example/lib/scrolling_screen.dart
+++ b/packages/patrol_finders/example/lib/scrolling_screen.dart
@@ -18,9 +18,9 @@ class ScrollingScreen extends StatelessWidget {
               key: K.topText,
               textAlign: TextAlign.center,
             ),
-            SizedBox(height: MediaQuery.of(context).size.height),
+            SizedBox(height: MediaQuery.sizeOf(context).height),
             const Text('Some text in the middle'),
-            SizedBox(height: MediaQuery.of(context).size.height),
+            SizedBox(height: MediaQuery.sizeOf(context).height),
             const Text(
               'Some text at the bottom',
               key: K.bottomText,

--- a/packages/patrol_finders/example/pubspec.yaml
+++ b/packages/patrol_finders/example/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  leancode_lint: ^17.0.0
+  leancode_lint: ^19.0.1
   patrol_finders:
     path: ../
 

--- a/packages/patrol_finders/pubspec.yaml
+++ b/packages/patrol_finders/pubspec.yaml
@@ -31,4 +31,4 @@ dependencies:
   patrol_log: ^0.10.0
 
 dev_dependencies:
-  leancode_lint: ^17.0.0
+  leancode_lint: ^19.0.1

--- a/scripts/flutter_test_repo_test.bat
+++ b/scripts/flutter_test_repo_test.bat
@@ -1,0 +1,19 @@
+@echo off
+
+set "root_dir=%CD%"
+
+for %%d in (
+    "packages\patrol_finders"
+    "packages\patrol_cli"
+) do (
+    echo Processing %%d
+    cd "%%d"
+
+    call flutter analyze --no-fatal-infos --no-fatal-warnings
+    if errorlevel 1 exit /b 1
+
+    call flutter test
+    if errorlevel 1 exit /b 1
+
+    cd "%root_dir%"
+)

--- a/scripts/flutter_test_repo_test.sh
+++ b/scripts/flutter_test_repo_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Script invoked by the Flutter customer tests repository.
+
+set -e
+
+# Array of relative directories
+dirs=("packages/patrol_finders" "packages/patrol_cli")
+
+# Loop through each directory
+for dir in "${dirs[@]}"; do
+  cd "$dir"
+
+  flutter analyze --no-fatal-infos --no-fatal-warnings
+  flutter test
+
+  cd - > /dev/null # Return to the previous directory
+done


### PR DESCRIPTION
Makes the flutter/tests customer tests pass on the Flutter main channel, so the disabled registry entry can be re-enabled with a master commit.

- Bumps leancode_lint to 19.x in patrol_finders; 17.x enables two lints that newer analyzers report as incompatible, failing `flutter analyze` on main.
- Fixes two `use_dedicated_media_query_methods` hits in the example surfaced by the bump.
- Adds the `scripts/flutter_test_repo_test.*` entrypoints invoked by flutter/tests; analyze runs there with `--no-fatal-warnings` so analyzer churn on main does not break the weekly check (repo CI keeps fatal warnings).

Verified locally on stable 3.44.1 and main 3.48.0-pre: analyze and tests green in patrol_finders and patrol_cli.