### PR TITLE
chore: run Flutter main customer tests on master

### DIFF
--- a/.github/workflows/test-flutter-main.yaml
+++ b/.github/workflows/test-flutter-main.yaml
@@ -1,6 +1,7 @@
 name: test flutter main channel
-# This workflow verifies if these tests are valid https://github.com/flutter/tests/blob/main/registry/patrol.test.disabled
-# It rebases fix/flutter-patrol-tests onto master weekly and always creates a PR with the results.
+# Verifies weekly that the flutter/tests customer tests
+# (https://github.com/flutter/tests/blob/main/registry/patrol.test)
+# still pass on master with the Flutter main channel.
 on:
   workflow_dispatch:
   schedule:
@@ -25,17 +26,6 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-        with:
-          ref: fix/flutter-patrol-tests
-          fetch-depth: 0
-
-      - name: Rebase fix/flutter-patrol-tests onto master
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin master
-          git rebase origin/master
-          git push --force-with-lease origin fix/flutter-patrol-tests
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -58,57 +48,11 @@ jobs:
         id: status_step
         if: always()
         run: >
-          if [ -z ${{ steps.tests_step.outputs.TESTS_EXIT_CODE }} ]; then 
+          if [ -z ${{ steps.tests_step.outputs.TESTS_EXIT_CODE }} ]; then
             echo "ERROR_STATUS=error" >> "$GITHUB_OUTPUT";
           elif [ ! ${{ steps.tests_step.outputs.TESTS_EXIT_CODE }} == 0 ]; then
             echo "FAILURE_STATUS=failure" >> "$GITHUB_OUTPUT";
           fi;
-
-  create_pr:
-    name: Create PR with test results
-    runs-on: ubuntu-latest
-    needs: run_tests
-    if: always()
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-        with:
-          ref: fix/flutter-patrol-tests
-
-      - name: Create Pull Request
-        env:
-          GH_TOKEN: ${{ github.token }}
-          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          TEST_RESULT: ${{ needs.run_tests.result }}
-        run: |
-          EXISTING_PR=$(gh pr list --head fix/flutter-patrol-tests --base master --state open --json number --jq '.[0].number')
-          if [ -n "$EXISTING_PR" ]; then
-            echo "PR #$EXISTING_PR already exists, adding a comment."
-            gh pr comment "$EXISTING_PR" --body "Flutter main channel tests result: **${TEST_RESULT}** on $(date -u '+%Y-%m-%d'). [See workflow run](${WORKFLOW_URL})"
-          else
-            PR_BODY="## Summary
-
-          Automated PR created after running Flutter main channel customer tests on the \`fix/flutter-patrol-tests\` branch (rebased onto \`master\`).
-
-          **Test result:** ${TEST_RESULT}
-          **Workflow run:** ${WORKFLOW_URL}
-
-          ## Steps to fix (if tests are failing)
-
-          1. Fix tests locally on the \`fix/flutter-patrol-tests\` branch
-          2. Fork the [flutter/tests](https://github.com/flutter/tests) repository
-          3. Update the commit hash in [\`registry/patrol.test\`](https://github.com/flutter/tests/blob/main/registry/patrol.test) to point to the fixed commit
-          4. Create a PR manually from your fork to the [flutter/tests](https://github.com/flutter/tests) repository"
-
-            gh pr create \
-              --title "fix: Flutter main channel customer tests are failing" \
-              --body "$PR_BODY" \
-              --head fix/flutter-patrol-tests \
-              --base master
-          fi
 
   call_send_slack_message:
     name: Notify on Slack


### PR DESCRIPTION
Runs the weekly Flutter main customer tests directly on master instead of auto-rebasing `fix/flutter-patrol-tests` and keeping a perpetual PR open; failures are reported on Slack only.

- The rebase step has been failing on a merge conflict for weeks, so recent weekly results were git errors, not test results.
- Needs #3260 for the scripts; after both are merged, #3025 can be closed and the `fix/flutter-patrol-tests` branch deleted.