### PR TITLE
feat(patrol): native screenshots on iOS (failure + on-demand)

### DIFF
--- a/.github/workflows/test-ios-device.yaml
+++ b/.github/workflows/test-ios-device.yaml
@@ -119,6 +119,57 @@ jobs:
           echo "TESTS_EXIT_CODE=$TESTS_EXIT_CODE" >> "$GITHUB_OUTPUT"
           exit $TESTS_EXIT_CODE
 
+      # Patrol screenshots (failure + on-demand) and failure recordings that
+      # run_ios_testlab pulled from the .xcresult in the FTL result bundle. Run
+      # even when tests fail, so failure artifacts are always collected.
+      - name: Upload Patrol screenshots to artifacts
+        id: upload_screenshots
+        if: ${{ (failure() || success()) && contains(fromJson('["success", "failure"]'), steps.tests_step.conclusion) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: iOS Patrol screenshots from ${{ matrix.device_model }}
+          path: dev/e2e_app/ios_screenshots/
+          if-no-files-found: warn
+
+      - name: Upload failure recordings to artifacts
+        id: upload_ios_videos
+        if: ${{ (failure() || success()) && contains(fromJson('["success", "failure"]'), steps.tests_step.conclusion) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: iOS failure recordings from ${{ matrix.device_model }}
+          path: dev/e2e_app/ios_videos/
+          if-no-files-found: warn
+
+      # GitHub can't preview artifact zips, and its Summary won't render our
+      # screenshots inline (they aren't public and data: URIs / signed <img> URLs
+      # are stripped by the sanitizer), so list them and link the downloadable
+      # artifacts.
+      - name: List screenshots in job summary
+        if: ${{ (failure() || success()) && contains(fromJson('["success", "failure"]'), steps.tests_step.conclusion) }}
+        working-directory: dev/e2e_app
+        run: |
+          shots_dir="ios_screenshots"
+          echo "### 📸 Patrol screenshots (${{ matrix.device_model }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -d "$shots_dir" ] && [ -n "$(ls -A "$shots_dir" 2>/dev/null)" ]; then
+            for png in "$shots_dir"/*.png; do
+              [ -e "$png" ] || continue
+              echo "- \`$(basename "$png")\`" >> "$GITHUB_STEP_SUMMARY"
+            done
+            if [ -n "${{ steps.upload_screenshots.outputs.artifact-url }}" ]; then
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "[⬇️ Download screenshots](${{ steps.upload_screenshots.outputs.artifact-url }})" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "_No Patrol screenshots were captured._" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ -n "${{ steps.upload_ios_videos.outputs.artifact-url }}" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "[⬇️ Download failure recordings](${{ steps.upload_ios_videos.outputs.artifact-url }})" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   call_send_slack_message:
     name: Notify on Slack
     uses: ./.github/workflows/send-slack-message.yaml

--- a/dev/e2e_app/pubspec.yaml
+++ b/dev/e2e_app/pubspec.yaml
@@ -55,6 +55,7 @@ flutter:
 
 patrol:
   app_name: Patrol example
+  screenshot_on_failure: true
   android:
     package_name: pl.leancode.patrol.e2e_app
   ios:

--- a/dev/e2e_app/run_ios_testlab
+++ b/dev/e2e_app/run_ios_testlab
@@ -23,9 +23,102 @@ else
     echo "Using locale: $IOS_DEVICE_LOCALE"
 fi
 
+RESULTS_BUCKET="patrol_runs"
+# A fixed results dir so we can pull the .xcresult back afterwards.
+RESULTS_DIR="${RESULTS_DIR:-ios_run_$(date -u +%Y%m%d_%H%M%S)}"
+
+# Don't let a failing test (gcloud exits non-zero) abort the screenshot pull.
+set +e
 gcloud firebase test ios run \
 	--type xctest \
 	--test "build/ios_integ/Build/Products/ios_tests.zip" \
 	--device model="$IOS_DEVICE_MODEL",version="$IOS_DEVICE_VERSION",locale="$IOS_DEVICE_LOCALE",orientation=portrait \
 	--timeout 30m \
-	--results-bucket="patrol_runs"
+	--results-bucket="$RESULTS_BUCKET" \
+	--results-dir="$RESULTS_DIR"
+TESTS_EXIT_CODE=$?
+set -e
+
+# Pull native artifacts off Firebase Test Lab. On iOS the screenshots are
+# attached to the test's .xcresult, which FTL uploads under
+# <device>/TestLogs/*.xcresult in the results bucket (there is no
+# --directories-to-pull for iOS like on Android). We download the result bundle
+# and export the Patrol screenshots (named `patrol_*`) as PNGs, plus the screen
+# recording (.mp4) for each failing test. Best-effort: never fails the run.
+# The screenshot filter mirrors `IOSTestBackend._copyScreenshotsFromExport` in
+# patrol_cli (`patrol_` prefix / failure flag) — keep the two in sync.
+SCREENSHOTS_DIR="${IOS_SCREENSHOTS_DIR:-ios_screenshots}"
+VIDEOS_DIR="${IOS_VIDEOS_DIR:-ios_videos}"
+pull_artifacts() {
+	command -v xcrun >/dev/null 2>&1 || { echo "xcrun not found; skipping artifact pull"; return 0; }
+
+	local pull_dir attach_dir
+	pull_dir="$(mktemp -d)"
+	rm -rf "$SCREENSHOTS_DIR" "$VIDEOS_DIR"
+	mkdir -p "$SCREENSHOTS_DIR" "$VIDEOS_DIR"
+
+	# Copy the whole results dir; the .xcresult prefix can't be cp'd directly
+	# ("no objects matched"), but its parent recurses fine.
+	if ! gcloud storage cp -r "gs://$RESULTS_BUCKET/$RESULTS_DIR" "$pull_dir" 2>/dev/null; then
+		echo "Could not download results from gs://$RESULTS_BUCKET/$RESULTS_DIR; skipping artifact pull"
+		rm -rf "$pull_dir"
+		return 0
+	fi
+
+	while IFS= read -r xcresult; do
+		attach_dir="$(mktemp -d)"
+		if xcrun xcresulttool export attachments --path "$xcresult" --output-path "$attach_dir" >/dev/null 2>&1; then
+			python3 - "$attach_dir" "$SCREENSHOTS_DIR" "$VIDEOS_DIR" <<'PY'
+import json, os, re, shutil, sys
+attach_dir, shots_dir, videos_dir = sys.argv[1], sys.argv[2], sys.argv[3]
+manifest = os.path.join(attach_dir, "manifest.json")
+
+
+def slug(s):
+    return re.sub(r"[^A-Za-z0-9._-]+", "_", s)[:80]
+
+
+if os.path.exists(manifest):
+    for test in json.load(open(manifest)):
+        tid = slug(test.get("testIdentifier", "unknown").split("/")[-1])
+        atts = test.get("attachments", [])
+        # A screen recording is only interesting for a test that failed.
+        failed = any(
+            a.get("isAssociatedWithFailure")
+            or a.get("suggestedHumanReadableName", "").startswith("patrol_failure")
+            for a in atts
+        )
+        vid_i = 0
+        for a in atts:
+            name = a.get("suggestedHumanReadableName", "")
+            src = os.path.join(attach_dir, a["exportedFileName"])
+            if name.startswith("patrol_"):
+                shutil.copy(src, os.path.join(shots_dir, f"{tid}__{slug(name)}"))
+            elif failed and a["exportedFileName"].lower().endswith(".mp4"):
+                shutil.copy(src, os.path.join(videos_dir, f"{tid}__{vid_i}.mp4"))
+                vid_i += 1
+PY
+		fi
+		rm -rf "$attach_dir"
+	done < <(find "$pull_dir" -type d -name '*.xcresult')
+
+	rm -rf "$pull_dir"
+
+	if [ -n "$(ls -A "$SCREENSHOTS_DIR" 2>/dev/null)" ]; then
+		echo "Patrol screenshots saved to $SCREENSHOTS_DIR:"
+		ls -1 "$SCREENSHOTS_DIR"
+	else
+		echo "No Patrol screenshots found in the result bundle."
+		rmdir "$SCREENSHOTS_DIR" 2>/dev/null || true
+	fi
+	if [ -n "$(ls -A "$VIDEOS_DIR" 2>/dev/null)" ]; then
+		echo "Failure recordings saved to $VIDEOS_DIR:"
+		ls -1 "$VIDEOS_DIR"
+	else
+		rmdir "$VIDEOS_DIR" 2>/dev/null || true
+	fi
+}
+
+pull_artifacts || echo "Artifact pull failed; continuing."
+
+exit "$TESTS_EXIT_CODE"

--- a/docs/cli-commands/test.mdx
+++ b/docs/cli-commands/test.mdx
@@ -187,6 +187,11 @@ Videos are saved as `.mp4` files in `<test-directory>/videos` (override with
 - Physical iOS devices are not supported.
 - `--video-size` and `--video-bit-rate` apply to Android only.
 
+On a device farm like Firebase Test Lab, `--record-video` doesn't apply (the
+tests run via `gcloud`, not `patrol test`), but FTL records its own per-test
+video into the iOS `.xcresult`. Pull it from the native artifacts the same way as
+[iOS screenshots](#ios) — the exported attachments include the `.mp4` recordings.
+
 <Warning>
     Recording is skipped on unsupported devices, and the test still runs.
 </Warning>
@@ -199,7 +204,7 @@ Videos are saved as `.mp4` files in `<test-directory>/videos` (override with
 
 ### Screenshots
 
-Patrol can capture native screenshots on Android — automatically on test
+Patrol can capture native screenshots on Android and iOS — automatically on test
 failure (opt-in) and on demand from a test:
 
 - Enable failure screenshots by adding `screenshot_on_failure: true` to the
@@ -222,8 +227,48 @@ collects them:
 - **Firebase Test Lab**: pass `--directories-to-pull=/sdcard/Download/screenshots`.
 
 <Info>
-    Android only for now (a no-op on iOS). Works in the `patrol build android`
-    APK as well as `patrol test`.
+    Works in the `patrol build android` APK as well as `patrol test`.
+</Info>
+
+#### iOS
+
+The same API works on iOS: enable `screenshot_on_failure: true` and/or call
+`await $.takeNativeScreenshot('tag')`. The screenshot is captured natively at the
+failure moment (via the Dart failure hook, before teardown) and attached to the
+test's `.xcresult` bundle, which `xcodebuild` writes on the host — so it works on
+simulators and physical devices alike, with no on-device pull. Requires Xcode 16
+or newer.
+
+On `patrol test`, Patrol extracts the images from the `.xcresult` into
+`<test-directory>/screenshots` after the run (override with
+`--screenshots-output-dir`). On device farms:
+
+- **BrowserStack XCUITest**: enable the result bundle
+  (`"enableResultBundle": true`); the `.xcresult` (with the screenshots) comes
+  back with the session results.
+- **Firebase Test Lab**: FTL uploads the `.xcresult` to the results bucket, nested
+  under `<device>/TestLogs/*.xcresult`. Because the tests run via `gcloud` (not
+  `patrol test`), pull the bundle after the run and export the Patrol attachments
+  — their names start with `patrol_`:
+
+  ```bash
+  # after `gcloud firebase test ios run` finishes, from the results bucket:
+  gcloud storage cp -r "gs://<results-bucket>/<run>/<device>/TestLogs" ./ftl_logs
+  xcrun xcresulttool export attachments \
+    --path "$(find ./ftl_logs -name '*.xcresult' -type d | head -1)" \
+    --output-path ./ios_screenshots
+  # keep the PNGs whose manifest.json `suggestedHumanReadableName` starts with `patrol_`
+  ```
+
+  Patrol's own
+  [`run_ios_testlab`](https://github.com/leancodepl/patrol/blob/master/dev/e2e_app/run_ios_testlab)
+  script and
+  [device workflow](https://github.com/leancodepl/patrol/blob/master/.github/workflows/test-ios-device.yaml)
+  do exactly this and upload the screenshots (and each failing test's screen
+  recording) as CI artifacts — copy them as a starting point.
+
+<Info>
+    iOS requires Xcode 16 or newer (`xcrun xcresulttool export attachments`).
 </Info>
 
 <Warning>

--- a/docs/documentation/index.mdx
+++ b/docs/documentation/index.mdx
@@ -135,7 +135,7 @@ Check out our video version of this tutorial on YouTube!
     <Info>
         **Native failure screenshots (device farms)**: set
         `screenshot_on_failure: true` to capture the failing screen and collect
-        it from your device-farm run (Android only, off by default). See
+        it from your device-farm run (Android and iOS, off by default). See
         [Screenshots](/cli-commands/test#screenshots) for setup and the per-farm
         details.
     </Info>

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Android: keep third-party `AccessibilityService`s running during the test session again. `AndroidAutomatorConfig.dontSuppressAccessibilityServices` now defaults to `true` (it was effectively `false` since 4.8.0) and is configurable, also via the `PATROL_ANDROID_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` dart-define. (#3227)
 - Report uncaught exceptions (e.g. from `onPressed`) in `patrol develop` instead of silently passing. (#3200)
 - Add opt-in native failure screenshots on Android for device farms (e.g. BrowserStack, Firebase Test Lab): set `screenshot_on_failure: true` in the pubspec's `patrol` section to capture the failing screen from the Dart failure path (before teardown). The screenshot is written to the folder named after the running JUnit test (read from its `Description`), so it matches what the farm reports. Also adds `$.takeNativeScreenshot('tag')` for on-demand captures. Off by default; iOS is a no-op for now. (#3222)
+- Extend native screenshots to iOS. With `screenshot_on_failure: true`, the Dart failure path captures the failing screen before teardown (`patrol_failure`); `$.takeNativeScreenshot('tag')` works on iOS too (attached as `patrol_<tag>`). Captures are buffered and attached to the test's `.xcresult`, which `xcodebuild` writes on the host, so this works on simulators and physical devices (e.g. Firebase Test Lab). `patrol test` extracts them to `<test-directory>/screenshots`. (#3271)
 
 ## 4.9.0
 

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
@@ -749,6 +749,10 @@ class Contracts {
     val tag: String
   )
 
+  data class IOSTakeNativeScreenshotRequest (
+    val tag: String
+  )
+
   data class IOSTakeCameraPhotoRequest (
     val shutterButtonSelector: IOSSelector? = null,
     val doneButtonSelector: IOSSelector? = null,

--- a/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Automator/Automator.swift
+++ b/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Automator/Automator.swift
@@ -218,6 +218,9 @@
       withTimeout timeout: TimeInterval?
     ) throws
 
+    // MARK: Screenshots
+    func takeNativeScreenshot(name: String) throws
+
     // MARK: Volume settings
     func pressVolumeUp() throws
     func pressVolumeDown() throws

--- a/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Automator/IOSAutomator.swift
+++ b/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Automator/IOSAutomator.swift
@@ -279,6 +279,19 @@
       }
     }
 
+    // MARK: Screenshots
+    func takeNativeScreenshot(name: String) throws {
+      runAction("taking native screenshot \(name)") {
+        let screenshot = XCUIScreen.main.screenshot()
+        // Prefixed so the CLI can tell Patrol screenshots apart from XCTest's
+        // own automatic attachments when it extracts them from the .xcresult.
+        PatrolScreenshotBuffer.sharedBuffer.add(
+          name: "patrol_\(name)",
+          screenshot: screenshot
+        )
+      }
+    }
+
     // MARK: Volume settings
     func pressVolumeUp() throws {
       #if targetEnvironment(simulator)

--- a/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Automator/MacOSAutomator.swift
+++ b/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Automator/MacOSAutomator.swift
@@ -153,6 +153,13 @@
       }
     }
 
+    // MARK: Screenshots
+    func takeNativeScreenshot(name: String) throws {
+      try runAction("takeNativeScreenshot") {
+        throw PatrolError.methodNotImplemented("takeNativeScreenshot")
+      }
+    }
+
     // MARK: Volume settings
     func pressVolumeUp() throws {
       try runAction("pressing volume up") {

--- a/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/AutomatorServer.swift
+++ b/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/AutomatorServer.swift
@@ -161,6 +161,13 @@
       }
     }
 
+    // MARK: Screenshots
+    func takeNativeScreenshot(request: IOSTakeNativeScreenshotRequest) throws {
+      return try runCatching {
+        try automator.takeNativeScreenshot(name: request.tag)
+      }
+    }
+
     // MARK: Volume settings
     func pressVolumeUp() throws {
       return try runCatching {

--- a/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Contracts.swift
+++ b/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Contracts.swift
@@ -492,6 +492,10 @@ public struct AndroidTakeNativeScreenshotRequest: Codable {
   public var tag: String
 }
 
+public struct IOSTakeNativeScreenshotRequest: Codable {
+  public var tag: String
+}
+
 public struct IOSTakeCameraPhotoRequest: Codable {
   public var shutterButtonSelector: IOSSelector?
   public var doneButtonSelector: IOSSelector?

--- a/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/IosAutomatorServer.swift
+++ b/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/IosAutomatorServer.swift
@@ -16,6 +16,7 @@ protocol IosAutomatorServer {
     func tapAt(request: IOSTapAtRequest) throws
     func waitUntilVisible(request: IOSWaitUntilVisibleRequest) throws
     func swipe(request: IOSSwipeRequest) throws
+    func takeNativeScreenshot(request: IOSTakeNativeScreenshotRequest) throws
     func closeHeadsUpNotification() throws
     func tapOnNotification(request: IOSTapOnNotificationRequest) throws
     func tapBackToPreviousAppButton(request: IOSTapBackToPreviousAppButtonRequest) throws
@@ -75,6 +76,12 @@ extension IosAutomatorServer {
     private func swipeHandler(request: HTTPRequest) throws -> HTTPResponse {
         let requestArg = try JSONDecoder().decode(IOSSwipeRequest.self, from: request.body)
         try swipe(request: requestArg)
+        return HTTPResponse(.ok)
+    }
+
+    private func takeNativeScreenshotHandler(request: HTTPRequest) throws -> HTTPResponse {
+        let requestArg = try JSONDecoder().decode(IOSTakeNativeScreenshotRequest.self, from: request.body)
+        try takeNativeScreenshot(request: requestArg)
         return HTTPResponse(.ok)
     }
 
@@ -179,6 +186,11 @@ extension IosAutomatorServer {
             request in handleRequest(
                 request: request,
                 handler: swipeHandler)
+        }
+        server.route(.POST, "takeNativeScreenshot") {
+            request in handleRequest(
+                request: request,
+                handler: takeNativeScreenshotHandler)
         }
         server.route(.POST, "closeHeadsUpNotification") {
             request in handleRequest(

--- a/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/PatrolScreenshotBuffer.swift
+++ b/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/PatrolScreenshotBuffer.swift
@@ -1,0 +1,45 @@
+#if PATROL_ENABLED && os(iOS)
+
+  import XCTest
+
+  /// Collects on-demand screenshots (`$.takeNativeScreenshot(...)`) taken while a
+  /// Dart test runs, so the runner can attach them to that test's `.xcresult`.
+  ///
+  /// The automation server handles requests on a background thread, but XCTest
+  /// attachments must be added from the test method. So the automator captures
+  /// the image and parks it here; the runner drains the buffer on the test
+  /// thread once the Dart test finishes (see PatrolIntegrationTestIosRunner.h).
+  @objc public class PatrolScreenshotBuffer: NSObject {
+    @objc public static let sharedBuffer = PatrolScreenshotBuffer()
+
+    private let lock = NSLock()
+    private var pending: [(name: String, screenshot: XCUIScreenshot)] = []
+
+    private override init() {
+      super.init()
+    }
+
+    /// Parks a captured [screenshot] under [name] for later attachment.
+    func add(name: String, screenshot: XCUIScreenshot) {
+      lock.lock()
+      defer { lock.unlock() }
+      pending.append((name: name, screenshot: screenshot))
+    }
+
+    /// Attaches every parked screenshot to [testCase] and clears the buffer.
+    @objc public func drainAttaching(to testCase: XCTestCase) {
+      lock.lock()
+      let items = pending
+      pending.removeAll()
+      lock.unlock()
+
+      for item in items {
+        let attachment = XCTAttachment(screenshot: item.screenshot)
+        attachment.name = item.name
+        attachment.lifetime = .keepAlways
+        testCase.add(attachment)
+      }
+    }
+  }
+
+#endif

--- a/packages/patrol/darwin/patrol/Sources/patrol/include/PatrolIntegrationTestIosRunner.h
+++ b/packages/patrol/darwin/patrol/Sources/patrol/include/PatrolIntegrationTestIosRunner.h
@@ -40,6 +40,7 @@
   +(BOOL)isPatrolDevelopMode {                                                                                      \
     return [[NSProcessInfo processInfo].environment[@"PATROL_DEVELOP"] isEqualToString:@"1"];                       \
   }                                                                                                                 \
+                                                                                                                    \
   +(void)launchPatrolAppWithServer : (PatrolServer *)server {                                                       \
     server.appReady = NO;                                                                                           \
     XCUIApplication *app = [[XCUIApplication alloc] init];                                                          \
@@ -361,6 +362,7 @@
         if (response && response.skipped) {                                                                         \
           XCTSkip(@"%@", details);                                                                                  \
         }                                                                                                           \
+        [[PatrolScreenshotBuffer sharedBuffer] drainAttachingTo:_self];                                             \
         XCTAssertTrue(passed, @"%@", details);                                                                      \
       });                                                                                                           \
       SEL selector = NSSelectorFromString(selectorName);                                                            \
@@ -588,6 +590,7 @@
     if (response && response.skipped) {                                                                                \
       XCTSkip(@"%@", details);                                                                                         \
     }                                                                                                                  \
+    [[PatrolScreenshotBuffer sharedBuffer] drainAttachingTo:self];                                                     \
     XCTAssertTrue(passed, @"%@", details);                                                                             \
   }
 

--- a/packages/patrol/darwin/patrol/Sources/patrol/include/patrol.h
+++ b/packages/patrol/darwin/patrol/Sources/patrol/include/patrol.h
@@ -21,6 +21,8 @@
 // Under CocoaPods this file is unused: everything compiles into one `patrol`
 // module and the Swift @objc classes are visible directly.
 
+@class XCTestCase;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /// Implemented in PatrolImpl (Swift). Declared here so runner macros compile
@@ -51,6 +53,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ObjCLocalization : NSObject
 + (NSString *)getLocalizedStringWithKey:(NSString *)key;
+@end
+
+@interface PatrolScreenshotBuffer : NSObject
+@property(class, nonatomic, readonly, strong) PatrolScreenshotBuffer *sharedBuffer;
+- (void)drainAttachingTo:(XCTestCase *)testCase;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/patrol/lib/src/custom_finders/patrol_integration_tester.dart
+++ b/packages/patrol/lib/src/custom_finders/patrol_integration_tester.dart
@@ -66,7 +66,8 @@ class PatrolIntegrationTester extends finders.PatrolTester {
   }
 
   /// Captures a native screenshot ([tag] is added to the file name) for a device
-  /// farm to collect. Android only (a no-op elsewhere); never throws.
+  /// farm to collect. Supported on Android and iOS (a no-op elsewhere); never
+  /// throws.
   Future<void> takeNativeScreenshot(String tag) async {
     try {
       await platformAutomator.takeNativeScreenshot(tag);

--- a/packages/patrol/lib/src/platform/contracts/contracts.dart
+++ b/packages/patrol/lib/src/platform/contracts/contracts.dart
@@ -1286,6 +1286,21 @@ class AndroidTakeNativeScreenshotRequest with Equatable {
 }
 
 @JsonSerializable()
+class IOSTakeNativeScreenshotRequest with Equatable {
+  const IOSTakeNativeScreenshotRequest({required this.tag});
+
+  factory IOSTakeNativeScreenshotRequest.fromJson(Map<String, dynamic> json) =>
+      _$IOSTakeNativeScreenshotRequestFromJson(json);
+
+  final String tag;
+
+  Map<String, dynamic> toJson() => _$IOSTakeNativeScreenshotRequestToJson(this);
+
+  @override
+  List<Object?> get props => [tag];
+}
+
+@JsonSerializable()
 class IOSTakeCameraPhotoRequest with Equatable {
   const IOSTakeCameraPhotoRequest({
     this.shutterButtonSelector,

--- a/packages/patrol/lib/src/platform/contracts/contracts.g.dart
+++ b/packages/patrol/lib/src/platform/contracts/contracts.g.dart
@@ -858,6 +858,14 @@ Map<String, dynamic> _$AndroidTakeNativeScreenshotRequestToJson(
   AndroidTakeNativeScreenshotRequest instance,
 ) => <String, dynamic>{'tag': instance.tag};
 
+IOSTakeNativeScreenshotRequest _$IOSTakeNativeScreenshotRequestFromJson(
+  Map<String, dynamic> json,
+) => IOSTakeNativeScreenshotRequest(tag: json['tag'] as String);
+
+Map<String, dynamic> _$IOSTakeNativeScreenshotRequestToJson(
+  IOSTakeNativeScreenshotRequest instance,
+) => <String, dynamic>{'tag': instance.tag};
+
 IOSTakeCameraPhotoRequest _$IOSTakeCameraPhotoRequestFromJson(
   Map<String, dynamic> json,
 ) => IOSTakeCameraPhotoRequest(

--- a/packages/patrol/lib/src/platform/contracts/ios_automator_client.dart
+++ b/packages/patrol/lib/src/platform/contracts/ios_automator_client.dart
@@ -74,6 +74,10 @@ class IosAutomatorClient {
     return _sendRequest('swipe', request.toJson());
   }
 
+  Future<void> takeNativeScreenshot(IOSTakeNativeScreenshotRequest request) {
+    return _sendRequest('takeNativeScreenshot', request.toJson());
+  }
+
   Future<void> closeHeadsUpNotification() {
     return _sendRequest('closeHeadsUpNotification');
   }

--- a/packages/patrol/lib/src/platform/ios/ios_automator.dart
+++ b/packages/patrol/lib/src/platform/ios/ios_automator.dart
@@ -218,6 +218,10 @@ abstract interface class IOSAutomator implements MobileAutomator {
     String? appId,
   });
 
+  /// Captures a native screenshot tagged with [tag] and attaches it to the
+  /// running test's `.xcresult` (for a device farm to collect).
+  Future<void> takeNativeScreenshot(String tag);
+
   /// Take and confirm the photo
   ///
   /// This method taps on the camera shutter button to take a photo, then taps

--- a/packages/patrol/lib/src/platform/ios/ios_automator_native.dart
+++ b/packages/patrol/lib/src/platform/ios/ios_automator_native.dart
@@ -238,6 +238,15 @@ class IOSAutomator extends NativeMobileAutomator
     });
   }
 
+  @override
+  Future<void> takeNativeScreenshot(String tag) async {
+    await wrapRequest('takeNativeScreenshot', () async {
+      await _client.takeNativeScreenshot(
+        IOSTakeNativeScreenshotRequest(tag: tag),
+      );
+    });
+  }
+
   /// Double taps on the native view specified by [selector].
   ///
   /// It waits for the view to become visible for [timeout] duration. If

--- a/packages/patrol/lib/src/platform/platform_automator.dart
+++ b/packages/patrol/lib/src/platform/platform_automator.dart
@@ -234,10 +234,13 @@ class PlatformAutomator {
     );
   }
 
-  /// Captures a native screenshot (for a device farm to collect). Android only;
-  /// a no-op elsewhere.
+  /// Captures a native screenshot (for a device farm to collect). Supported on
+  /// Android and iOS; a no-op elsewhere.
   Future<void> takeNativeScreenshot(String tag) async {
-    await action.maybe(android: () => android.takeNativeScreenshot(tag));
+    await action.maybe(
+      android: () => android.takeNativeScreenshot(tag),
+      ios: () => ios.takeNativeScreenshot(tag),
+    );
   }
 
   /// None of the native actions are supported on MacOS, so we will just always throw.

--- a/packages/patrol_cli/CHANGELOG.md
+++ b/packages/patrol_cli/CHANGELOG.md
@@ -16,6 +16,7 @@
   generated classes no longer compile in.
 - Add `screenshot_on_failure` option to the pubspec's `patrol` section, forwarded to the app (via a dart-define) for `build` and `test` so patrol can capture native failure screenshots on Android device farms (e.g. BrowserStack, Firebase Test Lab). Not collected by `patrol develop`. Off by default. (#3222)
 - `patrol test` (Android) now pulls native screenshots (failure and on-demand) from the device into `<test-directory>/screenshots` after the run (override with `--screenshots-output-dir`), so they are available from local/emulator runs, not only device farms. (#3222)
+- `patrol test` (iOS) now extracts native screenshots (failure and on-demand) from the `.xcresult` bundle into `<test-directory>/screenshots` after the run (override with `--screenshots-output-dir`), gated by `screenshot_on_failure`. Works for simulators and physical devices; requires Xcode 16 or newer. (#3271)
 - Allow the latest `package_config` (3.x), `cli_completion` (0.6.x) and `pub_updater` (0.6.x), without raising the minimum Dart SDK. (#3225)
 - Fix an issue when building iOS tests from different directory than project's root - we were looking in a wrong place for .xctestrun file. (#3250)
 - Fix hot restart dying on flavored `patrol develop` — `flutter attach` has no `--flavor`. Regressed in 4.6.1. (#3223)

--- a/packages/patrol_cli/lib/src/commands/build_ios.dart
+++ b/packages/patrol_cli/lib/src/commands/build_ios.dart
@@ -156,6 +156,7 @@ class BuildIOSCommand extends PatrolCommand {
       'PATROL_IOS_APP_NAME': appName,
       'PATROL_TEST_LABEL_ENABLED': displayLabel.toString(),
       'PATROL_TEST_DIRECTORY': config.testDirectory,
+      'PATROL_SCREENSHOT_ON_FAILURE': config.screenshotOnFailure.toString(),
       'INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE': 'false',
       'PATROL_TEST_SERVER_PORT': super.testServerPort.toString(),
       'PATROL_APP_SERVER_PORT': super.appServerPort.toString(),

--- a/packages/patrol_cli/lib/src/commands/test.dart
+++ b/packages/patrol_cli/lib/src/commands/test.dart
@@ -438,6 +438,7 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
       testDirectory: testDirectory,
       screenshotsOutputDir:
           stringArg('screenshots-output-dir') ?? '$testDirectory/screenshots',
+      screenshotOnFailure: config.screenshotOnFailure,
     );
 
     // Converted after the run, once the runner has written the raw JS coverage.
@@ -534,6 +535,7 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
     required bool clearTestSteps,
     required String testDirectory,
     required String screenshotsOutputDir,
+    required bool screenshotOnFailure,
   }) async {
     Future<void> Function() action;
     Future<void> Function()? finalizer;
@@ -572,6 +574,8 @@ See https://github.com/leancodepl/patrol/issues/1316 to learn more.
           hideTestSteps: hideTestSteps,
           clearTestSteps: clearTestSteps,
           videoConfig: videoConfig,
+          collectScreenshots: screenshotOnFailure,
+          screenshotsOutputDir: screenshotsOutputDir,
         );
         final bundleId = ios.bundleId;
         if (bundleId != null && uninstall) {

--- a/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
+++ b/packages/patrol_cli/lib/src/ios/ios_test_backend.dart
@@ -387,6 +387,8 @@ class IOSTestBackend {
     List<String> onlyTests = const [],
     void Function(Entry entry)? onLogEntry,
     VideoRecordingConfig? videoConfig,
+    bool collectScreenshots = false,
+    String? screenshotsOutputDir,
   }) async {
     final onlyTesting = onlyTests.isNotEmpty
         ? _resolveOnlyTesting(onlyTests)
@@ -483,6 +485,19 @@ class IOSTestBackend {
 
       // Cleanup video recording manager
       await videoRecordingManager?.dispose();
+
+      // Extract native screenshots (failure and on-demand) from the .xcresult.
+      // Runs whether tests passed or failed - before the exit-code check below
+      // that throws on failure - so failing runs still yield their screenshots.
+      // Skipped in develop, which reuses the bundle across hot restarts.
+      if (collectScreenshots &&
+          !interruptible &&
+          screenshotsOutputDir != null) {
+        await extractScreenshots(
+          xcresultPath: reportPath,
+          outputDir: screenshotsOutputDir,
+        );
+      }
 
       // Don't print the summary in develop
       if (!interruptible) {
@@ -733,5 +748,167 @@ class IOSTestBackend {
         .toList();
 
     return jsonEncode(ids);
+  }
+
+  /// The 8-byte PNG file signature.
+  static const _pngMagic = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+  /// Prefix that Patrol puts on the names of the screenshots it attaches
+  /// (failure and on-demand), so they can be told apart from XCTest's own
+  /// automatic attachments during extraction.
+  static const _patrolAttachmentPrefix = 'patrol_';
+
+  /// Extracts native screenshots captured during the run from the [xcresultPath]
+  /// bundle into [outputDir], organized per test. Best-effort: never throws.
+  ///
+  /// On iOS the screenshots ride inside the `.xcresult` that xcodebuild writes
+  /// on the host, so this works identically for simulators and physical devices
+  /// - there is no on-device pull step (unlike Android). We export every
+  /// attachment, then keep only PNG images that are either associated with a
+  /// test failure or were attached by Patrol (name prefixed with `patrol_`).
+  @visibleForTesting
+  Future<void> extractScreenshots({
+    required String xcresultPath,
+    required String outputDir,
+  }) async {
+    try {
+      final xcresult = _fs.directory(xcresultPath);
+      if (!xcresult.existsSync()) {
+        _logger.detail(
+          'No .xcresult bundle at $xcresultPath; '
+          'skipping screenshot extraction.',
+        );
+        return;
+      }
+
+      final destination = _rootDirectory.childDirectory(outputDir);
+      // Start clean so this run's artifacts don't mix with a previous run's.
+      if (destination.existsSync()) {
+        destination.deleteSync(recursive: true);
+      }
+
+      final exportDir = _fs.systemTempDirectory.createTempSync(
+        'patrol_ios_screenshots',
+      );
+      try {
+        final result = await _processManager.run([
+          'xcrun',
+          'xcresulttool',
+          'export',
+          'attachments',
+          '--path',
+          xcresult.absolute.path,
+          '--output-path',
+          exportDir.path,
+        ], runInShell: true);
+
+        if (result.exitCode != 0) {
+          // Older xcresulttool (pre-Xcode 16) lacks `export attachments`.
+          _logger.detail(
+            'Could not export screenshots from the .xcresult bundle '
+            '(xcresulttool exit code ${result.exitCode}). This requires '
+            'Xcode 16 or newer.',
+          );
+          return;
+        }
+
+        final manifestFile = exportDir.childFile('manifest.json');
+        if (!manifestFile.existsSync()) {
+          _logger.detail('No screenshots were captured during the run.');
+          return;
+        }
+
+        final saved = _copyScreenshotsFromExport(
+          manifest: jsonDecode(manifestFile.readAsStringSync()),
+          exportDir: exportDir,
+          destination: destination,
+        );
+
+        if (saved > 0) {
+          _logger.info('Screenshots saved to ${destination.path}');
+        } else {
+          _logger.detail('No screenshots were captured during the run.');
+        }
+      } finally {
+        exportDir.deleteSync(recursive: true);
+      }
+    } catch (err) {
+      _logger.warn('Failed to extract screenshots from the .xcresult: $err');
+    }
+  }
+
+  /// Copies the Patrol-attached and failure PNG attachments listed in
+  /// [manifest] from [exportDir] into [destination], grouped per test. Returns
+  /// the number of screenshots saved.
+  int _copyScreenshotsFromExport({
+    required Object? manifest,
+    required Directory exportDir,
+    required Directory destination,
+  }) {
+    if (manifest is! List) {
+      return 0;
+    }
+
+    var saved = 0;
+    for (final testEntry in manifest.whereType<Map<String, dynamic>>()) {
+      final testId = testEntry['testIdentifier'] as String? ?? 'unknown';
+      final attachments = testEntry['attachments'];
+      if (attachments is! List) {
+        continue;
+      }
+
+      var indexInTest = 0;
+      for (final attachment in attachments.whereType<Map<String, dynamic>>()) {
+        final fileName = attachment['exportedFileName'] as String?;
+        if (fileName == null) {
+          continue;
+        }
+        final name =
+            attachment['suggestedHumanReadableName'] as String? ?? 'screenshot';
+        final isFailure =
+            attachment['isAssociatedWithFailure'] as bool? ?? false;
+        final isPatrol = name.startsWith(_patrolAttachmentPrefix);
+        if (!isFailure && !isPatrol) {
+          continue;
+        }
+
+        final source = exportDir.childFile(fileName);
+        if (!source.existsSync() || !_isPng(source)) {
+          continue;
+        }
+
+        final testDir = destination.childDirectory(_sanitize(testId))
+          ..createSync(recursive: true);
+        testDir
+            .childFile('${_sanitize(name)}_$indexInTest.png')
+            .writeAsBytesSync(source.readAsBytesSync());
+        indexInTest++;
+        saved++;
+      }
+    }
+    return saved;
+  }
+
+  bool _isPng(File file) {
+    final raf = file.openSync();
+    try {
+      final header = raf.readSync(_pngMagic.length);
+      if (header.length < _pngMagic.length) {
+        return false;
+      }
+      for (var i = 0; i < _pngMagic.length; i++) {
+        if (header[i] != _pngMagic[i]) {
+          return false;
+        }
+      }
+      return true;
+    } finally {
+      raf.closeSync();
+    }
+  }
+
+  /// Makes [value] safe to use as a single path segment.
+  String _sanitize(String value) {
+    return value.replaceAll(RegExp('[^A-Za-z0-9._-]+'), '_');
   }
 }

--- a/packages/patrol_cli/lib/src/runner/patrol_command.dart
+++ b/packages/patrol_cli/lib/src/runner/patrol_command.dart
@@ -552,9 +552,10 @@ abstract class PatrolCommand extends Command<int> {
       ..addOption(
         'screenshots-output-dir',
         help:
-            'Directory to save native screenshots pulled from the device '
-            'after an Android `patrol test` run. Defaults to '
-            '<test-directory>/screenshots.',
+            'Directory to save native screenshots collected after a `patrol '
+            'test` run: pulled from the device on Android, and exported from '
+            'the `.xcresult` bundle on iOS (requires Xcode 16 or newer). '
+            'Defaults to <test-directory>/screenshots.',
         valueHelp: 'path/to/screenshots',
       );
   }

--- a/packages/patrol_cli/test/ios/ios_test_backend_test.dart
+++ b/packages/patrol_cli/test/ios/ios_test_backend_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io' show ProcessResult;
+
 import 'package:dispose_scope/dispose_scope.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
@@ -11,6 +14,13 @@ import 'package:patrol_cli/src/runner/flutter_command.dart';
 import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 import 'package:test/test.dart';
+
+/// PNG file signature followed by a couple of filler bytes.
+final _pngBytes = <int>[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0];
+
+/// Binary plist signature - what XCTest's automatic "UI Snapshot" element-tree
+/// attachments look like (not an image).
+final _bplistBytes = <int>[0x62, 0x70, 0x6C, 0x69, 0x73, 0x74, 0x30, 0x30];
 
 void main() {
   group('BuildMode', () {
@@ -337,9 +347,140 @@ void main() {
       );
     });
   });
+
+  group('IOSTestBackend.extractScreenshots', () {
+    late IOSTestBackend iosTestBackend;
+    late MockProcessManager processManager;
+    late FileSystem fs;
+    late Directory rootDirectory;
+
+    setUp(() {
+      processManager = MockProcessManager();
+      fs = MemoryFileSystem.test();
+      rootDirectory = fs.currentDirectory;
+
+      iosTestBackend = IOSTestBackend(
+        processManager: processManager,
+        platform: FakePlatform(),
+        fs: fs,
+        rootDirectory: rootDirectory,
+        parentDisposeScope: DisposeScope(),
+        logger: FakeLogger(),
+      );
+    });
+
+    /// Makes the mocked `xcresulttool export attachments` write [manifest] plus
+    /// the given [files] (name -> bytes) into whatever `--output-path` it is
+    /// given, mimicking the real tool.
+    void stubExport({
+      required List<Map<String, dynamic>> manifest,
+      required Map<String, List<int>> files,
+      int exitCode = 0,
+    }) {
+      when(
+        () => processManager.run(any(), runInShell: any(named: 'runInShell')),
+      ).thenAnswer((invocation) async {
+        final args = (invocation.positionalArguments.first as List)
+            .cast<String>();
+        final outIndex = args.indexOf('--output-path');
+        final outDir = fs.directory(args[outIndex + 1])
+          ..createSync(recursive: true);
+        if (exitCode == 0) {
+          outDir
+              .childFile('manifest.json')
+              .writeAsStringSync(jsonEncode(manifest));
+          files.forEach((name, bytes) {
+            outDir.childFile(name).writeAsBytesSync(bytes);
+          });
+        }
+        return ProcessResult(0, exitCode, '', '');
+      });
+    }
+
+    Map<String, dynamic> attachment(
+      String file,
+      String name, {
+      bool failure = false,
+    }) => {
+      'exportedFileName': file,
+      'suggestedHumanReadableName': name,
+      'isAssociatedWithFailure': failure,
+    };
+
+    test('keeps patrol-named and failure PNGs, drops the rest', () async {
+      fs.directory('build/out.xcresult').createSync(recursive: true);
+      stubExport(
+        manifest: [
+          {
+            'testIdentifier': 'RunnerUITests/RunnerUITests/test_login',
+            'attachments': [
+              attachment('a', 'patrol_failure'),
+              attachment('b', 'patrol_before_tap'),
+              attachment('c', 'UI Snapshot', failure: true),
+              attachment('d', 'UI Snapshot'),
+              attachment('e', 'patrol_broken'),
+            ],
+          },
+        ],
+        files: {
+          'a': _pngBytes,
+          'b': _pngBytes,
+          // Failure-associated but a bplist element tree, not an image - dropped.
+          'c': _bplistBytes,
+          // Not patrol, not a failure - dropped.
+          'd': _pngBytes,
+          // Patrol-named but not a PNG - dropped.
+          'e': _bplistBytes,
+        },
+      );
+
+      await iosTestBackend.extractScreenshots(
+        xcresultPath: 'build/out.xcresult',
+        outputDir: 'screenshots',
+      );
+
+      final testDir = rootDirectory
+          .childDirectory('screenshots')
+          .childDirectory('RunnerUITests_RunnerUITests_test_login');
+      final saved = testDir.listSync().map((e) => e.basename).toList()..sort();
+      expect(saved, ['patrol_before_tap_1.png', 'patrol_failure_0.png']);
+    });
+
+    test(
+      'does not throw and writes nothing when the bundle is missing',
+      () async {
+        await iosTestBackend.extractScreenshots(
+          xcresultPath: 'build/missing.xcresult',
+          outputDir: 'screenshots',
+        );
+
+        verifyNever(
+          () => processManager.run(any(), runInShell: any(named: 'runInShell')),
+        );
+        expect(
+          rootDirectory.childDirectory('screenshots').existsSync(),
+          isFalse,
+        );
+      },
+    );
+
+    test('does not throw when xcresulttool is too old', () async {
+      fs.directory('build/out.xcresult').createSync(recursive: true);
+      stubExport(manifest: [], files: {}, exitCode: 1);
+
+      await iosTestBackend.extractScreenshots(
+        xcresultPath: 'build/out.xcresult',
+        outputDir: 'screenshots',
+      );
+
+      expect(rootDirectory.childDirectory('screenshots').existsSync(), isFalse);
+    });
+  });
 }
 
 class FakeProcessManager extends Fake implements ProcessManager {}
+
+class MockProcessManager extends Mock implements ProcessManager {}
 
 class FakeLogger extends Fake implements Logger {
   @override
@@ -347,6 +488,16 @@ class FakeLogger extends Fake implements Logger {
 
   @override
   ProgressTask task(String message) => FakeProgressTask();
+
+  @override
+  void info(String? message, {String? Function(String?)? style}) {}
+
+  @override
+  void warn(
+    String? message, {
+    String tag = 'WARN',
+    String? Function(String?)? style,
+  }) {}
 }
 
 class FakeProgressTask extends Fake implements ProgressTask {}

--- a/packages/patrol_devtools_extension/CHANGELOG.md
+++ b/packages/patrol_devtools_extension/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Regenerate API contracts for the new Android `ConfigureRequest` accessibility flag. (#3227)
 - Regenerate API contracts (adds `AndroidTakeNativeScreenshotRequest`). (#3222)
+- Regenerate API contracts (adds `IOSTakeNativeScreenshotRequest`). (#3271)
 
 ## 0.4.1
 

--- a/packages/patrol_devtools_extension/lib/api/contracts.dart
+++ b/packages/patrol_devtools_extension/lib/api/contracts.dart
@@ -1285,6 +1285,21 @@ class AndroidTakeNativeScreenshotRequest with Equatable {
 }
 
 @JsonSerializable()
+class IOSTakeNativeScreenshotRequest with Equatable {
+  const IOSTakeNativeScreenshotRequest({required this.tag});
+
+  factory IOSTakeNativeScreenshotRequest.fromJson(Map<String, dynamic> json) =>
+      _$IOSTakeNativeScreenshotRequestFromJson(json);
+
+  final String tag;
+
+  Map<String, dynamic> toJson() => _$IOSTakeNativeScreenshotRequestToJson(this);
+
+  @override
+  List<Object?> get props => [tag];
+}
+
+@JsonSerializable()
 class IOSTakeCameraPhotoRequest with Equatable {
   const IOSTakeCameraPhotoRequest({
     this.shutterButtonSelector,

--- a/packages/patrol_devtools_extension/lib/api/contracts.g.dart
+++ b/packages/patrol_devtools_extension/lib/api/contracts.g.dart
@@ -858,6 +858,14 @@ Map<String, dynamic> _$AndroidTakeNativeScreenshotRequestToJson(
   AndroidTakeNativeScreenshotRequest instance,
 ) => <String, dynamic>{'tag': instance.tag};
 
+IOSTakeNativeScreenshotRequest _$IOSTakeNativeScreenshotRequestFromJson(
+  Map<String, dynamic> json,
+) => IOSTakeNativeScreenshotRequest(tag: json['tag'] as String);
+
+Map<String, dynamic> _$IOSTakeNativeScreenshotRequestToJson(
+  IOSTakeNativeScreenshotRequest instance,
+) => <String, dynamic>{'tag': instance.tag};
+
 IOSTakeCameraPhotoRequest _$IOSTakeCameraPhotoRequestFromJson(
   Map<String, dynamic> json,
 ) => IOSTakeCameraPhotoRequest(

--- a/schema.dart
+++ b/schema.dart
@@ -325,6 +325,10 @@ class AndroidTakeNativeScreenshotRequest {
   late String tag;
 }
 
+class IOSTakeNativeScreenshotRequest {
+  late String tag;
+}
+
 class IOSTakeCameraPhotoRequest {
   IOSSelector? shutterButtonSelector;
   IOSSelector? doneButtonSelector;
@@ -460,6 +464,9 @@ abstract class IosAutomator<IOSServer, DartClient> {
   void tapAt(IOSTapAtRequest request);
   void waitUntilVisible(IOSWaitUntilVisibleRequest request);
   void swipe(IOSSwipeRequest request);
+
+  // screenshots
+  void takeNativeScreenshot(IOSTakeNativeScreenshotRequest request);
 
   // notifications
   void closeHeadsUpNotification();


### PR DESCRIPTION
Native screenshots on iOS — failure + on-demand — collected locally, on BrowserStack, and from Firebase Test Lab.

**Change**
- Failure capture: with `screenshot_on_failure: true`, the Dart failure path grabs the failing screen before teardown (`patrol_failure`); the runner drains the buffer and attaches it to the test's `.xcresult` (dynamic + static macro variants).
- `$.takeNativeScreenshot('tag')` now works on iOS — captured on-device, buffered, drained by the runner per test.
- `patrol test` extracts `patrol_*` PNGs from the result bundle into `<test-dir>/screenshots` (gated by `screenshot_on_failure`, Xcode 16+).
- Device workflow: `run_ios_testlab` pulls the screenshots + each failing test's screen recording from the FTL bundle → two artifacts; the run Summary lists the screenshots and links the downloads (GitHub can't render them inline).

**Watch out**
- Works on simulators and physical devices — screenshots ride inside the host-written `.xcresult`; no on-device pull.
- FTL iOS has no `--directories-to-pull` and its console won't render attachments — the xcresult sits in the results bucket under `TestLogs/`, so we pull+extract it after the run.
- Extraction keeps PNGs by the `patrol_` name prefix (XCTest's own failure attachments are bplists, dropped by the PNG magic check).

**Result**
- Verified on a physical iPhone 16 Pro / iOS 18.3 (FTL): `patrol_failure` captures the failing screen at failure time, `patrol_before_tap` the on-demand moment.
- Screenshots + failure recordings collected as artifacts and listed in the run Summary — verification run (temporarily scoped to a deliberate-fail repro): https://github.com/leancodepl/patrol/actions/runs/33505164168
