### PR TITLE
Fix(patrol_cli): Normalize test directory path [WIP]

### DIFF
--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Normalize `test_directory` from the pubspec's `patrol` section to the host's path convention, so a nested path spelled with forward slashes (`test/integration_test`) resolves the same on Windows as it does on macOS and Linux. (#2896)
 - Add `screenshot_on_failure` option to the pubspec's `patrol` section, forwarded to the app (via a dart-define) for `build` and `test` so patrol can capture native failure screenshots on Android device farms (e.g. BrowserStack, Firebase Test Lab). Not collected by `patrol develop`. Off by default. (#3222)
 - `patrol test` (Android) now pulls native screenshots (failure and on-demand) from the device into `<test-directory>/screenshots` after the run (override with `--screenshots-output-dir`), so they are available from local/emulator runs, not only device farms. (#3222)
 

--- a/packages/patrol_cli/lib/src/pubspec_reader.dart
+++ b/packages/patrol_cli/lib/src/pubspec_reader.dart
@@ -185,7 +185,7 @@ class PubspecReader {
 
     final dynamic testDirectory = patrol['test_directory'];
     if (testDirectory != null && testDirectory is String) {
-      config.testDirectory = testDirectory;
+      config.testDirectory = _fs.path.normalize(testDirectory);
     }
 
     final dynamic testFileSuffix = patrol['test_file_suffix'];

--- a/packages/patrol_cli/test/general/pubspec_reader_test.dart
+++ b/packages/patrol_cli/test/general/pubspec_reader_test.dart
@@ -57,6 +57,69 @@ patrol:
         expect(reader.read().ios.flavor, equals('dev'));
       });
 
+      group('test_directory', () {
+        // One pubspec.yaml is shared by a team on mixed operating systems, so a
+        // nested path can only be committed with forward slashes. See #2896.
+        test("a forward-slash path resolves to this host's separator", () {
+          fs.file('pubspec.yaml').writeAsStringSync('''
+$_pubspecBase
+patrol:
+  test_directory: test/integration_test
+''');
+
+          expect(
+            reader.read().testDirectory,
+            equals(fs.path.join('test', 'integration_test')),
+          );
+        });
+
+        test('a doubled separator is collapsed', () {
+          fs.file('pubspec.yaml').writeAsStringSync('''
+$_pubspecBase
+patrol:
+  test_directory: test//integration_test
+''');
+
+          expect(
+            reader.read().testDirectory,
+            equals(fs.path.join('test', 'integration_test')),
+          );
+        });
+
+        test('a trailing separator is dropped', () {
+          fs.file('pubspec.yaml').writeAsStringSync('''
+$_pubspecBase
+patrol:
+  test_directory: test/integration_test/
+''');
+
+          expect(
+            reader.read().testDirectory,
+            equals(fs.path.join('test', 'integration_test')),
+          );
+        });
+
+        test('a single-segment directory is left alone', () {
+          fs.file('pubspec.yaml').writeAsStringSync('''
+$_pubspecBase
+patrol:
+  test_directory: my_custom_test_dir
+''');
+
+          expect(reader.read().testDirectory, equals('my_custom_test_dir'));
+        });
+
+        test('defaults to patrol_test', () {
+          fs.file('pubspec.yaml').writeAsStringSync('''
+$_pubspecBase
+patrol:
+  app_name: Example
+''');
+
+          expect(reader.read().testDirectory, equals('patrol_test'));
+        });
+      });
+
       test('emit_test_manifest defaults to false', () {
         fs.file('pubspec.yaml').writeAsStringSync('''
 $_pubspecBase


### PR DESCRIPTION
Resolves #2896 
## Summary
The test directory value from `pubspec.yaml` is now normalized to project fs so it works on Windows with forward slash (/)