### PR TITLE
feat(patrol_cli): build and develop on different machines with prebuilt APKs

### DIFF
--- a/docs/cli-commands/build.mdx
+++ b/docs/cli-commands/build.mdx
@@ -95,6 +95,40 @@ See [Build-time test discovery][discovery] for setup (including the required iOS
 
 [discovery]: /documentation/ci/build-time-test-discovery
 
+### Building for a `patrol develop` session on another machine
+
+`patrol develop` normally builds the app itself. With `--develop`, `patrol build
+android` produces the same two APKs `patrol develop` would build (the app and the
+androidTest APK) for a single `--target`, with Hot Restart enabled. That lets you
+build once — for example on CI — and iterate elsewhere without Gradle:
+
+```
+patrol build android --develop --target patrol_test/example_test.dart
+```
+
+Then, on a checkout of the **same commit** using the **same Flutter version**,
+point `patrol develop` at a directory that contains the two APKs:
+
+```
+patrol develop --use-prebuilt-apks path/to/apks --target patrol_test/example_test.dart
+```
+
+Nothing is built on that machine: the APKs are installed with `adb`, the Patrol
+instrumentation is started with `am instrument`, `flutter attach` connects, and
+the requested target is hot restarted in place of the test that was bundled at
+build time. From there the session behaves exactly like a regular `patrol
+develop` — edit the test (or Dart app code), press `r`, repeat. Also works from
+[Patrol MCP](/documentation/other/patrol-mcp) via
+`PATROL_FLAGS=--use-prebuilt-apks=<dir>`.
+
+<Info>
+  Hot Restart only replaces Dart code, so the sources must otherwise match the
+  build: same Flutter/Dart SDK (a different one fails on the device with
+  `Invalid kernel binary format version`), same `--dart-define`s and `--flavor`,
+  same Patrol server ports. Native changes (plugins, manifest, permissions)
+  still require a new build. Android only.
+</Info>
+
 ### Under the hood
 
 The `patrol build` command walks through hierarchy of the `patrol_test`

--- a/docs/cli-commands/build.mdx
+++ b/docs/cli-commands/build.mdx
@@ -113,10 +113,12 @@ point `patrol develop` at a directory that contains the two APKs:
 patrol develop --use-prebuilt-apks path/to/apks --target patrol_test/example_test.dart
 ```
 
-Nothing is built on that machine: the APKs are installed with `adb`, the Patrol
-instrumentation is started with `am instrument`, `flutter attach` connects, and
-the requested target is hot restarted in place of the test that was bundled at
-build time. From there the session behaves exactly like a regular `patrol
+No Gradle or APK build runs on that machine. Patrol compiles the Dart bundle
+once with `flutter build bundle --debug` (which also generates the Dart plugin
+registrant that `flutter attach` needs on a never-built checkout), installs the
+APKs with `adb`, starts the Patrol instrumentation with `am instrument`,
+connects `flutter attach`, and hot restarts the requested target in place of
+the test that was bundled at build time. From there the session behaves exactly like a regular `patrol
 develop` — edit the test (or Dart app code), press `r`, repeat. Also works from
 [Patrol MCP](/documentation/other/patrol-mcp) via
 `PATROL_FLAGS=--use-prebuilt-apks=<dir>`.

--- a/docs/cli-commands/build.mdx
+++ b/docs/cli-commands/build.mdx
@@ -107,7 +107,9 @@ patrol build android --develop --target patrol_test/example_test.dart
 ```
 
 Then, on a checkout of the **same commit** using the **same Flutter version**,
-point `patrol develop` at a directory that contains the two APKs:
+point `patrol develop` at a directory that contains exactly those two APKs. If
+you pass `--test-server-port` or `--app-server-port`, pass the same values to
+both commands - the ports are baked into the APKs at build time:
 
 ```
 patrol develop --use-prebuilt-apks path/to/apks --target patrol_test/example_test.dart

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -15,7 +15,7 @@
   runner with discovery disabled, or the 4.7.0 `STATIC_BEGIN`/`STATIC_END` form, which the per-file
   generated classes no longer compile in.
 - Add `patrol build android --develop`, which builds the app + androidTest APKs the way `patrol develop` does (single-target develop bundle, Hot Restart enabled), so they can be handed to another machine. (#3266)
-- Add `patrol develop --use-prebuilt-apks <dir>` (Android only): skip the Gradle build, install the APKs from `<dir>`, start the Patrol instrumentation with `am instrument` and attach for Hot Restart. Also usable from `patrol_mcp` via `PATROL_FLAGS=--use-prebuilt-apks=<dir>`. (#3266)
+- Add `patrol develop --use-prebuilt-apks <dir>` (Android only): skip the Gradle build, install the APKs from `<dir>`, start the Patrol instrumentation with `am instrument` and attach for Hot Restart. Supports `--record-video` like a regular develop session (the placeholder test baked into the APKs is never recorded). Also usable from `patrol_mcp` via `PATROL_FLAGS=--use-prebuilt-apks=<dir>`. (#3266)
 - Add `screenshot_on_failure` option to the pubspec's `patrol` section, forwarded to the app (via a dart-define) for `build` and `test` so patrol can capture native failure screenshots on Android device farms (e.g. BrowserStack, Firebase Test Lab). Not collected by `patrol develop`. Off by default. (#3222)
 - `patrol test` (Android) now pulls native screenshots (failure and on-demand) from the device into `<test-directory>/screenshots` after the run (override with `--screenshots-output-dir`), so they are available from local/emulator runs, not only device farms. (#3222)
 - Allow the latest `package_config` (3.x), `cli_completion` (0.6.x) and `pub_updater` (0.6.x), without raising the minimum Dart SDK. (#3225)

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Fail with an explanation when `RunnerUITests.m` disagrees with the discovery setting: the static
   runner with discovery disabled, or the 4.7.0 `STATIC_BEGIN`/`STATIC_END` form, which the per-file
   generated classes no longer compile in.
+- Add `patrol build android --develop`, which builds the app + androidTest APKs the way `patrol develop` does (single-target develop bundle, Hot Restart enabled), so they can be handed to another machine. (#3266)
+- Add `patrol develop --use-prebuilt-apks <dir>` (Android only): skip the Gradle build, install the APKs from `<dir>`, start the Patrol instrumentation with `am instrument` and attach for Hot Restart. Also usable from `patrol_mcp` via `PATROL_FLAGS=--use-prebuilt-apks=<dir>`. (#3266)
 - Add `screenshot_on_failure` option to the pubspec's `patrol` section, forwarded to the app (via a dart-define) for `build` and `test` so patrol can capture native failure screenshots on Android device farms (e.g. BrowserStack, Firebase Test Lab). Not collected by `patrol develop`. Off by default. (#3222)
 - `patrol test` (Android) now pulls native screenshots (failure and on-demand) from the device into `<test-directory>/screenshots` after the run (override with `--screenshots-output-dir`), so they are available from local/emulator runs, not only device farms. (#3222)
 - Allow the latest `package_config` (3.x), `cli_completion` (0.6.x) and `pub_updater` (0.6.x), without raising the minimum Dart SDK. (#3225)

--- a/packages/patrol_cli/lib/src/android/android_test_backend.dart
+++ b/packages/patrol_cli/lib/src/android/android_test_backend.dart
@@ -525,6 +525,181 @@ class AndroidTestBackend {
     });
   }
 
+  /// Makes a checkout that was never built ready for `flutter attach`.
+  ///
+  /// `flutter attach` starts the frontend_server (initial compile) before it
+  /// runs the source generators, and passes `-Dflutter.dart_plugin_registrant`
+  /// only if `.dart_tool/flutter_build/dart_plugin_registrant.dart` already
+  /// exists. On a fresh checkout it doesn't, so every Dart-registered plugin
+  /// (e.g. `shared_preferences_android`) throws `MissingPluginException` after
+  /// the first Hot Restart. A normal `patrol develop` never hits this because
+  /// the Gradle build generates the file first. Here no Gradle runs, so run a
+  /// one-off `flutter build bundle --debug` (Dart-only compile, ~20 s) instead;
+  /// it also leaves an `app.dill` the attach compiler can initialize from.
+  Future<void> prepareSourcesForAttach(FlutterAppOptions options) async {
+    final registrant = _rootDirectory
+        .childDirectory('.dart_tool')
+        .childDirectory('flutter_build')
+        .childFile('dart_plugin_registrant.dart');
+    if (registrant.existsSync()) {
+      _logger.detail('Dart plugin registrant already generated, skipping');
+      return;
+    }
+    await _disposeScope.run((scope) async {
+      final task = _logger.task(
+        'Preparing sources for attach (flutter build bundle)',
+      );
+      final process =
+          await _processManager.start([
+              options.command.executable,
+              ...options.command.arguments,
+              'build',
+              'bundle',
+              '--debug',
+              if (options.flavor case final flavor?) ...['--flavor', flavor],
+              ...['-t', options.target],
+              for (final dartDefine in options.dartDefines.entries) ...[
+                '--dart-define',
+                '${dartDefine.key}=${dartDefine.value}',
+              ],
+              for (final path in options.dartDefineFromFilePaths) ...[
+                '--dart-define-from-file',
+                path,
+              ],
+            ], runInShell: true)
+            ..disposedBy(scope);
+      process.listenStdOut((l) => _logger.detail('	: $l')).disposedBy(scope);
+      process.listenStdErr((l) => _logger.err('	$l')).disposedBy(scope);
+      final exitCode = await process.exitCode;
+      if (exitCode != 0) {
+        task.fail('Failed to prepare sources for attach (exit code $exitCode)');
+        throw Exception('flutter build bundle failed with code $exitCode');
+      }
+      task.complete('Prepared sources for attach');
+    });
+  }
+
+  /// Develop-mode counterpart of [execute] for APKs built on another machine
+  /// Develop-mode counterpart of [execute] for APKs built on another machine
+  /// (`patrol develop --use-prebuilt-apks`). Installs the app + androidTest
+  /// APKs found in [apksDir] and starts the Patrol instrumentation directly
+  /// with `am instrument -w`, bypassing Gradle entirely.
+  ///
+  /// The APKs must come from a develop-mode build (`patrol build android
+  /// --develop`): with `PATROL_HOT_RESTART=true` baked in, the Dart side never
+  /// reports `PatrolAppService` readiness, so `PatrolJUnitRunner` blocks in
+  /// `waitForPatrolAppService()` and the app process stays alive for
+  /// `flutter attach` + Hot Restart. Test-orchestrator extras (e.g.
+  /// `clearPackageData`) are not applied - they never were in develop mode.
+  Future<void> executePrebuilt(
+    AndroidAppOptions options,
+    Device device, {
+    required String apksDir,
+    required bool showFlutterLogs,
+    required bool hideTestSteps,
+    required bool clearTestSteps,
+    void Function(Entry entry)? onLogEntry,
+  }) async {
+    final packageName = options.packageName;
+    if (packageName == null) {
+      throwToolExit(
+        'Android applicationId is unknown. Set patrol.android.package_name in '
+        'pubspec.yaml or pass --package-name.',
+      );
+    }
+
+    final dir = _rootDirectory.fileSystem.directory(apksDir);
+    if (!dir.existsSync()) {
+      throwToolExit('Prebuilt APK directory does not exist: $apksDir');
+    }
+    File? appApk;
+    File? testApk;
+    for (final entity in dir.listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.apk')) {
+        continue;
+      }
+      if (entity.path.endsWith('-androidTest.apk')) {
+        testApk ??= entity;
+      } else {
+        appApk ??= entity;
+      }
+    }
+    if (appApk == null || testApk == null) {
+      throwToolExit(
+        'Expected an app APK and a *-androidTest.apk in $apksDir (got '
+        'app=${appApk?.path}, test=${testApk?.path}).',
+      );
+    }
+
+    _logger.detail('Installing app APK: ${appApk.path}');
+    await _adbInstall(appApk.path, device);
+    _logger.detail('Installing androidTest APK: ${testApk.path}');
+    await _adbInstall(testApk.path, device);
+
+    final (instrumentPackage, instrumentRunner) =
+        await _resolveInstrumentationComponent(packageName, device);
+
+    await _disposeScope.run((scope) async {
+      final processLogcat =
+          await _adb.logcat(
+              device: device.id,
+              arguments: {'-T': '1'},
+              filter: 'PatrolServer:I Patrol:I flutter:I *:S',
+            )
+            ..disposedBy(scope);
+
+      final path = generateTestReportPath(
+        rootPath: _rootDirectory.path,
+        buildMode: options.flutter.buildMode,
+        flavor: options.flutter.flavor,
+      );
+      final reportPath = _platform.isWindows
+          ? path.replaceAll(r'\', '/')
+          : path;
+
+      final patrolLogReader =
+          PatrolLogReader(
+              listenStdOut: processLogcat.listenStdOut,
+              scope: scope,
+              log: _logger.info,
+              reportPath: reportPath,
+              showFlutterLogs: showFlutterLogs,
+              hideTestSteps: hideTestSteps,
+              clearTestSteps: clearTestSteps,
+              onLogEntry: onLogEntry,
+            )
+            ..listen()
+            ..startTimer();
+
+      final subject =
+          'prebuilt ${options.description} on ${device.description}';
+      final task = _logger.task('Executing tests of $subject (no build)');
+
+      // No `-e class`: AndroidJUnitRunner discovers the (single) Patrol host
+      // class in the androidTest APK itself, exactly like Gradle's connected
+      // task does. In develop mode this call blocks until the session quits.
+      final process =
+          await _adb.instrument(
+              packageName: instrumentPackage,
+              intentClass: instrumentRunner,
+              device: device.id,
+            )
+            ..disposedBy(scope);
+      process.listenStdOut((l) => _logger.detail('\t: $l')).disposedBy(scope);
+      process.listenStdErr((l) => _logger.detail('\t$l')).disposedBy(scope);
+
+      final exitCode = await process.exitCode;
+      patrolLogReader.stopTimer();
+      processLogcat.kill();
+
+      if (exitCode == 0) {
+        task.complete('Completed executing $subject');
+      } else {
+        task.complete('App shut down on request');
+      }
+    });
+  }
+
   /// Runs already-built tests without rebuilding, via `adb shell am instrument`
   /// (the true no-rebuild path, no Gradle up-to-date check). Requires a prior
   /// `patrol build android --emit-test-manifest`, whose generated JUnit classes

--- a/packages/patrol_cli/lib/src/android/android_test_backend.dart
+++ b/packages/patrol_cli/lib/src/android/android_test_backend.dart
@@ -579,35 +579,17 @@ class AndroidTestBackend {
     });
   }
 
-  /// Develop-mode counterpart of [execute] for APKs built on another machine
-  /// Develop-mode counterpart of [execute] for APKs built on another machine
-  /// (`patrol develop --use-prebuilt-apks`). Installs the app + androidTest
-  /// APKs found in [apksDir] and starts the Patrol instrumentation directly
-  /// with `am instrument -w`, bypassing Gradle entirely.
+  /// Installs the prebuilt app + androidTest APKs found in [apksDir] onto
+  /// [device] with `adb install -r -t`, without Gradle.
   ///
-  /// The APKs must come from a develop-mode build (`patrol build android
-  /// --develop`): with `PATROL_HOT_RESTART=true` baked in, the Dart side never
-  /// reports `PatrolAppService` readiness, so `PatrolJUnitRunner` blocks in
-  /// `waitForPatrolAppService()` and the app process stays alive for
-  /// `flutter attach` + Hot Restart. Test-orchestrator extras (e.g.
-  /// `clearPackageData`) are not applied - they never were in develop mode.
-  Future<void> executePrebuilt(
-    AndroidAppOptions options,
-    Device device, {
+  /// Runs before [executePrebuilt] so that a bad directory or a failed install
+  /// surfaces as a [ToolExit] from the setup phase - the way a Gradle build
+  /// failure would - instead of leaving `flutter attach` waiting for an app
+  /// that was never installed.
+  Future<void> installPrebuiltApks({
     required String apksDir,
-    required bool showFlutterLogs,
-    required bool hideTestSteps,
-    required bool clearTestSteps,
-    void Function(Entry entry)? onLogEntry,
+    required Device device,
   }) async {
-    final packageName = options.packageName;
-    if (packageName == null) {
-      throwToolExit(
-        'Android applicationId is unknown. Set patrol.android.package_name in '
-        'pubspec.yaml or pass --package-name.',
-      );
-    }
-
     final dir = _rootDirectory.fileSystem.directory(apksDir);
     if (!dir.existsSync()) {
       throwToolExit('Prebuilt APK directory does not exist: $apksDir');
@@ -635,6 +617,34 @@ class AndroidTestBackend {
     await _adbInstall(appApk.path, device);
     _logger.detail('Installing androidTest APK: ${testApk.path}');
     await _adbInstall(testApk.path, device);
+  }
+
+  /// Develop-mode counterpart of [execute] for APKs built on another machine
+  /// (`patrol develop --use-prebuilt-apks`): starts the Patrol instrumentation
+  /// directly with `am instrument -w`, bypassing Gradle entirely. The APKs
+  /// must already be installed - see [installPrebuiltApks].
+  ///
+  /// They must come from a develop-mode build (`patrol build android
+  /// --develop`): with `PATROL_HOT_RESTART=true` baked in, the Dart side never
+  /// reports `PatrolAppService` readiness, so `PatrolJUnitRunner` blocks in
+  /// `waitForPatrolAppService()` and the app process stays alive for
+  /// `flutter attach` + Hot Restart. Test-orchestrator extras (e.g.
+  /// `clearPackageData`) are not applied - they never were in develop mode.
+  Future<void> executePrebuilt(
+    AndroidAppOptions options,
+    Device device, {
+    required bool showFlutterLogs,
+    required bool hideTestSteps,
+    required bool clearTestSteps,
+    void Function(Entry entry)? onLogEntry,
+  }) async {
+    final packageName = options.packageName;
+    if (packageName == null) {
+      throwToolExit(
+        'Android applicationId is unknown. Set patrol.android.package_name in '
+        'pubspec.yaml or pass --package-name.',
+      );
+    }
 
     final (instrumentPackage, instrumentRunner) =
         await _resolveInstrumentationComponent(packageName, device);

--- a/packages/patrol_cli/lib/src/android/android_test_backend.dart
+++ b/packages/patrol_cli/lib/src/android/android_test_backend.dart
@@ -16,6 +16,7 @@ import 'package:patrol_cli/src/crossplatform/app_options.dart';
 import 'package:patrol_cli/src/crossplatform/test_manifest.dart';
 import 'package:patrol_cli/src/crossplatform/test_manifest_generator.dart';
 import 'package:patrol_cli/src/crossplatform/video_recording_config.dart';
+import 'package:patrol_cli/src/crossplatform/video_recording_manager.dart';
 import 'package:patrol_cli/src/devices.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
 import 'package:patrol_cli/src/runner/flutter_command.dart';
@@ -365,6 +366,32 @@ class AndroidTestBackend {
     });
   }
 
+  /// Builds the `onLogEntry` callback handed to [PatrolLogReader], composing
+  /// (outermost first): an optional [acceptLogEntries] gate that drops entries
+  /// while it returns false, an optional [videoRecordingManager] that starts
+  /// and stops recordings on test lifecycle entries, and the caller's
+  /// [onLogEntry]. The gate must sit OUTSIDE the recording manager: with
+  /// prebuilt APKs, entries emitted by the placeholder test baked into the APK
+  /// at build time must neither reach the caller nor start a recording.
+  @visibleForTesting
+  static void Function(Entry entry)? composeLogEntryCallback({
+    void Function(Entry entry)? onLogEntry,
+    VideoRecordingManager? videoRecordingManager,
+    bool Function()? acceptLogEntries,
+  }) {
+    final withVideo = videoRecordingManager == null
+        ? onLogEntry
+        : videoRecordingManager.wrapOnLogEntry(onLogEntry);
+    if (acceptLogEntries == null || withVideo == null) {
+      return withVideo;
+    }
+    return (entry) {
+      if (acceptLogEntries()) {
+        withVideo(entry);
+      }
+    };
+  }
+
   /// Executes the tests of the given [options] on the given [device].
   ///
   /// [build] must be called before this method.
@@ -426,9 +453,10 @@ class AndroidTestBackend {
               showFlutterLogs: showFlutterLogs,
               hideTestSteps: hideTestSteps,
               clearTestSteps: clearTestSteps,
-              onLogEntry:
-                  videoRecordingManager?.wrapOnLogEntry(onLogEntry) ??
-                  onLogEntry,
+              onLogEntry: composeLogEntryCallback(
+                onLogEntry: onLogEntry,
+                videoRecordingManager: videoRecordingManager,
+              ),
             )
             ..listen()
             ..startTimer();
@@ -637,6 +665,8 @@ class AndroidTestBackend {
     required bool hideTestSteps,
     required bool clearTestSteps,
     void Function(Entry entry)? onLogEntry,
+    VideoRecordingConfig? videoConfig,
+    bool Function()? acceptLogEntries,
   }) async {
     final packageName = options.packageName;
     if (packageName == null) {
@@ -667,6 +697,19 @@ class AndroidTestBackend {
           ? path.replaceAll(r'\', '/')
           : path;
 
+      AndroidVideoRecordingManager? videoRecordingManager;
+      if (videoConfig?.enabled ?? false) {
+        videoRecordingManager = AndroidVideoRecordingManager(
+          processManager: _processManager,
+          adb: _adb,
+          rootDirectory: _rootDirectory,
+          logger: _logger,
+          config: videoConfig!,
+          device: device,
+          scope: scope,
+        );
+      }
+
       final patrolLogReader =
           PatrolLogReader(
               listenStdOut: processLogcat.listenStdOut,
@@ -676,7 +719,11 @@ class AndroidTestBackend {
               showFlutterLogs: showFlutterLogs,
               hideTestSteps: hideTestSteps,
               clearTestSteps: clearTestSteps,
-              onLogEntry: onLogEntry,
+              onLogEntry: composeLogEntryCallback(
+                onLogEntry: onLogEntry,
+                videoRecordingManager: videoRecordingManager,
+                acceptLogEntries: acceptLogEntries,
+              ),
             )
             ..listen()
             ..startTimer();
@@ -701,6 +748,10 @@ class AndroidTestBackend {
       final exitCode = await process.exitCode;
       patrolLogReader.stopTimer();
       processLogcat.kill();
+
+      // Stops and saves any in-flight recording (e.g. the session was quit
+      // mid-test).
+      await videoRecordingManager?.dispose();
 
       if (exitCode == 0) {
         task.complete('Completed executing $subject');

--- a/packages/patrol_cli/lib/src/android/android_test_backend.dart
+++ b/packages/patrol_cli/lib/src/android/android_test_backend.dart
@@ -622,24 +622,27 @@ class AndroidTestBackend {
     if (!dir.existsSync()) {
       throwToolExit('Prebuilt APK directory does not exist: $apksDir');
     }
-    File? appApk;
-    File? testApk;
+    final appApks = <File>[];
+    final testApks = <File>[];
     for (final entity in dir.listSync(recursive: true)) {
       if (entity is! File || !entity.path.endsWith('.apk')) {
         continue;
       }
       if (entity.path.endsWith('-androidTest.apk')) {
-        testApk ??= entity;
+        testApks.add(entity);
       } else {
-        appApk ??= entity;
+        appApks.add(entity);
       }
     }
-    if (appApk == null || testApk == null) {
+    if (appApks.length != 1 || testApks.length != 1) {
+      final found = [...appApks, ...testApks].map((f) => f.path).join(', ');
       throwToolExit(
-        'Expected an app APK and a *-androidTest.apk in $apksDir (got '
-        'app=${appApk?.path}, test=${testApk?.path}).',
+        'Expected exactly one app APK and one *-androidTest.apk in $apksDir '
+        '(found: ${found.isEmpty ? 'none' : found}).',
       );
     }
+    final appApk = appApks.single;
+    final testApk = testApks.single;
 
     _logger.detail('Installing app APK: ${appApk.path}');
     await _adbInstall(appApk.path, device);

--- a/packages/patrol_cli/lib/src/commands/build_android.dart
+++ b/packages/patrol_cli/lib/src/commands/build_android.dart
@@ -4,6 +4,7 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' show join;
 import 'package:patrol_cli/src/analytics/analytics.dart';
 import 'package:patrol_cli/src/android/android_test_backend.dart';
+import 'package:patrol_cli/src/base/exceptions.dart';
 import 'package:patrol_cli/src/base/extensions/core.dart';
 import 'package:patrol_cli/src/base/logger.dart';
 import 'package:patrol_cli/src/commands/dart_define_utils.dart';
@@ -51,6 +52,17 @@ class BuildAndroidCommand extends PatrolCommand {
     usesAndroidOptions();
     usesAppNameOption();
     usesEmitTestManifestOption();
+
+    argParser.addFlag(
+      'develop',
+      negatable: false,
+      help:
+          'Build the APKs for a `patrol develop --use-prebuilt-apks` session '
+          'on another machine: bundles only the single --target in develop '
+          'mode (Hot Restart enabled) instead of the full test bundle. The '
+          'bundled test is a placeholder - it is replaced on the first Hot '
+          'Restart.',
+    );
   }
 
   final TestFinderFactory _testFinderFactory;
@@ -117,10 +129,28 @@ class BuildAndroidCommand extends PatrolCommand {
     if (excludeTags != null) {
       _logger.detail('Received exclude tag(s): $excludeTags');
     }
-    if (boolArg('generate-bundle')) {
-      _testBundler.createTestBundle(testDirectory, targets, tags, excludeTags);
+    final develop = boolArg('develop');
+    if (develop && targets.length != 1) {
+      throwToolExit('--develop requires exactly one --target');
     }
-    final entrypoint = _testBundler.getBundledTestFile(testDirectory);
+    if (boolArg('generate-bundle')) {
+      if (develop) {
+        _testBundler.createDevelopTestBundle(testDirectory, targets.single);
+      } else {
+        _testBundler.createTestBundle(
+          testDirectory,
+          targets,
+          tags,
+          excludeTags,
+        );
+      }
+    }
+    if (develop) {
+      _testBundler.ensureEntrypoint(testDirectory);
+    }
+    final entrypoint = develop
+        ? _testBundler.getEntrypointFile(testDirectory)
+        : _testBundler.getBundledTestFile(testDirectory);
 
     final flavor = stringArg('flavor') ?? config.android.flavor;
     if (flavor != null) {
@@ -148,15 +178,31 @@ class BuildAndroidCommand extends PatrolCommand {
       ..._dartDefinesReader.fromFile(),
       ..._dartDefinesReader.fromCli(args: stringsArg('dart-define')),
     };
-    final internalDartDefines = {
-      'PATROL_WAIT': defaultWait.toString(),
-      'PATROL_APP_PACKAGE_NAME': packageName,
-      'PATROL_ANDROID_APP_NAME': appName,
-      'PATROL_TEST_LABEL_ENABLED': displayLabel.toString(),
-      'PATROL_TEST_DIRECTORY': config.testDirectory,
-      'PATROL_SCREENSHOT_ON_FAILURE': config.screenshotOnFailure.toString(),
-      'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE': 'false',
-    }.withNullsRemoved();
+    // In develop mode mirror DevelopService's internal defines: the baked
+    // kernel must run in Hot Restart mode so the native runner keeps the app
+    // alive for `flutter attach` instead of driving tests over RPC.
+    final internalDartDefines = develop
+        ? {
+            'PATROL_APP_PACKAGE_NAME': packageName,
+            'PATROL_ANDROID_APP_NAME': appName,
+            'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE': 'false',
+            'PATROL_TEST_LABEL_ENABLED': displayLabel.toString(),
+            'PATROL_TEST_DIRECTORY': config.testDirectory,
+            'PATROL_SCREENSHOT_ON_FAILURE': 'false',
+            'PATROL_HOT_RESTART': 'true',
+            'PATROL_TEST_SERVER_PORT': super.testServerPort.toString(),
+            'PATROL_APP_SERVER_PORT': super.appServerPort.toString(),
+          }.withNullsRemoved()
+        : {
+            'PATROL_WAIT': defaultWait.toString(),
+            'PATROL_APP_PACKAGE_NAME': packageName,
+            'PATROL_ANDROID_APP_NAME': appName,
+            'PATROL_TEST_LABEL_ENABLED': displayLabel.toString(),
+            'PATROL_TEST_DIRECTORY': config.testDirectory,
+            'PATROL_SCREENSHOT_ON_FAILURE': config.screenshotOnFailure
+                .toString(),
+            'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE': 'false',
+          }.withNullsRemoved();
 
     final dartDefines = {...customDartDefines, ...internalDartDefines};
     _logger.detail(
@@ -211,6 +257,10 @@ class BuildAndroidCommand extends PatrolCommand {
         ..detail('$st')
         ..err(defaultFailureMessage);
       rethrow;
+    } finally {
+      if (develop) {
+        _testBundler.deleteEntrypointProxy(testDirectory);
+      }
     }
 
     return 0;

--- a/packages/patrol_cli/lib/src/commands/develop_arg_parser.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_arg_parser.dart
@@ -28,6 +28,16 @@ void configureDevelopArgParser(PatrolCommand command) {
     ..usesVideoRecordingOptions()
     ..usesEmitTestManifestOption();
 
+  command.argParser.addOption(
+    'use-prebuilt-apks',
+    help:
+        'Android only. Directory with the app APK and the androidTest APK '
+        'built elsewhere with `patrol build android --develop`. Skips the '
+        'Gradle build entirely: installs both APKs, starts the Patrol '
+        'instrumentation with `am instrument` and attaches for Hot Restart.',
+    valueHelp: 'path/to/apks',
+  );
+
   command.argParser.addFlag(
     'open-devtools',
     help: 'Automatically open Patrol extension in DevTools when ready.',

--- a/packages/patrol_cli/lib/src/commands/develop_options.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_options.dart
@@ -36,6 +36,7 @@ class DevelopOptions {
     this.iosVersion,
     this.videoConfig,
     this.emitTestManifest,
+    this.prebuiltApksDir,
   });
 
   factory DevelopOptions.fromArgResults(
@@ -79,6 +80,7 @@ class DevelopOptions {
       clearTestSteps: results['clear-test-steps'] as bool,
       checkCompatibility: results['check-compatibility'] as bool,
       iosVersion: results['ios'] as String?,
+      prebuiltApksDir: results['use-prebuilt-apks'] as String?,
       videoConfig: VideoRecordingConfig(
         enabled: results['record-video'] as bool,
         outputDirectory:
@@ -175,6 +177,11 @@ class DevelopOptions {
   /// tests. `null` means the flag wasn't passed, so the `patrol.emit_test_manifest`
   /// pubspec value applies.
   final bool? emitTestManifest;
+
+  /// Directory with prebuilt app + androidTest APKs (Android only). When set,
+  /// the Gradle build is skipped and the session is started from these
+  /// artifacts (`adb install` + `am instrument`). See `--use-prebuilt-apks`.
+  final String? prebuiltApksDir;
 }
 
 class _DevelopOptionsParserCommand extends PatrolCommand {

--- a/packages/patrol_cli/lib/src/commands/develop_service.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_service.dart
@@ -465,19 +465,13 @@ class DevelopService {
 
     // Prebuilt APKs carry a placeholder test baked in at build time, which
     // runs as soon as the app launches. Its log entries would be mistaken for
-    // results of *our* test (e.g. by patrol_mcp), so hold them back until
+    // results of *our* test (e.g. by patrol_mcp) and would start video
+    // recordings of the wrong program, so the backend drops entries until
     // `flutter attach` reports the restart into the requested target as
     // COMPLETED. Logcat delivery is asynchronous, so opening the gate when the
     // restart is merely requested could still let a buffered entry of the
     // placeholder through.
     var prebuiltTargetActive = prebuiltApksDir == null;
-    final void Function(Entry entry)? gatedOnLogEntry = onLogEntry == null
-        ? null
-        : (entry) {
-            if (prebuiltTargetActive) {
-              onLogEntry?.call(entry);
-            }
-          };
 
     switch (device.targetPlatform) {
       case TargetPlatform.android:
@@ -489,7 +483,9 @@ class DevelopService {
                 showFlutterLogs: showFlutterLogs,
                 hideTestSteps: hideTestSteps,
                 clearTestSteps: clearTestSteps,
-                onLogEntry: gatedOnLogEntry,
+                onLogEntry: onLogEntry,
+                videoConfig: videoConfig,
+                acceptLogEntries: () => prebuiltTargetActive,
               )
             : () => _androidTestBackend.execute(
                 android,

--- a/packages/patrol_cli/lib/src/commands/develop_service.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_service.dart
@@ -625,6 +625,16 @@ class DevelopService {
           );
           _flutterTool.hotRestart(
             onCompleted: () => prebuiltTargetActive = true,
+            // The placeholder is gone once a restart was attempted, so open
+            // the gate anyway; otherwise a compile error in the target would
+            // keep every later entry (after the user's fix + `r`) hidden.
+            onFailed: () {
+              prebuiltTargetActive = true;
+              _logger.warn(
+                'Hot restart into the requested target failed. Fix the '
+                'error above and press r.',
+              );
+            },
           );
         }
       }

--- a/packages/patrol_cli/lib/src/commands/develop_service.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_service.dart
@@ -176,6 +176,12 @@ class DevelopService {
 
     _logger.detail('Received device: ${device.name} (${device.id})');
 
+    final prebuiltApksDir = options.prebuiltApksDir;
+    if (prebuiltApksDir != null &&
+        device.targetPlatform != TargetPlatform.android) {
+      throwToolExit('--use-prebuilt-apks is supported on Android only');
+    }
+
     final packageName = options.packageName ?? config.android.packageName;
     final bundleId = options.bundleId ?? config.ios.bundleId;
     final androidAppName = options.appName ?? config.android.appName;
@@ -298,7 +304,14 @@ class DevelopService {
     final webOpts = WebAppOptions(flutter: flutterOpts);
 
     try {
-      await _build(androidOpts, iosOpts, macosOpts, webOpts, device);
+      if (prebuiltApksDir == null) {
+        await _build(androidOpts, iosOpts, macosOpts, webOpts, device);
+      } else {
+        _logger.info(
+          'Skipping build, using prebuilt APKs from $prebuiltApksDir',
+        );
+        await _androidTestBackend.prepareSourcesForAttach(flutterOpts);
+      }
       await _preExecute(androidOpts, iosOpts, device, options.uninstall);
       await _execute(
         flutterOpts,
@@ -314,6 +327,7 @@ class DevelopService {
         hideTestSteps: options.hideTestSteps,
         clearTestSteps: options.clearTestSteps,
         videoConfig: options.videoConfig,
+        prebuiltApksDir: prebuiltApksDir,
       );
     } finally {
       for (final sub in signalSubscriptions) {
@@ -421,6 +435,7 @@ class DevelopService {
     required bool hideTestSteps,
     required bool clearTestSteps,
     VideoRecordingConfig? videoConfig,
+    String? prebuiltApksDir,
   }) async {
     Future<void> Function() action;
     Future<void> Function()? finalizer;
@@ -438,20 +453,43 @@ class DevelopService {
         ? Completer<String>()
         : null;
 
+    // Prebuilt APKs carry a placeholder test baked in at build time, which
+    // runs as soon as the app launches. Until we've attached and hot
+    // restarted with the real target, its log entries would be mistaken for
+    // results of *our* test (e.g. by patrol_mcp), so hold them back.
+    var prebuiltRestartSent = prebuiltApksDir == null;
+    final void Function(Entry entry)? gatedOnLogEntry = onLogEntry == null
+        ? null
+        : (entry) {
+            if (prebuiltRestartSent) {
+              onLogEntry?.call(entry);
+            }
+          };
+
     switch (device.targetPlatform) {
       case TargetPlatform.android:
         appId = android.packageName;
-        action = () => _androidTestBackend.execute(
-          android,
-          device,
-          interruptible: true,
-          showFlutterLogs: showFlutterLogs,
-          hideTestSteps: hideTestSteps,
-          flavor: flutterOpts.flavor,
-          clearTestSteps: clearTestSteps,
-          onLogEntry: onLogEntry,
-          videoConfig: videoConfig,
-        );
+        action = prebuiltApksDir != null
+            ? () => _androidTestBackend.executePrebuilt(
+                android,
+                device,
+                apksDir: prebuiltApksDir,
+                showFlutterLogs: showFlutterLogs,
+                hideTestSteps: hideTestSteps,
+                clearTestSteps: clearTestSteps,
+                onLogEntry: gatedOnLogEntry,
+              )
+            : () => _androidTestBackend.execute(
+                android,
+                device,
+                interruptible: true,
+                showFlutterLogs: showFlutterLogs,
+                hideTestSteps: hideTestSteps,
+                flavor: flutterOpts.flavor,
+                clearTestSteps: clearTestSteps,
+                onLogEntry: onLogEntry,
+                videoConfig: videoConfig,
+              );
         final package = android.packageName;
         if (package != null && uninstall) {
           finalizer = () => _androidTestBackend.uninstall(package, device);
@@ -556,6 +594,14 @@ class DevelopService {
           forwardFlutterLogs: flutterLogs.forwardFlutterLogs,
           onQuit: onQuitCleanup,
         );
+        if (prebuiltApksDir != null) {
+          _logger.info(
+            'Prebuilt APKs: the app launched with the placeholder test baked '
+            'in at build time; hot restarting with the requested target...',
+          );
+          prebuiltRestartSent = true;
+          _flutterTool.hotRestart();
+        }
       }
 
       try {

--- a/packages/patrol_cli/lib/src/commands/develop_service.dart
+++ b/packages/patrol_cli/lib/src/commands/develop_service.dart
@@ -313,6 +313,16 @@ class DevelopService {
         await _androidTestBackend.prepareSourcesForAttach(flutterOpts);
       }
       await _preExecute(androidOpts, iosOpts, device, options.uninstall);
+      if (prebuiltApksDir != null) {
+        // After _preExecute, so the optional uninstall can't race the install.
+        // Installing here (not inside _execute) makes a bad directory or a
+        // failed install a setup error that aborts the run, instead of an
+        // async failure while the CLI is already waiting on flutter attach.
+        await _androidTestBackend.installPrebuiltApks(
+          apksDir: prebuiltApksDir,
+          device: device,
+        );
+      }
       await _execute(
         flutterOpts,
         androidOpts,
@@ -454,14 +464,17 @@ class DevelopService {
         : null;
 
     // Prebuilt APKs carry a placeholder test baked in at build time, which
-    // runs as soon as the app launches. Until we've attached and hot
-    // restarted with the real target, its log entries would be mistaken for
-    // results of *our* test (e.g. by patrol_mcp), so hold them back.
-    var prebuiltRestartSent = prebuiltApksDir == null;
+    // runs as soon as the app launches. Its log entries would be mistaken for
+    // results of *our* test (e.g. by patrol_mcp), so hold them back until
+    // `flutter attach` reports the restart into the requested target as
+    // COMPLETED. Logcat delivery is asynchronous, so opening the gate when the
+    // restart is merely requested could still let a buffered entry of the
+    // placeholder through.
+    var prebuiltTargetActive = prebuiltApksDir == null;
     final void Function(Entry entry)? gatedOnLogEntry = onLogEntry == null
         ? null
         : (entry) {
-            if (prebuiltRestartSent) {
+            if (prebuiltTargetActive) {
               onLogEntry?.call(entry);
             }
           };
@@ -473,7 +486,6 @@ class DevelopService {
             ? () => _androidTestBackend.executePrebuilt(
                 android,
                 device,
-                apksDir: prebuiltApksDir,
                 showFlutterLogs: showFlutterLogs,
                 hideTestSteps: hideTestSteps,
                 clearTestSteps: clearTestSteps,
@@ -582,7 +594,7 @@ class DevelopService {
       );
 
       if (device.targetPlatform != TargetPlatform.web) {
-        await _flutterTool.attachForHotRestart(
+        final attached = _flutterTool.attachForHotRestart(
           flutterCommand: flutterOpts.command,
           deviceId: device.id,
           target: flutterOpts.target,
@@ -594,13 +606,30 @@ class DevelopService {
           forwardFlutterLogs: flutterLogs.forwardFlutterLogs,
           onQuit: onQuitCleanup,
         );
-        if (prebuiltApksDir != null) {
+        if (prebuiltApksDir == null) {
+          await attached;
+        } else {
+          // No Gradle ran before this point, so nothing has verified that the
+          // instrumentation actually came up. If the backend settles before
+          // attach connects (instrumentation not found, app crash on launch),
+          // fail instead of waiting forever for an attach that can't succeed.
+          final backendExitedFirst = await Future.any<bool>([
+            attached.then((_) => false),
+            future.then((_) => true, onError: (Object _) => true),
+          ]);
+          if (backendExitedFirst) {
+            throwToolExit(
+              'The instrumentation exited before `flutter attach` could '
+              'connect - the app never came up. See the logs above.',
+            );
+          }
           _logger.info(
             'Prebuilt APKs: the app launched with the placeholder test baked '
             'in at build time; hot restarting with the requested target...',
           );
-          prebuiltRestartSent = true;
-          _flutterTool.hotRestart();
+          _flutterTool.hotRestart(
+            onCompleted: () => prebuiltTargetActive = true,
+          );
         }
       }
 

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -41,6 +41,26 @@ class FlutterTool {
   var _logsActive = false;
   var _logsSkipped = false;
   var _devtoolsUrl = '';
+  io.Process? _attachProcess;
+  var _pendingHotRestart = false;
+
+  /// Sends a Hot Restart to the attached app - the same as pressing `r`.
+  ///
+  /// If `flutter attach` hasn't connected yet the request is queued and sent
+  /// as soon as it does. Dropping it (the previous behaviour) left callers
+  /// such as patrol_mcp waiting for a test run that never started.
+  void hotRestart() {
+    final process = _attachProcess;
+    if (process == null || !_hotRestartActive) {
+      _logger.warn(
+        'Hot Restart: not attached to the app yet, will restart once attached',
+      );
+      _pendingHotRestart = true;
+      return;
+    }
+    _logger.success('Hot Restart requested...');
+    process.stdin.add('R'.codeUnits);
+  }
 
   /// Forwards logs and hot restarts the app when "r" is pressed.
   Future<void> attachForHotRestart({
@@ -162,6 +182,7 @@ class FlutterTool {
               ],
             ])
             ..disposedBy(scope);
+      _attachProcess = process;
 
       final completer = Completer<void>();
       scope.addDispose(() {
@@ -176,7 +197,11 @@ class FlutterTool {
             final char = String.fromCharCode(event.first);
             if (char == 'r' || char == 'R') {
               if (!_hotRestartActive) {
-                _logger.warn('Hot Restart: not attached to the app yet!');
+                _logger.warn(
+                  'Hot Restart: not attached to the app yet, will restart once '
+                  'attached',
+                );
+                _pendingHotRestart = true;
                 return;
               }
 
@@ -236,6 +261,11 @@ class FlutterTool {
                 'q Quit (terminate the process and application on the device)',
               );
               _hotRestartActive = true;
+              if (_pendingHotRestart) {
+                _pendingHotRestart = false;
+                _logger.success('Hot Restart: sending the queued restart');
+                process.stdin.add('R'.codeUnits);
+              }
 
               if (!_logsActive && !_logsSkipped) {
                 _logger.warn('Hot Restart: logs are not connected yet');

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -44,6 +44,7 @@ class FlutterTool {
   io.Process? _attachProcess;
   var _pendingHotRestart = false;
   void Function()? _onRestartCompleted;
+  void Function()? _onRestartFailed;
 
   /// Sends a Hot Restart to the attached app - the same as pressing `r`.
   ///
@@ -54,8 +55,11 @@ class FlutterTool {
   /// [onCompleted] fires once `flutter attach` reports the restart as
   /// completed ('Restarted application ...'), not when it is requested.
   /// Callers use it to tell output of the old and the new program apart.
-  void hotRestart({void Function()? onCompleted}) {
+  /// [onFailed] fires instead when the restart is rejected (compile error);
+  /// exactly one of the two fires, at most once.
+  void hotRestart({void Function()? onCompleted, void Function()? onFailed}) {
     _onRestartCompleted = onCompleted;
+    _onRestartFailed = onFailed;
     final process = _attachProcess;
     if (process == null || !_hotRestartActive) {
       _logger.warn(
@@ -66,6 +70,12 @@ class FlutterTool {
     }
     _logger.success('Hot Restart requested...');
     process.stdin.add('R'.codeUnits);
+  }
+
+  void _settleRestart(void Function()? callback) {
+    _onRestartCompleted = null;
+    _onRestartFailed = null;
+    callback?.call();
   }
 
   /// Forwards logs and hot restarts the app when "r" is pressed.
@@ -280,9 +290,11 @@ class FlutterTool {
             }
 
             if (line.startsWith('Restarted application')) {
-              final onRestartCompleted = _onRestartCompleted;
-              _onRestartCompleted = null;
-              onRestartCompleted?.call();
+              _settleRestart(_onRestartCompleted);
+            }
+
+            if (line.startsWith('Try again after fixing the above error')) {
+              _settleRestart(_onRestartFailed);
             }
 
             if (line.startsWith('The Flutter DevTools debugger and profiler')) {

--- a/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
+++ b/packages/patrol_cli/lib/src/crossplatform/flutter_tool.dart
@@ -43,13 +43,19 @@ class FlutterTool {
   var _devtoolsUrl = '';
   io.Process? _attachProcess;
   var _pendingHotRestart = false;
+  void Function()? _onRestartCompleted;
 
   /// Sends a Hot Restart to the attached app - the same as pressing `r`.
   ///
   /// If `flutter attach` hasn't connected yet the request is queued and sent
   /// as soon as it does. Dropping it (the previous behaviour) left callers
   /// such as patrol_mcp waiting for a test run that never started.
-  void hotRestart() {
+  ///
+  /// [onCompleted] fires once `flutter attach` reports the restart as
+  /// completed ('Restarted application ...'), not when it is requested.
+  /// Callers use it to tell output of the old and the new program apart.
+  void hotRestart({void Function()? onCompleted}) {
+    _onRestartCompleted = onCompleted;
     final process = _attachProcess;
     if (process == null || !_hotRestartActive) {
       _logger.warn(
@@ -271,6 +277,12 @@ class FlutterTool {
                 _logger.warn('Hot Restart: logs are not connected yet');
               }
               completer.complete();
+            }
+
+            if (line.startsWith('Restarted application')) {
+              final onRestartCompleted = _onRestartCompleted;
+              _onRestartCompleted = null;
+              onRestartCompleted?.call();
             }
 
             if (line.startsWith('The Flutter DevTools debugger and profiler')) {

--- a/packages/patrol_cli/test/android/compose_log_entry_callback_test.dart
+++ b/packages/patrol_cli/test/android/compose_log_entry_callback_test.dart
@@ -1,0 +1,89 @@
+import 'package:patrol_cli/src/android/android_test_backend.dart';
+import 'package:patrol_cli/src/crossplatform/video_recording_manager.dart';
+import 'package:patrol_log/patrol_log.dart';
+import 'package:test/test.dart';
+
+class _FakeVideoRecordingManager extends VideoRecordingManager {
+  final List<String> started = <String>[];
+  int stopped = 0;
+
+  @override
+  Future<void> startRecording(String testName) async => started.add(testName);
+
+  @override
+  Future<void> stopRecording() async => stopped++;
+}
+
+/// Lets the manager's internal operation chain settle.
+Future<void> _pump() => Future<void>.delayed(const Duration(milliseconds: 10));
+
+void main() {
+  group('AndroidTestBackend.composeLogEntryCallback', () {
+    test('is a passthrough when neither manager nor gate is given', () {
+      void callback(Entry entry) {}
+      expect(
+        AndroidTestBackend.composeLogEntryCallback(onLogEntry: callback),
+        same(callback),
+      );
+      expect(AndroidTestBackend.composeLogEntryCallback(), isNull);
+    });
+
+    test('a closed gate drops entries before they reach the manager', () async {
+      final manager = _FakeVideoRecordingManager();
+      final received = <Entry>[];
+      final callback = AndroidTestBackend.composeLogEntryCallback(
+        onLogEntry: received.add,
+        videoRecordingManager: manager,
+        acceptLogEntries: () => false,
+      )!;
+
+      // The placeholder test baked into prebuilt APKs emits these on app
+      // launch; none of it may start a recording or reach the caller.
+      callback(TestEntry(name: 'placeholder', status: TestEntryStatus.start));
+      callback(
+        ConfigEntry(config: const {ConfigEntry.developCompletedKey: true}),
+      );
+      await _pump();
+
+      expect(manager.started, isEmpty);
+      expect(manager.stopped, 0);
+      expect(received, isEmpty);
+    });
+
+    test('an open gate lets the manager record and forwards entries', () async {
+      final manager = _FakeVideoRecordingManager();
+      final received = <Entry>[];
+      var open = false;
+      final callback = AndroidTestBackend.composeLogEntryCallback(
+        onLogEntry: received.add,
+        videoRecordingManager: manager,
+        acceptLogEntries: () => open,
+      )!;
+
+      callback(TestEntry(name: 'placeholder', status: TestEntryStatus.start));
+      open = true;
+      callback(TestEntry(name: 'real test', status: TestEntryStatus.start));
+      callback(
+        ConfigEntry(config: const {ConfigEntry.developCompletedKey: true}),
+      );
+      await _pump();
+
+      expect(manager.started, ['real test']);
+      expect(manager.stopped, 1);
+      expect(received, hasLength(2));
+    });
+
+    test('without a gate the manager wraps the callback directly', () async {
+      final manager = _FakeVideoRecordingManager();
+      final callback = AndroidTestBackend.composeLogEntryCallback(
+        onLogEntry: (_) {},
+        videoRecordingManager: manager,
+      )!;
+
+      callback(TestEntry(name: 'a test', status: TestEntryStatus.start));
+      await _pump();
+
+      expect(manager.started, ['a test']);
+    });
+  });
+}

--- a/packages/patrol_cli/test/commands/build_android_command_test.dart
+++ b/packages/patrol_cli/test/commands/build_android_command_test.dart
@@ -4,6 +4,7 @@ import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' show join;
+import 'package:patrol_cli/src/base/exceptions.dart';
 import 'package:patrol_cli/src/commands/build_android.dart';
 import 'package:patrol_cli/src/crossplatform/app_options.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart';
@@ -37,6 +38,8 @@ void main() {
       PatrolPubspecConfig.empty(flutterPackageName: 'test_app'),
     );
     registerFallbackValue(MemoryFileSystem().file('test'));
+    registerFallbackValue(<String>[]);
+    registerFallbackValue(<String>{});
     registerFallbackValue(Directory.current);
   });
 
@@ -133,6 +136,83 @@ void main() {
 
         return result;
       }
+
+      group('--develop', () {
+        setUp(() {
+          when(
+            () => mockTestFinder.findTests(any(), any(), any()),
+          ).thenReturn(['patrol_test/app_test.dart']);
+          when(
+            () => mockTestBundler.createDevelopTestBundle(any(), any()),
+          ).thenReturn(null);
+          when(() => mockTestBundler.ensureEntrypoint(any())).thenReturn(null);
+          when(() => mockTestBundler.getEntrypointFile(any())).thenReturn(
+            MemoryFileSystem().file('integration_test/patrol_test_bundle.dart'),
+          );
+          when(
+            () => mockTestBundler.deleteEntrypointProxy(any()),
+          ).thenReturn(null);
+        });
+
+        test('bundles the single target in develop mode', () async {
+          final result = await runCommand([
+            '--develop',
+            '--target',
+            'patrol_test/app_test.dart',
+          ]);
+
+          expect(result, equals(0));
+          verify(
+            () => mockTestBundler.createDevelopTestBundle(
+              any(),
+              'patrol_test/app_test.dart',
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockTestBundler.createTestBundle(any(), any(), any(), any()),
+          );
+
+          final opts =
+              verify(
+                    () => mockAndroidTestBackend.build(captureAny()),
+                  ).captured.single
+                  as AndroidAppOptions;
+          expect(
+            opts.flutter.target,
+            endsWith('integration_test/patrol_test_bundle.dart'),
+          );
+          expect(
+            opts.flutter.dartDefines,
+            containsPair('PATROL_HOT_RESTART', 'true'),
+          );
+          expect(
+            opts.flutter.dartDefines,
+            containsPair('PATROL_TEST_SERVER_PORT', '8081'),
+          );
+          expect(opts.flutter.dartDefines, isNot(contains('PATROL_WAIT')));
+
+          // The DevTools proxy entrypoint is a build-time artifact only.
+          verify(() => mockTestBundler.deleteEntrypointProxy(any())).called(1);
+        });
+
+        test('requires exactly one target', () async {
+          when(
+            () => mockTestFinder.findTests(any(), any(), any()),
+          ).thenReturn(['patrol_test/a_test.dart', 'patrol_test/b_test.dart']);
+
+          await expectLater(
+            runCommand([
+              '--develop',
+              '--target',
+              'patrol_test/a_test.dart',
+              '--target',
+              'patrol_test/b_test.dart',
+            ]),
+            throwsA(isA<ToolExit>()),
+          );
+          verifyNever(() => mockAndroidTestBackend.build(any()));
+        });
+      });
 
       test('builds Android app with default options', () async {
         final result = await runCommand();

--- a/packages/patrol_cli/test/commands/develop_options_test.dart
+++ b/packages/patrol_cli/test/commands/develop_options_test.dart
@@ -1,0 +1,28 @@
+import 'package:patrol_cli/src/commands/develop_options.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DevelopOptions.parseArgs', () {
+    test('parses --use-prebuilt-apks alongside develop and global flags', () {
+      final (options, results) = DevelopOptions.parseArgs([
+        '--use-prebuilt-apks=/tmp/apks',
+        '--device',
+        'emulator-5554',
+        '--verbose',
+      ], target: 'patrol_test/app_test.dart');
+
+      expect(options.prebuiltApksDir, '/tmp/apks');
+      expect(options.devices, ['emulator-5554']);
+      expect(results['verbose'], isTrue);
+    });
+
+    test('prebuiltApksDir is null when the flag is absent', () {
+      final (options, _) = DevelopOptions.parseArgs(
+        const [],
+        target: 'patrol_test/app_test.dart',
+      );
+
+      expect(options.prebuiltApksDir, isNull);
+    });
+  });
+}

--- a/packages/patrol_cli/test/commands/develop_service_test.dart
+++ b/packages/patrol_cli/test/commands/develop_service_test.dart
@@ -10,6 +10,7 @@ import 'package:patrol_cli/src/devices.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart' show BuildMode;
 import 'package:patrol_cli/src/pubspec_reader.dart';
 import 'package:patrol_cli/src/runner/flutter_command.dart';
+import 'package:patrol_log/patrol_log.dart';
 import 'package:test/test.dart';
 
 import '../src/mocks.dart';
@@ -148,22 +149,24 @@ void main() {
       when(() => androidTestBackend.build(any())).thenAnswer((_) async {});
     });
 
-    DevelopService buildService() => DevelopService(
-      deviceFinder: deviceFinder,
-      testFinderFactory: testFinderFactory,
-      testBundler: testBundler,
-      dartDefinesReader: dartDefinesReader,
-      compatibilityChecker: compatibilityChecker,
-      pubspecReader: pubspecReader,
-      androidTestBackend: androidTestBackend,
-      iosTestBackend: iosTestBackend,
-      macosTestBackend: macosTestBackend,
-      webTestBackend: webTestBackend,
-      flutterTool: flutterTool,
-      logger: logger,
-      stdin: const Stream.empty(),
-      onTestsCompleted: (result) => _lastResult = result,
-    );
+    DevelopService buildService({void Function(Entry entry)? onLogEntry}) =>
+        DevelopService(
+          deviceFinder: deviceFinder,
+          testFinderFactory: testFinderFactory,
+          testBundler: testBundler,
+          dartDefinesReader: dartDefinesReader,
+          compatibilityChecker: compatibilityChecker,
+          pubspecReader: pubspecReader,
+          androidTestBackend: androidTestBackend,
+          iosTestBackend: iosTestBackend,
+          macosTestBackend: macosTestBackend,
+          webTestBackend: webTestBackend,
+          flutterTool: flutterTool,
+          logger: logger,
+          stdin: const Stream.empty(),
+          onTestsCompleted: (result) => _lastResult = result,
+          onLogEntry: onLogEntry,
+        );
 
     const options = DevelopOptions(
       target: 'onboarding_test.dart',
@@ -373,6 +376,160 @@ void main() {
       );
 
       expect((await built.future).emitTestManifest, isFalse);
+    });
+
+    group('with prebuilt APKs', () {
+      const prebuiltOptions = DevelopOptions(
+        target: 'onboarding_test.dart',
+        flutterCommand: FlutterCommand('flutter'),
+        buildMode: BuildMode.debug,
+        testServerPort: 8081,
+        appServerPort: 8080,
+        generateBundle: false,
+        uninstall: false,
+        checkCompatibility: false,
+        prebuiltApksDir: '/apks',
+      );
+
+      late Completer<void> attachCompleter;
+      late Completer<void> backendExit;
+      void Function(Entry entry)? backendOnLogEntry;
+      var backendStarted = false;
+      var hotRestarts = 0;
+
+      setUpAll(() {
+        registerFallbackValue(
+          const FlutterAppOptions(
+            command: FlutterCommand('flutter'),
+            target: 'patrol_test/test_bundle.dart',
+            flavor: null,
+            buildMode: BuildMode.debug,
+            dartDefines: <String, String>{},
+            dartDefineFromFilePaths: <String>[],
+            buildName: null,
+            buildNumber: null,
+          ),
+        );
+      });
+
+      setUp(() {
+        attachCompleter = Completer<void>();
+        backendExit = Completer<void>();
+        backendOnLogEntry = null;
+        backendStarted = false;
+        hotRestarts = 0;
+
+        when(
+          () => androidTestBackend.prepareSourcesForAttach(any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => androidTestBackend.executePrebuilt(
+            any(),
+            any(),
+            apksDir: any(named: 'apksDir'),
+            showFlutterLogs: any(named: 'showFlutterLogs'),
+            hideTestSteps: any(named: 'hideTestSteps'),
+            clearTestSteps: any(named: 'clearTestSteps'),
+            onLogEntry: any(named: 'onLogEntry'),
+          ),
+        ).thenAnswer((invocation) {
+          backendOnLogEntry =
+              invocation.namedArguments[#onLogEntry]
+                  as void Function(Entry entry)?;
+          backendStarted = true;
+          return backendExit.future;
+        });
+        when(
+          () => flutterTool.attachForHotRestart(
+            flutterCommand: any(named: 'flutterCommand'),
+            deviceId: any(named: 'deviceId'),
+            target: any(named: 'target'),
+            appId: any(named: 'appId'),
+            dartDefines: any(named: 'dartDefines'),
+            openDevtools: any(named: 'openDevtools'),
+            attachUsingUrl: any(named: 'attachUsingUrl'),
+            forwardFlutterLogs: any(named: 'forwardFlutterLogs'),
+            onQuit: any(named: 'onQuit'),
+          ),
+        ).thenAnswer((_) => attachCompleter.future);
+        when(() => flutterTool.hotRestart()).thenAnswer((_) => hotRestarts++);
+      });
+
+      test(
+        'skips the build, prepares the sources and hot restarts once attached',
+        () async {
+          unawaited(buildService().run(prebuiltOptions));
+          await _waitFor(() => backendStarted);
+
+          verifyNever(() => androidTestBackend.build(any()));
+          verify(
+            () => androidTestBackend.prepareSourcesForAttach(any()),
+          ).called(1);
+          final apksDir = verify(
+            () => androidTestBackend.executePrebuilt(
+              any(),
+              any(),
+              apksDir: captureAny(named: 'apksDir'),
+              showFlutterLogs: any(named: 'showFlutterLogs'),
+              hideTestSteps: any(named: 'hideTestSteps'),
+              clearTestSteps: any(named: 'clearTestSteps'),
+              onLogEntry: any(named: 'onLogEntry'),
+            ),
+          ).captured.single;
+          expect(apksDir, '/apks');
+
+          // The APK runs the test bundled at build time; the requested target
+          // is only hot restarted in once `flutter attach` has connected.
+          expect(hotRestarts, 0);
+          attachCompleter.complete();
+          await _waitFor(() => hotRestarts == 1);
+        },
+      );
+
+      test(
+        'holds back log entries until the requested target is hot restarted',
+        () async {
+          final received = <String>[];
+          unawaited(
+            buildService(
+              onLogEntry: (entry) => received.add((entry as LogEntry).message),
+            ).run(prebuiltOptions),
+          );
+          await _waitFor(() => backendOnLogEntry != null);
+
+          // Emitted by the placeholder test baked into the APK -- must not be
+          // mistaken for a result of the requested target (e.g. by patrol_mcp).
+          backendOnLogEntry!(LogEntry(message: 'placeholder finished'));
+          expect(received, isEmpty);
+
+          attachCompleter.complete();
+          await _waitFor(() => hotRestarts == 1);
+
+          backendOnLogEntry!(LogEntry(message: 'requested target finished'));
+          expect(received, ['requested target finished']);
+        },
+      );
+
+      test('is rejected on non-Android devices', () async {
+        const iosDevice = Device(
+          name: 'iPhone',
+          id: 'ios-sim',
+          targetPlatform: TargetPlatform.iOS,
+          real: false,
+        );
+        when(
+          () => deviceFinder.find(
+            any(),
+            flutterCommand: any(named: 'flutterCommand'),
+          ),
+        ).thenAnswer((_) async => [iosDevice]);
+
+        await expectLater(
+          buildService().run(prebuiltOptions),
+          throwsA(isA<ToolExit>()),
+        );
+        verifyNever(() => androidTestBackend.build(any()));
+      });
     });
 
     group('iOS logs', () {

--- a/packages/patrol_cli/test/commands/develop_service_test.dart
+++ b/packages/patrol_cli/test/commands/develop_service_test.dart
@@ -464,7 +464,10 @@ void main() {
           ),
         ).thenAnswer((_) => attachCompleter.future);
         when(
-          () => flutterTool.hotRestart(onCompleted: any(named: 'onCompleted')),
+          () => flutterTool.hotRestart(
+            onCompleted: any(named: 'onCompleted'),
+            onFailed: any(named: 'onFailed'),
+          ),
         ).thenAnswer((invocation) {
           hotRestarts++;
           // The real FlutterTool fires this once `flutter attach` reports
@@ -544,8 +547,10 @@ void main() {
             throwsA(isA<ToolExit>()),
           );
           verifyNever(
-            () =>
-                flutterTool.hotRestart(onCompleted: any(named: 'onCompleted')),
+            () => flutterTool.hotRestart(
+              onCompleted: any(named: 'onCompleted'),
+              onFailed: any(named: 'onFailed'),
+            ),
           );
         },
       );

--- a/packages/patrol_cli/test/commands/develop_service_test.dart
+++ b/packages/patrol_cli/test/commands/develop_service_test.dart
@@ -6,6 +6,7 @@ import 'package:patrol_cli/src/base/exceptions.dart';
 import 'package:patrol_cli/src/commands/develop_options.dart';
 import 'package:patrol_cli/src/commands/develop_service.dart';
 import 'package:patrol_cli/src/crossplatform/app_options.dart';
+import 'package:patrol_cli/src/crossplatform/video_recording_config.dart';
 import 'package:patrol_cli/src/devices.dart';
 import 'package:patrol_cli/src/ios/ios_test_backend.dart' show BuildMode;
 import 'package:patrol_cli/src/pubspec_reader.dart';
@@ -389,11 +390,15 @@ void main() {
         uninstall: false,
         checkCompatibility: false,
         prebuiltApksDir: '/apks',
+        videoConfig: VideoRecordingConfig(
+          enabled: true,
+          outputDirectory: 'videos',
+        ),
       );
 
       late Completer<void> attachCompleter;
       late Completer<void> backendExit;
-      void Function(Entry entry)? backendOnLogEntry;
+      bool Function()? backendAcceptLogEntries;
       var backendStarted = false;
       var hotRestarts = 0;
 
@@ -415,7 +420,7 @@ void main() {
       setUp(() {
         attachCompleter = Completer<void>();
         backendExit = Completer<void>();
-        backendOnLogEntry = null;
+        backendAcceptLogEntries = null;
         backendStarted = false;
         hotRestarts = 0;
 
@@ -436,11 +441,12 @@ void main() {
             hideTestSteps: any(named: 'hideTestSteps'),
             clearTestSteps: any(named: 'clearTestSteps'),
             onLogEntry: any(named: 'onLogEntry'),
+            videoConfig: any(named: 'videoConfig'),
+            acceptLogEntries: any(named: 'acceptLogEntries'),
           ),
         ).thenAnswer((invocation) {
-          backendOnLogEntry =
-              invocation.namedArguments[#onLogEntry]
-                  as void Function(Entry entry)?;
+          backendAcceptLogEntries =
+              invocation.namedArguments[#acceptLogEntries] as bool Function()?;
           backendStarted = true;
           return backendExit.future;
         });
@@ -484,16 +490,22 @@ void main() {
             ),
           ).captured.single;
           expect(apksDir, '/apks');
-          verify(
-            () => androidTestBackend.executePrebuilt(
-              any(),
-              any(),
-              showFlutterLogs: any(named: 'showFlutterLogs'),
-              hideTestSteps: any(named: 'hideTestSteps'),
-              clearTestSteps: any(named: 'clearTestSteps'),
-              onLogEntry: any(named: 'onLogEntry'),
-            ),
-          ).called(1);
+          final videoConfig =
+              verify(
+                    () => androidTestBackend.executePrebuilt(
+                      any(),
+                      any(),
+                      showFlutterLogs: any(named: 'showFlutterLogs'),
+                      hideTestSteps: any(named: 'hideTestSteps'),
+                      clearTestSteps: any(named: 'clearTestSteps'),
+                      onLogEntry: any(named: 'onLogEntry'),
+                      videoConfig: captureAny(named: 'videoConfig'),
+                      acceptLogEntries: any(named: 'acceptLogEntries'),
+                    ),
+                  ).captured.single
+                  as VideoRecordingConfig?;
+          // --record-video must keep working with prebuilt APKs.
+          expect(videoConfig, same(prebuiltOptions.videoConfig));
 
           // The APK runs the test bundled at build time; the requested target
           // is only hot restarted in once `flutter attach` has connected.
@@ -503,29 +515,21 @@ void main() {
         },
       );
 
-      test(
-        'holds back log entries until the requested target is hot restarted',
-        () async {
-          final received = <String>[];
-          unawaited(
-            buildService(
-              onLogEntry: (entry) => received.add((entry as LogEntry).message),
-            ).run(prebuiltOptions),
-          );
-          await _waitFor(() => backendOnLogEntry != null);
+      test('opens the log-entry gate only once the requested target is hot '
+          'restarted', () async {
+        unawaited(buildService(onLogEntry: (_) {}).run(prebuiltOptions));
+        await _waitFor(() => backendAcceptLogEntries != null);
 
-          // Emitted by the placeholder test baked into the APK -- must not be
-          // mistaken for a result of the requested target (e.g. by patrol_mcp).
-          backendOnLogEntry!(LogEntry(message: 'placeholder finished'));
-          expect(received, isEmpty);
+        // While the gate is closed the backend drops entries (see
+        // AndroidTestBackend.composeLogEntryCallback), so nothing the
+        // placeholder test emits reaches the caller or starts a recording.
+        expect(backendAcceptLogEntries!(), isFalse);
 
-          attachCompleter.complete();
-          await _waitFor(() => hotRestarts == 1);
+        attachCompleter.complete();
+        await _waitFor(() => hotRestarts == 1);
 
-          backendOnLogEntry!(LogEntry(message: 'requested target finished'));
-          expect(received, ['requested target finished']);
-        },
-      );
+        expect(backendAcceptLogEntries!(), isTrue);
+      });
 
       test(
         'fails instead of hanging when the instrumentation exits early',

--- a/packages/patrol_cli/test/commands/develop_service_test.dart
+++ b/packages/patrol_cli/test/commands/develop_service_test.dart
@@ -423,10 +423,15 @@ void main() {
           () => androidTestBackend.prepareSourcesForAttach(any()),
         ).thenAnswer((_) async {});
         when(
+          () => androidTestBackend.installPrebuiltApks(
+            apksDir: any(named: 'apksDir'),
+            device: any(named: 'device'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
           () => androidTestBackend.executePrebuilt(
             any(),
             any(),
-            apksDir: any(named: 'apksDir'),
             showFlutterLogs: any(named: 'showFlutterLogs'),
             hideTestSteps: any(named: 'hideTestSteps'),
             clearTestSteps: any(named: 'clearTestSteps'),
@@ -452,7 +457,14 @@ void main() {
             onQuit: any(named: 'onQuit'),
           ),
         ).thenAnswer((_) => attachCompleter.future);
-        when(() => flutterTool.hotRestart()).thenAnswer((_) => hotRestarts++);
+        when(
+          () => flutterTool.hotRestart(onCompleted: any(named: 'onCompleted')),
+        ).thenAnswer((invocation) {
+          hotRestarts++;
+          // The real FlutterTool fires this once `flutter attach` reports
+          // 'Restarted application ...'.
+          (invocation.namedArguments[#onCompleted] as void Function()?)?.call();
+        });
       });
 
       test(
@@ -466,17 +478,22 @@ void main() {
             () => androidTestBackend.prepareSourcesForAttach(any()),
           ).called(1);
           final apksDir = verify(
+            () => androidTestBackend.installPrebuiltApks(
+              apksDir: captureAny(named: 'apksDir'),
+              device: any(named: 'device'),
+            ),
+          ).captured.single;
+          expect(apksDir, '/apks');
+          verify(
             () => androidTestBackend.executePrebuilt(
               any(),
               any(),
-              apksDir: captureAny(named: 'apksDir'),
               showFlutterLogs: any(named: 'showFlutterLogs'),
               hideTestSteps: any(named: 'hideTestSteps'),
               clearTestSteps: any(named: 'clearTestSteps'),
               onLogEntry: any(named: 'onLogEntry'),
             ),
-          ).captured.single;
-          expect(apksDir, '/apks');
+          ).called(1);
 
           // The APK runs the test bundled at build time; the requested target
           // is only hot restarted in once `flutter attach` has connected.
@@ -507,6 +524,25 @@ void main() {
 
           backendOnLogEntry!(LogEntry(message: 'requested target finished'));
           expect(received, ['requested target finished']);
+        },
+      );
+
+      test(
+        'fails instead of hanging when the instrumentation exits early',
+        () async {
+          // The backend settles immediately (e.g. `am instrument` printed an
+          // error and returned) while attach never connects. Previously the
+          // CLI would sit on `flutter attach` forever.
+          backendExit.complete();
+
+          await expectLater(
+            buildService().run(prebuiltOptions),
+            throwsA(isA<ToolExit>()),
+          );
+          verifyNever(
+            () =>
+                flutterTool.hotRestart(onCompleted: any(named: 'onCompleted')),
+          );
         },
       );
 

--- a/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
@@ -75,6 +75,45 @@ void main() {
         await processStdout.close();
       },
     );
+
+    test(
+      'hotRestart onCompleted fires when the restart completes, not sooner',
+      () async {
+        final process = MockProcess();
+        final processStdin = _MockIOSink();
+        final processStdout = StreamController<List<int>>();
+        when(() => process.stdout).thenAnswer((_) => processStdout.stream);
+        when(
+          () => process.stderr,
+        ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
+        when(() => process.stdin).thenReturn(processStdin);
+        when(() => processStdin.add(any())).thenReturn(null);
+        when(
+          () => processManager.start(any()),
+        ).thenAnswer((_) async => process);
+
+        final attach = flutterTool.attach(
+          flutterCommand: flutterCommand,
+          deviceId: 'testDeviceId',
+          target: 'target',
+          appId: 'appId',
+          dartDefines: {},
+          openBrowser: false,
+        );
+        processStdout.add(utf8.encode('Flutter run key commands.\n'));
+        await attach;
+
+        var completed = false;
+        flutterTool.hotRestart(onCompleted: () => completed = true);
+        verify(() => processStdin.add('R'.codeUnits)).called(1);
+        expect(completed, isFalse);
+
+        processStdout.add(utf8.encode('Restarted application in 1,234ms.\n'));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(completed, isTrue);
+        await processStdout.close();
+      },
+    );
     test('attach passes deviceId correctly', () {
       final process = MockProcess();
       when(

--- a/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
@@ -11,8 +11,12 @@ import 'package:test/test.dart';
 
 import '../src/mocks.dart';
 
+class _MockIOSink extends Mock implements IOSink {}
+
 void main() {
   const flutterCommand = FlutterCommand('flutter');
+
+  setUpAll(() => registerFallbackValue(<int>[]));
 
   late FlutterTool flutterTool;
   late MockProcessManager processManager;
@@ -34,6 +38,43 @@ void main() {
   });
 
   group('FlutterTool', () {
+    test(
+      'hotRestart requested before attach completes is queued, then sent',
+      () async {
+        final process = MockProcess();
+        final processStdin = _MockIOSink();
+        final processStdout = StreamController<List<int>>();
+        when(() => process.stdout).thenAnswer((_) => processStdout.stream);
+        when(
+          () => process.stderr,
+        ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
+        when(() => process.stdin).thenReturn(processStdin);
+        when(() => processStdin.add(any())).thenReturn(null);
+        when(
+          () => processManager.start(any()),
+        ).thenAnswer((_) async => process);
+
+        final attach = flutterTool.attach(
+          flutterCommand: flutterCommand,
+          deviceId: 'testDeviceId',
+          target: 'target',
+          appId: 'appId',
+          dartDefines: {},
+          openBrowser: false,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        // Not attached yet: previously this was silently dropped.
+        flutterTool.hotRestart();
+        verifyNever(() => processStdin.add(any()));
+
+        processStdout.add(utf8.encode('Flutter run key commands.\n'));
+        await attach;
+
+        verify(() => processStdin.add('R'.codeUnits)).called(1);
+        await processStdout.close();
+      },
+    );
     test('attach passes deviceId correctly', () {
       final process = MockProcess();
       when(

--- a/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
+++ b/packages/patrol_cli/test/crossplatform/flutter_tool_test.dart
@@ -114,6 +114,54 @@ void main() {
         await processStdout.close();
       },
     );
+    test(
+      'hotRestart onFailed fires when Flutter rejects the restart',
+      () async {
+        final process = MockProcess();
+        final processStdin = _MockIOSink();
+        final processStdout = StreamController<List<int>>();
+        when(() => process.stdout).thenAnswer((_) => processStdout.stream);
+        when(
+          () => process.stderr,
+        ).thenAnswer((_) => Stream<List<int>>.fromIterable([]));
+        when(() => process.stdin).thenReturn(processStdin);
+        when(() => processStdin.add(any())).thenReturn(null);
+        when(
+          () => processManager.start(any()),
+        ).thenAnswer((_) async => process);
+
+        final attach = flutterTool.attach(
+          flutterCommand: flutterCommand,
+          deviceId: 'testDeviceId',
+          target: 'target',
+          appId: 'appId',
+          dartDefines: {},
+          openBrowser: false,
+        );
+        processStdout.add(utf8.encode('Flutter run key commands.\n'));
+        await attach;
+
+        var completed = false;
+        var failed = false;
+        flutterTool.hotRestart(
+          onCompleted: () => completed = true,
+          onFailed: () => failed = true,
+        );
+
+        processStdout.add(
+          utf8.encode('Try again after fixing the above error(s).\n'),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(failed, isTrue);
+        expect(completed, isFalse);
+
+        // A later successful restart must not fire the stale callback again.
+        processStdout.add(utf8.encode('Restarted application in 1,234ms.\n'));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(completed, isFalse);
+        await processStdout.close();
+      },
+    );
     test('attach passes deviceId correctly', () {
       final process = MockProcess();
       when(

--- a/packages/patrol_mcp/CHANGELOG.md
+++ b/packages/patrol_mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- Wait for the previous develop session to finish before starting a new one.
+  `quit` followed quickly by `run` could otherwise let the old session's
+  cleanup delete the entrypoint the new session had just generated
+  ("Target file ... not found"), which is easy to hit with
+  `PATROL_FLAGS=--use-prebuilt-apks=<dir>` where a session starts in seconds
+  instead of minutes (#3266).
 - Fix the `screenshot` tool on iOS: it now captures to a temp file instead of
   `/dev/stdout`, since `simctl io screenshot` writes atomically and can't
   create its temp file inside `/dev` (#3257).

--- a/packages/patrol_mcp/lib/src/patrol_session.dart
+++ b/packages/patrol_mcp/lib/src/patrol_session.dart
@@ -256,12 +256,17 @@ final class PatrolSession {
     final previousRun = _runFuture;
     if (previousRun != null) {
       logger.fine('Waiting for the previous develop session to finish');
-      await previousRun.timeout(
-        const Duration(seconds: 30),
-        onTimeout: () => logger.warning(
-          'Previous develop session did not finish in 30 s; continuing',
-        ),
-      );
+      try {
+        await previousRun.timeout(const Duration(seconds: 30));
+      } on TimeoutException {
+        // Starting anyway would reintroduce the race this wait exists to
+        // prevent: the old DevelopService could still dispose shared session
+        // state and delete the entrypoint the new session is about to
+        // generate.
+        return 'The previous develop session is still shutting down (waited '
+            '30 s). Wait a moment and call run again; restart the MCP server '
+            'if this persists.';
+      }
       _runFuture = null;
     }
 
@@ -419,29 +424,35 @@ final class PatrolSession {
       // restart). Test completion is detected by callbacks, not by run()
       // returning.
       final runFuture = developService.run(options);
-      // Swallow errors here; they are reported by the chain below.
-      _runFuture = runFuture.then<void>((_) {}, onError: (Object _) {});
-      unawaited(
-        Future.any([runFuture, exitCompleter.future])
-            .then((_) {
-              // Session ended (e.g. user sent quit). If tests haven't already
-              // been marked as done by callbacks, mark idle.
-              if (_testState == TestState.running) {
-                _testState = TestState.idle;
-              }
-              _completeFinish();
-              unawaited(_cleanup());
-            })
-            .catchError((Object err, StackTrace st) {
-              logger.warning('Develop session error: $err\n$st');
-              _pushOutput('ERROR: $err');
-              if (_testState == TestState.running) {
-                _testState = TestState.finishedFailed;
-              }
-              _completeFinish();
-              unawaited(_cleanup());
-            }),
-      );
+      // The chain below is this session's full teardown: _cleanup() plus
+      // run()'s own finally block (finalizer uninstall, entrypoint proxy
+      // cleanup). _start awaits it (via _runFuture) before a new session may
+      // start, so the old session can't dispose shared state or delete the
+      // new session's freshly generated entrypoint from under it.
+      final sessionDone = Future.any([runFuture, exitCompleter.future])
+          .then((_) async {
+            // Session ended (e.g. user sent quit). If tests haven't already
+            // been marked as done by callbacks, mark idle.
+            if (_testState == TestState.running) {
+              _testState = TestState.idle;
+            }
+            _completeFinish();
+            await _cleanup();
+            // On quit, exitCompleter settles this chain while run() is still
+            // in its finally block - wait for that too.
+            await runFuture;
+          })
+          .catchError((Object err, StackTrace st) async {
+            logger.warning('Develop session error: $err\n$st');
+            _pushOutput('ERROR: $err');
+            if (_testState == TestState.running) {
+              _testState = TestState.finishedFailed;
+            }
+            _completeFinish();
+            await _cleanup();
+          });
+      _runFuture = sessionDone;
+      unawaited(sessionDone);
     });
   }
 

--- a/packages/patrol_mcp/lib/src/patrol_session.dart
+++ b/packages/patrol_mcp/lib/src/patrol_session.dart
@@ -211,6 +211,11 @@ final class PatrolSession {
   String? _finishWarning;
 
   Completer<void>? _finishCompleter;
+
+  /// The previous session's `DevelopService.run()`; it keeps running past
+  /// quit (finalizer uninstall, entrypoint proxy cleanup) and must finish
+  /// before a new session generates its own entrypoint.
+  Future<void>? _runFuture;
   DisposeScope? _disposeScope;
   StreamController<List<int>>? _stdinController;
   DevelopService? _developService;
@@ -247,6 +252,18 @@ final class PatrolSession {
     }
 
     final logger = Logger('PatrolSession');
+
+    final previousRun = _runFuture;
+    if (previousRun != null) {
+      logger.fine('Waiting for the previous develop session to finish');
+      await previousRun.timeout(
+        const Duration(seconds: 30),
+        onTimeout: () => logger.warning(
+          'Previous develop session did not finish in 30 s; continuing',
+        ),
+      );
+      _runFuture = null;
+    }
 
     await _startLogStreamingAndTerminal();
 
@@ -401,8 +418,11 @@ final class PatrolSession {
       // session (gradle/xcodebuild + flutter attach stay alive for hot
       // restart). Test completion is detected by callbacks, not by run()
       // returning.
+      final runFuture = developService.run(options);
+      // Swallow errors here; they are reported by the chain below.
+      _runFuture = runFuture.then<void>((_) {}, onError: (Object _) {});
       unawaited(
-        Future.any([developService.run(options), exitCompleter.future])
+        Future.any([runFuture, exitCompleter.future])
             .then((_) {
               // Session ended (e.g. user sent quit). If tests haven't already
               // been marked as done by callbacks, mark idle.


### PR DESCRIPTION

## Summary

`patrol develop` always builds the app before attaching. That makes it impossible to
build once (e.g. on CI, or on a teammate's machine) and iterate with Hot Restart
somewhere else — even though Hot Restart itself recompiles the Dart kernel from the
sources of the machine running `flutter attach`, so the build and the attach never had
to happen on the same host.

This PR adds the two halves needed to split them, Android only:

- **`patrol build android --develop --target <test>`** builds the same two APKs
  `patrol develop` would build (app + androidTest) for a single target, with Hot Restart
  enabled (`PATROL_HOT_RESTART=true`). The bundled test is a placeholder — it is replaced
  on the first Hot Restart.
- **`patrol develop --use-prebuilt-apks <dir>`** skips Gradle entirely: installs both
  APKs with `adb install -r -t`, starts the Patrol instrumentation with `am instrument`
  (resolving the component from `pm list instrumentation`, like `test-without-building`),
  runs `flutter attach`, and hot restarts the requested target as soon as attach connects.
  Also reachable from `patrol_mcp` via `PATROL_FLAGS=--use-prebuilt-apks=<dir>` without
  MCP changes.

Measured on a small app (M-series Mac, warm Gradle daemon): time from start to an active
Hot Restart session drops from **174 s** to **43 s**; hot restarts are unchanged (~5–12 s);
switching to a new test file (`quit` + `run`) takes ~32 s instead of another Gradle build.

## Why the APKs must be develop-mode

The native side of a Patrol build does not depend on the Dart target at all — only the
baked kernel does. But it must be a develop-mode kernel: with `PATROL_HOT_RESTART=true`
the Dart side never reports `PatrolAppService` readiness, so `PatrolJUnitRunner` blocks in
`waitForPatrolAppService()` and the app process stays alive for `flutter attach`. A regular
`patrol build android` bundle would have the native runner list and drive tests over RPC,
and the first Hot Restart (which kills `PatrolAppService`) would end the instrumentation —
and the app with it.

## Two things this fixes along the way

1. **`flutter attach` on a never-built checkout loses the Dart plugin registrant.**
   `flutter attach` spawns the frontend_server before running the source generators and
   passes `-Dflutter.dart_plugin_registrant` only if
   `.dart_tool/flutter_build/dart_plugin_registrant.dart` already exists. On a fresh
   checkout it doesn't, so Dart-registered plugins (e.g. `shared_preferences_android`)
   throw `MissingPluginException` after the first Hot Restart. Regular `patrol develop`
   never hits this because Gradle generates the file first. With prebuilt APKs we run a
   one-off `flutter build bundle --debug` (Dart-only, ~20 s) before attaching
   (`AndroidTestBackend.prepareSourcesForAttach`).
2. **A Hot Restart requested before attach connects was silently dropped**
   (`FlutterTool`: "not attached to the app yet!"). With prebuilt APKs the app is up in
   seconds, so `patrol_mcp`'s first `run` returned the placeholder's result before attach
   and the next `run`'s `R` vanished, hanging MCP until its timeout. `R` is now queued and
   sent once attached, and in prebuilt mode `DevelopService` hot restarts automatically
   after attach and holds back `onLogEntry` until then, so callers only ever see results
   of the requested target. The same drop could hit existing flows with a slow attach.
3. **`patrol_mcp`: `quit` + `run` raced with the previous session's cleanup.**
   `DevelopService.run()` keeps running after quit (finalizer uninstall, then
   `deleteEntrypointProxy`) and nobody awaited it, so a new session that started quickly
   had its freshly generated `integration_test/patrol_test_bundle.dart` deleted from under
   it ("Target file ... not found"). `PatrolSession._start` now awaits the previous run
   (30 s cap). Masked so far by the multi-minute Gradle build of a new session.

## Changes

- `patrol_cli`
  - `develop_arg_parser.dart`, `develop_options.dart`: `--use-prebuilt-apks`.
  - `develop_service.dart`: Android-only guard; skip build; `prepareSourcesForAttach`;
    `executePrebuilt`; auto Hot Restart after attach; gated `onLogEntry`.
  - `android_test_backend.dart`: `prepareSourcesForAttach`, `executePrebuilt`.
  - `flutter_tool.dart`: `hotRestart()`, queued restart before attach.
  - `build_android.dart`: `--develop`.
  - `CHANGELOG.md`, tests (`develop_service_test`, `flutter_tool_test`,
    `build_android_command_test`, new `develop_options_test`).
- `patrol_mcp`
  - `patrol_session.dart`: await the previous develop run before starting a new session.
- `docs/cli-commands/build.mdx`: new section.

## Testing

- `dart analyze` clean in both packages; `dart test` green.
- Manual, Android emulator (API 34), Flutter 3.44.9, `patrol` 4.9.0, on a project with
  `test_directory: patrol_test` and the Android Test Orchestrator configured:
  1. `patrol build android --develop --target patrol_test/login_test.dart` on machine A.
  2. Fresh clone of the same commit on "machine B" (never built; `android/gradlew` made
     non-executable to prove no Gradle runs), `patrol develop --use-prebuilt-apks <dir>
     --target patrol_test/login_test.dart`: attached in 43 s, edited test hot restarted in
     11.6 s; a brand-new test file added after the build runs after a Hot Restart (7–9 s).
  3. `patrol_mcp` with `PATROL_FLAGS=--use-prebuilt-apks=<dir> --device=<id>`: 5 consecutive
     `run` → `screenshot` → `native-tree` → edit → `run` iterations, all passing; `quit` +
     `run(new file)` in 32 s.
  4. Negative: attaching with a different Flutter version fails on the device with
     `Invalid kernel binary format version` (the tool still prints "Restarted application")
     — documented as a requirement; a follow-up could validate versions up front.

## Limitations / follow-ups

- Android only (`--use-prebuilt-apks` is rejected on other platforms).
- Hot Restart applies Dart changes only; native changes still need a new build.
- The Flutter/Dart SDK, `--dart-define`s, `--flavor` and Patrol ports must match the
  build. A machine-readable manifest written by `--develop` and validated by
  `--use-prebuilt-apks` would turn today's runtime symptoms into an up-front error.
- `patrol_mcp` still refuses `run` with a different test file while a session is live;
  since the bundle is just a generated file, regenerating it and hot restarting would
  replace `quit` + `run` (32 s) with a single Hot Restart (~8 s).
- The Dart plugin registrant behaviour of `flutter attach` looks worth an upstream Flutter
  issue.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Aef3wqzNAirusCutGjENh
