### PR TITLE
ci: gate mandatory workflows for required-check enforcement

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -39,7 +39,7 @@ So each mandatory workflow drops the `on: paths` filter and gains two jobs:
 
 The real jobs get `if: needs.changes.outputs.relevant == 'true'`, so a PR that does not touch a package skips its jobs (reported as success) and the gate still goes green. Branch protection requires the gate names, not the individual matrix jobs, so the required list stays short and the matrices can change freely. `pana` and the Slack notifier are left out of the gate, they stay advisory.
 
-emulator.wtf runs on `pull_request_target` and only for users with write access. The gate keeps that: for an outside contributor the heavy job skips (secrets never reach a fork) and the gate passes, so their PR is not wedged. A maintainer runs emulator.wtf before merging such a PR.
+emulator.wtf runs on `pull_request_target`, so it has the base repo's secrets. Its inline `access` job lets `run_tests` run only when the PR branch lives in this repository (`head.repo == github.repository`, i.e. a trusted author with write access pushed it) and the paths are relevant. A fork PR skips `run_tests`, so fork code never sees the secrets and the gate still passes (the PR is not wedged). It checks `head.repo`, not `github.triggering_actor`: the actor becomes the maintainer on a re-run, which would otherwise hand fork code the secrets. A maintainer tests a fork PR from a trusted in-repo branch.
 
 ### Rollout
 
@@ -110,13 +110,13 @@ Package-level `pana` scoring only runs for packages published to pub.dev (`patro
 | [patrol_log publish][patrol_log-publish] | Tag push (`patrol_log-v*`) | Publishes `patrol_log` package to pub.dev. Sends Slack notification for releases. |
 | [adb publish][adb-publish] | Tag push (`adb-v*`) | Publishes `adb` package to pub.dev. |
 
-### PR-Triggered Workflows with Permission Checks
+### PR-Triggered Workflows with Secrets
 
-Some workflows run on `pull_request_target` (which has access to secrets) require repository write permission:
-- [test android emulator][test-android-emulator] - Requires repository write permission
-- [test android emulator webview][test-android-emulator-webview] - Requires repository write permission
+These workflows run on `pull_request_target`, which has access to secrets:
+- [test android emulator][test-android-emulator]
+- [test android emulator webview][test-android-emulator-webview]
 
-These workflows verify the user has write access before running. If you don't have write access, the workflow will fail with a permission error. Contact a Patrol team member to run these workflows on your PR.
+Their `access` job runs the emulator job only for PRs whose branch lives in this repository (`head.repo == github.repository`). A fork PR does not fail: its `run_tests` is skipped and the gate passes, so the PR is not blocked. To exercise a fork PR on emulator.wtf, a maintainer runs it from an in-repo branch. Re-running the fork PR does not help, because the trust check is on the head repository, not on the actor who triggered the run.
 
 ## Semver Check Workflows
 
@@ -140,7 +140,7 @@ These workflows verify the user has write access before running. If you don't ha
 | [Verify Version Compatibility][verify_compatibility] | PR/push (on compatibility checker changes) | Runs compatibility tests and verifies compatibility tables are up-to-date. |
 | [check skills][check-skills] | PR (on `skills/`, `.agents/skills/`, `.claude/skills`, or script changes), manual | Validates the agent-skills setup via `tool/check_skills.sh`: the `.claude/skills` symlink resolves to `.agents/skills`, and every `SKILL.md` has valid frontmatter (`name` matches its folder and is kebab-case, plus a non-empty `description`). |
 | [send slack message][send-slack-message] | Reusable workflow | Reusable workflow for sending test results notifications to Slack. Invoked by test workflows; the Slack step runs only when `github.event_name == 'schedule'` in the **caller** workflow (so scheduled cron runs notify; PR, push, `workflow_dispatch`, and other triggers do not). |
-| [_relevant][_relevant] | Reusable workflow | Reusable `changes` job. Takes a dorny/paths-filter `filters` block and outputs `relevant` ('true' when a PR touches those paths, or on any non-PR event). Used by every mandatory workflow's `changes` job so the paths-filter logic is defined once. The two emulator.wtf workflows keep an inline `access` job instead (it also runs the write-permission check). |
+| [_relevant][_relevant] | Reusable workflow | Reusable `changes` job. Takes a dorny/paths-filter `filters` block and outputs `relevant` ('true' when a PR touches those paths, or on any non-PR event). Used by every mandatory workflow's `changes` job so the paths-filter logic is defined once. The two emulator.wtf workflows keep an inline `access` job instead (it also enforces the fork trust boundary, running the emulator job only for in-repo branches so secrets never reach fork code). |
 | [label pull request][label_pull_request] | All PRs | Automatically labels PRs based on changed files. |
 | [Add prioritized issues to project][add-to-project] | Issue labeled (P0, P1, P2) | Automatically adds prioritized issues to GitHub project board. |
 | [Potential Duplicates][potential-duplicates] | Issue opened/edited | Automatically detects and labels potential duplicate issues using similarity threshold. |

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -2,6 +2,57 @@
 
 This document describes all GitHub Actions workflows used in the Patrol project. Each workflow is listed with its purpose, trigger conditions, and Flutter/Dart versions.
 
+## Required checks
+
+This is the agreed split of PR checks: what blocks a merge, what only advises, and what never runs on a PR. Enforcement is not on yet, see Rollout at the end of this section.
+
+The last neglect happened because failing workflows were not blocking merges. Required status checks fix that, with one catch we hit head-on (see Why a gate job).
+
+**Mandatory: must be green to merge**
+
+- Package CI: patrol prepare, patrol_cli prepare, patrol_finders prepare, patrol_log prepare, patrol_devtools_extension prepare, patrol_gen prepare, patrol_mcp prepare, adb prepare, prepare e2e_app
+- Fast checks: check changelog, check skills, Verify Version Compatibility
+- Android E2E on emulator.wtf: test android emulator, test android emulator webview
+- Other E2E: test macos, test web, test patrol develop, test ios simulator (keep a retry on the iOS simulator, it is the flakiest of the gates)
+
+**Advisory: read but never block**
+
+- Semver: patrol check semver, patrol_finders check semver, patrol_log check semver. A version bump is the author's call, sometimes breaking on purpose, so we look at these and move on.
+- pana scores: they run `continue-on-error` and sit outside every gate. A pub.dev score is a publish-time concern, not something a PR has to clear.
+- patrol_mcp cli-compat: reports without failing CI by design.
+- `pub publish --dry-run` inside the prepare jobs: set to `continue-on-error`. pub runs its own bundled `dart analyze`, which can lag the SDK version and flag a phantom, unactionable warning (exit 65) even when the job's own `flutter analyze` is clean. The real publish workflow validates at tag-push, so the dry-run stays advisory here.
+
+**Never a PR gate: scheduled only**
+
+- test flutter main channel, test flutter beta channel (they track upstream Flutter, a red there is usually not the PR's fault)
+- test android device, test ios device, test locales on android device, test locales on ios device (Firebase Test Lab, real hardware, slow and paid)
+- test ios simulator webview (monthly)
+
+### Why a gate job
+
+A required check that never reports leaves the PR stuck on "Expected — Waiting for status to be reported". GitHub does this whenever a required workflow is filtered out by `on: paths`: the run never starts, so no status arrives, and no branch-protection or ruleset setting counts a missing check as passed. A job skipped by a job-level `if:` reports success instead, and that does satisfy the check.
+
+So each mandatory workflow drops the `on: paths` filter and gains two jobs:
+
+- a `changes` job that runs dorny/paths-filter and outputs whether the PR touches relevant files,
+- a gate job (named `<workflow> gate`) that `needs` every real job, runs with `if: always()`, and fails only when one of them failed or was cancelled.
+
+The real jobs get `if: needs.changes.outputs.relevant == 'true'`, so a PR that does not touch a package skips its jobs (reported as success) and the gate still goes green. Branch protection requires the gate names, not the individual matrix jobs, so the required list stays short and the matrices can change freely. `pana` and the Slack notifier are left out of the gate, they stay advisory.
+
+emulator.wtf runs on `pull_request_target` and only for users with write access. The gate keeps that: for an outside contributor the heavy job skips (secrets never reach a fork) and the gate passes, so their PR is not wedged. A maintainer runs emulator.wtf before merging such a PR.
+
+### Rollout
+
+1. Land the gate jobs (this change).
+2. Open one throwaway PR and confirm every gate goes green, including a docs-only PR and a single-package PR.
+3. Add the `<workflow> gate` contexts to branch protection or a ruleset as required. This needs repo admin. The API read returned 404 for the current user, so someone with admin has to do this step.
+
+Confirm dorny/paths-filter is allowed by the org action policy before step 2, or the changes jobs will fail.
+
+### Bypass
+
+Not built. Two routes if we want one: a bypass list on the ruleset for maintainers (native, shows in the audit log), or a label the gate reads and turns green on demand (same idea as the existing `skip changelog` label).
+
 ## Testing Workflows
 
 ### Android Testing

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -34,7 +34,7 @@ A required check that never reports leaves the PR stuck on "Expected — Waiting
 
 So each mandatory workflow drops the `on: paths` filter and gains two jobs:
 
-- a `changes` job that runs dorny/paths-filter and outputs whether the PR touches relevant files,
+- a `changes` job that calls the reusable [_relevant][_relevant] workflow with its filter globs and outputs whether the PR touches relevant files (the paths-filter + decide logic lives in one place instead of being copy-pasted per workflow),
 - a gate job (named `<workflow> gate`) that `needs` every real job, runs with `if: always()`, and fails only when one of them failed or was cancelled.
 
 The real jobs get `if: needs.changes.outputs.relevant == 'true'`, so a PR that does not touch a package skips its jobs (reported as success) and the gate still goes green. Branch protection requires the gate names, not the individual matrix jobs, so the required list stays short and the matrices can change freely. `pana` and the Slack notifier are left out of the gate, they stay advisory.
@@ -140,6 +140,7 @@ These workflows verify the user has write access before running. If you don't ha
 | [Verify Version Compatibility][verify_compatibility] | PR/push (on compatibility checker changes) | Runs compatibility tests and verifies compatibility tables are up-to-date. |
 | [check skills][check-skills] | PR (on `skills/`, `.agents/skills/`, `.claude/skills`, or script changes), manual | Validates the agent-skills setup via `tool/check_skills.sh`: the `.claude/skills` symlink resolves to `.agents/skills`, and every `SKILL.md` has valid frontmatter (`name` matches its folder and is kebab-case, plus a non-empty `description`). |
 | [send slack message][send-slack-message] | Reusable workflow | Reusable workflow for sending test results notifications to Slack. Invoked by test workflows; the Slack step runs only when `github.event_name == 'schedule'` in the **caller** workflow (so scheduled cron runs notify; PR, push, `workflow_dispatch`, and other triggers do not). |
+| [_relevant][_relevant] | Reusable workflow | Reusable `changes` job. Takes a dorny/paths-filter `filters` block and outputs `relevant` ('true' when a PR touches those paths, or on any non-PR event). Used by every mandatory workflow's `changes` job so the paths-filter logic is defined once. The two emulator.wtf workflows keep an inline `access` job instead (it also runs the write-permission check). |
 | [label pull request][label_pull_request] | All PRs | Automatically labels PRs based on changed files. |
 | [Add prioritized issues to project][add-to-project] | Issue labeled (P0, P1, P2) | Automatically adds prioritized issues to GitHub project board. |
 | [Potential Duplicates][potential-duplicates] | Issue opened/edited | Automatically detects and labels potential duplicate issues using similarity threshold. |
@@ -235,6 +236,7 @@ A test is selected if it matches ALL conditions in the boolean expression (AND o
 [docs-preview]: workflows/docs-preview.yaml
 [verify_compatibility]: workflows/verify_compatibility.yml
 [send-slack-message]: workflows/send-slack-message.yaml
+[_relevant]: workflows/_relevant.yaml
 [label_pull_request]: workflows/label_pull_request.yaml
 [add-to-project]: workflows/add-to-project.yaml
 [potential-duplicates]: workflows/potential-duplicates.yaml

--- a/.github/workflows/_relevant.yaml
+++ b/.github/workflows/_relevant.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Filter paths
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
         with:
           predicate-quantifier: ${{ inputs.quantifier }}
           filters: ${{ inputs.filters }}

--- a/.github/workflows/_relevant.yaml
+++ b/.github/workflows/_relevant.yaml
@@ -12,6 +12,14 @@ on:
         description: A dorny/paths-filter `filters` block with a `relevant:` filter.
         required: true
         type: string
+      quantifier:
+        # 'every' (a file must match all patterns) is what makes `!**/*.md`
+        # exclusions actually work; combine positives into one `{a,b}` pattern
+        # when using it. 'some' (default) is for a plain list of alternatives.
+        description: dorny/paths-filter predicate-quantifier ('some' or 'every').
+        required: false
+        type: string
+        default: some
     outputs:
       relevant:
         description: "'true' when the PR is relevant or the event is not a PR."
@@ -31,6 +39,7 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
         uses: dorny/paths-filter@v3
         with:
+          predicate-quantifier: ${{ inputs.quantifier }}
           filters: ${{ inputs.filters }}
       - name: Decide whether to run
         id: decide

--- a/.github/workflows/_relevant.yaml
+++ b/.github/workflows/_relevant.yaml
@@ -1,0 +1,42 @@
+name: _relevant
+
+# Reusable "changes" job. Callers pass a dorny/paths-filter `filters` block and
+# get back `relevant`: 'true' when a PR touches those paths, or on any non-PR
+# event (schedule / workflow_dispatch / push), so the caller's real jobs run.
+# Skipped jobs report success, which keeps the caller's required gate green.
+
+on:
+  workflow_call:
+    inputs:
+      filters:
+        description: A dorny/paths-filter `filters` block with a `relevant:` filter.
+        required: true
+        type: string
+    outputs:
+      relevant:
+        description: "'true' when the PR is relevant or the event is not a PR."
+        value: ${{ jobs.relevant.outputs.relevant }}
+
+jobs:
+  relevant:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: ${{ inputs.filters }}
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ github.event_name }}" != "pull_request_target" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/adb-prepare.yaml
+++ b/.github/workflows/adb-prepare.yaml
@@ -3,12 +3,37 @@ name: adb prepare
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'packages/adb/**'
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/adb/**'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
     name: Dart ${{ matrix.dart-version }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -45,10 +70,15 @@ jobs:
         run: dart format --set-exit-if-changed .
 
       - name: dart pub publish --dry-run
+        # Still reports issues, but does not fail the PR on pub's false-positive analyzer warning (exit 65).
+        if: success() || failure()
+        continue-on-error: true
         run: dart pub publish --dry-run
 
   pana-score:
     name: pana score
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -64,3 +94,17 @@ jobs:
         uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/adb
+
+  adb-prepare-gate:
+    name: adb prepare gate
+    needs: [changes, main]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/adb-prepare.yaml
+++ b/.github/workflows/adb-prepare.yaml
@@ -6,29 +6,11 @@ on:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/adb/**'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/adb/**'
 
   main:
     name: Dart ${{ matrix.dart-version }}

--- a/.github/workflows/check-changelog.yaml
+++ b/.github/workflows/check-changelog.yaml
@@ -6,16 +6,40 @@ on:
     # `labeled`/`unlabeled` are included so toggling the `skip changelog`
     # label re-evaluates the job condition below and updates the check status.
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths:
-      - 'packages/**'
-      - 'tool/check_changelog.sh'
-      - '.github/workflows/check-changelog.yaml'
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/**'
+              - 'tool/check_changelog.sh'
+              - '.github/workflows/check-changelog.yaml'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   check-changelog:
     name: Check CHANGELOG entries
+    needs: changes
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip changelog') }}
+    if: ${{ needs.changes.outputs.relevant == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip changelog') }}
 
     steps:
       - name: Clone repository
@@ -27,3 +51,17 @@ jobs:
         # github.base_ref is empty on workflow_dispatch, so fall back to the
         # repository's default branch.
         run: tool/check_changelog.sh "origin/${{ github.base_ref || github.event.repository.default_branch }}"
+
+  check-changelog-gate:
+    name: check changelog gate
+    needs: [changes, check-changelog]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/check-changelog.yaml
+++ b/.github/workflows/check-changelog.yaml
@@ -9,31 +9,13 @@ on:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/**'
-              - 'tool/check_changelog.sh'
-              - '.github/workflows/check-changelog.yaml'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/**'
+          - 'tool/check_changelog.sh'
+          - '.github/workflows/check-changelog.yaml'
 
   check-changelog:
     name: Check CHANGELOG entries

--- a/.github/workflows/check-skills.yaml
+++ b/.github/workflows/check-skills.yaml
@@ -6,33 +6,15 @@ on:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'skills/**'
-              - '.agents/skills/**'
-              - '.claude/skills'
-              - 'tool/check_skills.sh'
-              - '.github/workflows/check-skills.yaml'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'skills/**'
+          - '.agents/skills/**'
+          - '.claude/skills'
+          - 'tool/check_skills.sh'
+          - '.github/workflows/check-skills.yaml'
 
   check-skills:
     name: Validate agent skills

--- a/.github/workflows/check-skills.yaml
+++ b/.github/workflows/check-skills.yaml
@@ -3,16 +3,41 @@ name: check skills
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'skills/**'
-      - '.agents/skills/**'
-      - '.claude/skills'
-      - 'tool/check_skills.sh'
-      - '.github/workflows/check-skills.yaml'
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'skills/**'
+              - '.agents/skills/**'
+              - '.claude/skills'
+              - 'tool/check_skills.sh'
+              - '.github/workflows/check-skills.yaml'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   check-skills:
     name: Validate agent skills
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -21,3 +46,17 @@ jobs:
 
       - name: Check agent skills
         run: tool/check_skills.sh
+
+  check-skills-gate:
+    name: check skills gate
+    needs: [changes, check-skills]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/patrol-prepare.yaml
+++ b/.github/workflows/patrol-prepare.yaml
@@ -6,29 +6,11 @@ on:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/patrol/**'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/patrol/**'
 
   prepare-android-on-windows:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/patrol-prepare.yaml
+++ b/.github/workflows/patrol-prepare.yaml
@@ -3,13 +3,38 @@ name: patrol prepare
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'packages/patrol/**'
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol/**'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   prepare-android-on-windows:
     runs-on: ${{ matrix.os }}
     name: Android on ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
 
     strategy:
       fail-fast: false
@@ -60,6 +85,8 @@ jobs:
   prepare-android-on-linux:
     runs-on: ${{ matrix.os }}
     name: Android on ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
 
     strategy:
       fail-fast: false
@@ -128,6 +155,8 @@ jobs:
   prepare-darwin:
     runs-on: ${{ matrix.os }}
     name: darwin on ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
 
     strategy:
       fail-fast: false
@@ -169,6 +198,8 @@ jobs:
   prepare-flutter:
     name: Flutter ${{ matrix.flutter-version }}
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
 
     strategy:
       fail-fast: false
@@ -214,7 +245,9 @@ jobs:
         run: dart format --set-exit-if-changed .
 
       - name: flutter pub publish --dry-run
+        # Still reports issues, but does not fail the PR on pub's false-positive analyzer warning (exit 65).
         if: success() || failure()
+        continue-on-error: true
         run: |
           rm -f pubspec_overrides.yaml
           flutter pub get
@@ -235,6 +268,8 @@ jobs:
 
   pana-score:
     name: pana score
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -250,3 +285,17 @@ jobs:
         uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/patrol
+
+  patrol-prepare-gate:
+    name: patrol prepare gate
+    needs: [changes, prepare-android-on-windows, prepare-android-on-linux, prepare-darwin, prepare-flutter]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/patrol_cli-prepare.yaml
+++ b/.github/workflows/patrol_cli-prepare.yaml
@@ -3,12 +3,37 @@ name: patrol_cli prepare
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'packages/patrol_cli/**'
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol_cli/**'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
     name: Flutter ${{ matrix.flutter-version }} on ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -63,10 +88,15 @@ jobs:
         run: dart format --set-exit-if-changed .
 
       - name: dart pub publish --dry-run
+        # Still reports issues, but does not fail the PR on pub's false-positive analyzer warning (exit 65).
+        if: success() || failure()
+        continue-on-error: true
         run: dart pub publish --dry-run
 
   pana-score:
     name: pana score
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -82,3 +112,17 @@ jobs:
         uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/patrol_cli
+
+  patrol_cli-prepare-gate:
+    name: patrol_cli prepare gate
+    needs: [changes, main]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/patrol_cli-prepare.yaml
+++ b/.github/workflows/patrol_cli-prepare.yaml
@@ -6,29 +6,11 @@ on:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/patrol_cli/**'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/patrol_cli/**'
 
   main:
     name: Flutter ${{ matrix.flutter-version }} on ${{ matrix.os }}

--- a/.github/workflows/patrol_devtools_extension-prepare.yaml
+++ b/.github/workflows/patrol_devtools_extension-prepare.yaml
@@ -6,29 +6,11 @@ on:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/patrol_devtools_extension/**'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/patrol_devtools_extension/**'
 
   prepare:
     name: Flutter ${{ matrix.flutter-version }}

--- a/.github/workflows/patrol_devtools_extension-prepare.yaml
+++ b/.github/workflows/patrol_devtools_extension-prepare.yaml
@@ -3,12 +3,37 @@ name: patrol_devtools_extension prepare
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'packages/patrol_devtools_extension/**'
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol_devtools_extension/**'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   prepare:
     name: Flutter ${{ matrix.flutter-version }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -51,3 +76,17 @@ jobs:
       - name: Build extension
         if: success() || failure()
         run: ./publish_to_patrol_extension
+
+  patrol_devtools_extension-prepare-gate:
+    name: patrol_devtools_extension prepare gate
+    needs: [changes, prepare]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/patrol_finders-prepare.yaml
+++ b/.github/workflows/patrol_finders-prepare.yaml
@@ -3,12 +3,37 @@ name: patrol_finders prepare
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'packages/patrol_finders/**'
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol_finders/**'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   prepare:
     name: Flutter ${{ matrix.flutter-version }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -59,7 +84,9 @@ jobs:
         run: dart format --set-exit-if-changed .
 
       - name: flutter pub publish --dry-run
+        # Still reports issues, but does not fail the PR on pub's false-positive analyzer warning (exit 65).
         if: success() || failure()
+        continue-on-error: true
         run: flutter pub publish --dry-run
 
       - name: flutter pub get (example app)
@@ -74,6 +101,8 @@ jobs:
 
   pana-score:
     name: pana score
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -89,3 +118,17 @@ jobs:
         uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/patrol_finders
+
+  patrol_finders-prepare-gate:
+    name: patrol_finders prepare gate
+    needs: [changes, prepare]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/patrol_finders-prepare.yaml
+++ b/.github/workflows/patrol_finders-prepare.yaml
@@ -6,29 +6,11 @@ on:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/patrol_finders/**'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/patrol_finders/**'
 
   prepare:
     name: Flutter ${{ matrix.flutter-version }}

--- a/.github/workflows/patrol_gen-prepare.yaml
+++ b/.github/workflows/patrol_gen-prepare.yaml
@@ -6,29 +6,11 @@ on:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/patrol_gen/**'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/patrol_gen/**'
 
   prepare:
     name: Dart ${{ matrix.dart-version }}

--- a/.github/workflows/patrol_gen-prepare.yaml
+++ b/.github/workflows/patrol_gen-prepare.yaml
@@ -3,12 +3,37 @@ name: patrol_gen prepare
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'packages/patrol_gen/**'
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol_gen/**'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   prepare:
     name: Dart ${{ matrix.dart-version }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -41,3 +66,17 @@ jobs:
       - name: dart format
         if: success() || failure()
         run: dart format --set-exit-if-changed .
+
+  patrol_gen-prepare-gate:
+    name: patrol_gen prepare gate
+    needs: [changes, prepare]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/patrol_log-prepare.yaml
+++ b/.github/workflows/patrol_log-prepare.yaml
@@ -6,29 +6,11 @@ on:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/patrol_log/**'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/patrol_log/**'
 
   prepare:
     name: Flutter ${{ matrix.flutter-version }}

--- a/.github/workflows/patrol_log-prepare.yaml
+++ b/.github/workflows/patrol_log-prepare.yaml
@@ -3,12 +3,37 @@ name: patrol_log prepare
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'packages/patrol_log/**'
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol_log/**'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   prepare:
     name: Flutter ${{ matrix.flutter-version }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -49,11 +74,15 @@ jobs:
         run: dart format --set-exit-if-changed .
 
       - name: flutter pub publish --dry-run
+        # Still reports issues, but does not fail the PR on pub's false-positive analyzer warning (exit 65).
         if: success() || failure()
+        continue-on-error: true
         run: flutter pub publish --dry-run
 
   pana-score:
     name: pana score
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -69,3 +98,17 @@ jobs:
         uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/patrol_log
+
+  patrol_log-prepare-gate:
+    name: patrol_log prepare gate
+    needs: [changes, prepare]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/patrol_mcp-prepare.yaml
+++ b/.github/workflows/patrol_mcp-prepare.yaml
@@ -6,29 +6,11 @@ on:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/patrol_mcp/**'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/patrol_mcp/**'
 
   smoke_test:
     name: Smoke (${{ matrix.resolution }} patrol_cli) on ${{ matrix.os }}

--- a/.github/workflows/patrol_mcp-prepare.yaml
+++ b/.github/workflows/patrol_mcp-prepare.yaml
@@ -3,12 +3,37 @@ name: patrol_mcp prepare
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'packages/patrol_mcp/**'
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol_mcp/**'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   smoke_test:
     name: Smoke (${{ matrix.resolution }} patrol_cli) on ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -48,6 +73,8 @@ jobs:
 
   pana-score:
     name: pana score
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -63,3 +90,17 @@ jobs:
         uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
         with:
           path: packages/patrol_mcp
+
+  patrol_mcp-prepare-gate:
+    name: patrol_mcp prepare gate
+    needs: [changes, smoke_test]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/prepare-e2e_app.yaml
+++ b/.github/workflows/prepare-e2e_app.yaml
@@ -6,31 +6,13 @@ on:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - '**'
-              - '!**.md'
-              - '!**.mdx'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - '**'
+          - '!**.md'
+          - '!**.mdx'
 
   prepare-android-on-windows:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/prepare-e2e_app.yaml
+++ b/.github/workflows/prepare-e2e_app.yaml
@@ -3,15 +3,40 @@ name: prepare e2e_app
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - '**'
-      - '!**.md' # ignore readmes
-      - '!**.mdx' # ignore docs
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - '**'
+              - '!**.md'
+              - '!**.mdx'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   prepare-android-on-windows:
     runs-on: ${{ matrix.os }}
     name: Android on ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
 
     strategy:
       fail-fast: false
@@ -72,6 +97,8 @@ jobs:
   prepare-android-on-linux:
     runs-on: ${{ matrix.os }}
     name: Android on ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
 
     strategy:
       fail-fast: false
@@ -131,6 +158,8 @@ jobs:
   prepare-ios:
     runs-on: ${{ matrix.os }}
     name: iOS on ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
 
     strategy:
       fail-fast: false
@@ -214,6 +243,8 @@ jobs:
   prepare-flutter:
     name: Flutter ${{ matrix.flutter-version }}
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
 
     strategy:
       fail-fast: false
@@ -257,3 +288,17 @@ jobs:
       - name: dart format
         if: success() || failure()
         run: dart format --set-exit-if-changed .
+
+  prepare-e2e_app-gate:
+    name: prepare e2e_app gate
+    needs: [changes, prepare-android-on-windows, prepare-android-on-linux, prepare-ios, prepare-flutter]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/prepare-e2e_app.yaml
+++ b/.github/workflows/prepare-e2e_app.yaml
@@ -8,11 +8,12 @@ jobs:
   changes:
     uses: ./.github/workflows/_relevant.yaml
     with:
+      quantifier: every
       filters: |
         relevant:
           - '**'
-          - '!**.md'
-          - '!**.mdx'
+          - '!**/*.md'
+          - '!**/*.mdx'
 
   prepare-android-on-windows:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-android-emulator-webview.yaml
+++ b/.github/workflows/test-android-emulator-webview.yaml
@@ -7,26 +7,66 @@ on:
     - cron: "0 23 * * *"
   pull_request_target:
     types: [opened, synchronize]
-    paths:
-      - 'packages/patrol/**'
-      - 'packages/patrol_finders/**'
-      - 'packages/patrol_log/**'
-      - 'packages/patrol_cli/**'
-      - 'packages/adb/**'
-      - 'packages/patrol_gen/**'
-      - 'dev/e2e_app/**'
-      - 'schema.dart'
-      - 'gen_from_schema'
-      - '!**.md'
-      - '!**.mdx'
-      
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  # Decides whether the heavy emulator.wtf job runs. On a PR it runs only when
+  # the actor has write access (secrets never reach a fork) and the PR touches
+  # relevant paths. An outside contributor's PR skips run_tests, so the gate
+  # still goes green and the PR is not wedged; a maintainer runs it before merge.
+  access:
+    name: access
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - name: Check user permission
+        id: perm
+        if: github.event_name == 'pull_request_target'
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request_target'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol/**'
+              - 'packages/patrol_finders/**'
+              - 'packages/patrol_log/**'
+              - 'packages/patrol_cli/**'
+              - 'packages/adb/**'
+              - 'packages/patrol_gen/**'
+              - 'dev/e2e_app/**'
+              - 'schema.dart'
+              - 'gen_from_schema'
+              - '!**.md'
+              - '!**.mdx'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request_target" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.perm.outputs.require-result }}" = "true" ] && [ "${{ steps.filter.outputs.relevant }}" = "true" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   run_tests:
     name: Flutter ${{ matrix.flutter-version }} webview on emulator.wtf
+    needs: access
+    if: ${{ needs.access.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -45,23 +85,6 @@ jobs:
         working-directory: dev/e2e_app
 
     steps:
-      - name: Get User Permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check User Permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
-
       - name: Clone repository
         uses: actions/checkout@v4
         with:
@@ -143,3 +166,17 @@ jobs:
       SLACK_MESSAGE_TITLE: ${{ needs.run_tests.outputs.SLACK_MESSAGE_TITLE }}
       URL_TO_DETAILS: ${{ needs.run_tests.outputs.URL_TO_DETAILS }}
     secrets: inherit
+
+  test-android-emulator-webview-gate:
+    name: test android emulator webview gate
+    needs: [access, run_tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/test-android-emulator-webview.yaml
+++ b/.github/workflows/test-android-emulator-webview.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Filter paths
         id: filter
         if: github.event_name == 'pull_request_target'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
         with:
           predicate-quantifier: every
           filters: |

--- a/.github/workflows/test-android-emulator-webview.yaml
+++ b/.github/workflows/test-android-emulator-webview.yaml
@@ -13,10 +13,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Decides whether the heavy emulator.wtf job runs. On a PR it runs only when
-  # the actor has write access (secrets never reach a fork) and the PR touches
-  # relevant paths. An outside contributor's PR skips run_tests, so the gate
-  # still goes green and the PR is not wedged; a maintainer runs it before merge.
+  # Decides whether the heavy emulator.wtf job runs. Its secrets must never reach
+  # fork code, so on a PR it runs only when the branch lives in this repo
+  # (head.repo == this repo, i.e. a trusted author with write access) and the PR
+  # touches relevant paths. A fork PR skips run_tests, so the gate still goes
+  # green and the PR is not wedged; a maintainer tests it from a trusted branch.
+  # We check head.repo, not github.triggering_actor: the actor becomes the
+  # maintainer on a re-run, which would otherwise expose secrets to fork code.
   access:
     name: access
     runs-on: ubuntu-latest
@@ -25,39 +28,23 @@ jobs:
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
-      - name: Check user permission
-        id: perm
-        if: github.event_name == 'pull_request_target'
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Filter paths
         id: filter
         if: github.event_name == 'pull_request_target'
         uses: dorny/paths-filter@v3
         with:
+          predicate-quantifier: every
           filters: |
             relevant:
-              - 'packages/patrol/**'
-              - 'packages/patrol_finders/**'
-              - 'packages/patrol_log/**'
-              - 'packages/patrol_cli/**'
-              - 'packages/adb/**'
-              - 'packages/patrol_gen/**'
-              - 'dev/e2e_app/**'
-              - 'schema.dart'
-              - 'gen_from_schema'
-              - '!**.md'
-              - '!**.mdx'
+              - '{packages/patrol/**,packages/patrol_finders/**,packages/patrol_log/**,packages/patrol_cli/**,packages/adb/**,packages/patrol_gen/**,dev/e2e_app/**,schema.dart,gen_from_schema}'
+              - '!**/*.md'
+              - '!**/*.mdx'
       - name: Decide whether to run
         id: decide
         run: |
           if [ "${{ github.event_name }}" != "pull_request_target" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
-          elif [ "${{ steps.perm.outputs.require-result }}" = "true" ] && [ "${{ steps.filter.outputs.relevant }}" = "true" ]; then
+          elif [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ] && [ "${{ steps.filter.outputs.relevant }}" = "true" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-android-emulator.yaml
+++ b/.github/workflows/test-android-emulator.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Filter paths
         id: filter
         if: github.event_name == 'pull_request_target'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
         with:
           predicate-quantifier: every
           filters: |

--- a/.github/workflows/test-android-emulator.yaml
+++ b/.github/workflows/test-android-emulator.yaml
@@ -7,26 +7,66 @@ on:
     - cron: "0 */12 * * *"
   pull_request_target:
     types: [opened, synchronize]
-    paths:
-      - 'packages/patrol/**'
-      - 'packages/patrol_finders/**'
-      - 'packages/patrol_log/**'
-      - 'packages/patrol_cli/**'
-      - 'packages/adb/**'
-      - 'packages/patrol_gen/**'
-      - 'dev/e2e_app/**'
-      - 'schema.dart'
-      - 'gen_from_schema'
-      - '!**.md'
-      - '!**.mdx'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  # Decides whether the heavy emulator.wtf job runs. On a PR it runs only when
+  # the actor has write access (secrets never reach a fork) and the PR touches
+  # relevant paths. An outside contributor's PR skips run_tests, so the gate
+  # still goes green and the PR is not wedged; a maintainer runs it before merge.
+  access:
+    name: access
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - name: Check user permission
+        id: perm
+        if: github.event_name == 'pull_request_target'
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request_target'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol/**'
+              - 'packages/patrol_finders/**'
+              - 'packages/patrol_log/**'
+              - 'packages/patrol_cli/**'
+              - 'packages/adb/**'
+              - 'packages/patrol_gen/**'
+              - 'dev/e2e_app/**'
+              - 'schema.dart'
+              - 'gen_from_schema'
+              - '!**.md'
+              - '!**.mdx'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request_target" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.perm.outputs.require-result }}" = "true" ] && [ "${{ steps.filter.outputs.relevant }}" = "true" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   run_tests:
     name: Flutter ${{ matrix.flutter-version }} on API ${{ matrix.api-level }}
+    needs: access
+    if: ${{ needs.access.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 55
     outputs:
@@ -46,23 +86,6 @@ jobs:
         working-directory: dev/e2e_app
 
     steps:
-      - name: Get User Permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check User Permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
-
       - name: Clone repository
         uses: actions/checkout@v4
         with:
@@ -149,3 +172,17 @@ jobs:
       SLACK_MESSAGE_TITLE: ${{ needs.run_tests.outputs.SLACK_MESSAGE_TITLE }}
       URL_TO_DETAILS: ${{ needs.run_tests.outputs.URL_TO_DETAILS }}
     secrets: inherit
+
+  test-android-emulator-gate:
+    name: test android emulator gate
+    needs: [access, run_tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/test-android-emulator.yaml
+++ b/.github/workflows/test-android-emulator.yaml
@@ -13,10 +13,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Decides whether the heavy emulator.wtf job runs. On a PR it runs only when
-  # the actor has write access (secrets never reach a fork) and the PR touches
-  # relevant paths. An outside contributor's PR skips run_tests, so the gate
-  # still goes green and the PR is not wedged; a maintainer runs it before merge.
+  # Decides whether the heavy emulator.wtf job runs. Its secrets must never reach
+  # fork code, so on a PR it runs only when the branch lives in this repo
+  # (head.repo == this repo, i.e. a trusted author with write access) and the PR
+  # touches relevant paths. A fork PR skips run_tests, so the gate still goes
+  # green and the PR is not wedged; a maintainer tests it from a trusted branch.
+  # We check head.repo, not github.triggering_actor: the actor becomes the
+  # maintainer on a re-run, which would otherwise expose secrets to fork code.
   access:
     name: access
     runs-on: ubuntu-latest
@@ -25,39 +28,23 @@ jobs:
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
-      - name: Check user permission
-        id: perm
-        if: github.event_name == 'pull_request_target'
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Filter paths
         id: filter
         if: github.event_name == 'pull_request_target'
         uses: dorny/paths-filter@v3
         with:
+          predicate-quantifier: every
           filters: |
             relevant:
-              - 'packages/patrol/**'
-              - 'packages/patrol_finders/**'
-              - 'packages/patrol_log/**'
-              - 'packages/patrol_cli/**'
-              - 'packages/adb/**'
-              - 'packages/patrol_gen/**'
-              - 'dev/e2e_app/**'
-              - 'schema.dart'
-              - 'gen_from_schema'
-              - '!**.md'
-              - '!**.mdx'
+              - '{packages/patrol/**,packages/patrol_finders/**,packages/patrol_log/**,packages/patrol_cli/**,packages/adb/**,packages/patrol_gen/**,dev/e2e_app/**,schema.dart,gen_from_schema}'
+              - '!**/*.md'
+              - '!**/*.mdx'
       - name: Decide whether to run
         id: decide
         run: |
           if [ "${{ github.event_name }}" != "pull_request_target" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
-          elif [ "${{ steps.perm.outputs.require-result }}" = "true" ] && [ "${{ steps.filter.outputs.relevant }}" = "true" ]; then
+          elif [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ] && [ "${{ steps.filter.outputs.relevant }}" = "true" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -13,19 +13,12 @@ jobs:
   changes:
     uses: ./.github/workflows/_relevant.yaml
     with:
+      quantifier: every
       filters: |
         relevant:
-          - 'packages/patrol/**'
-          - 'packages/patrol_finders/**'
-          - 'packages/patrol_log/**'
-          - 'packages/patrol_cli/**'
-          - 'packages/adb/**'
-          - 'packages/patrol_gen/**'
-          - 'dev/e2e_app/**'
-          - 'schema.dart'
-          - 'gen_from_schema'
-          - '!**.md'
-          - '!**.mdx'
+          - '{packages/patrol/**,packages/patrol_finders/**,packages/patrol_log/**,packages/patrol_cli/**,packages/adb/**,packages/patrol_gen/**,dev/e2e_app/**,schema.dart,gen_from_schema}'
+          - '!**/*.md'
+          - '!**/*.mdx'
 
   run_tests:
     name: Flutter ${{ matrix.flutter-version }} on ${{ matrix.device_model }} (${{ matrix.os_version }}) simulator

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -11,39 +11,21 @@ concurrency:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/patrol/**'
-              - 'packages/patrol_finders/**'
-              - 'packages/patrol_log/**'
-              - 'packages/patrol_cli/**'
-              - 'packages/adb/**'
-              - 'packages/patrol_gen/**'
-              - 'dev/e2e_app/**'
-              - 'schema.dart'
-              - 'gen_from_schema'
-              - '!**.md'
-              - '!**.mdx'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/patrol/**'
+          - 'packages/patrol_finders/**'
+          - 'packages/patrol_log/**'
+          - 'packages/patrol_cli/**'
+          - 'packages/adb/**'
+          - 'packages/patrol_gen/**'
+          - 'dev/e2e_app/**'
+          - 'schema.dart'
+          - 'gen_from_schema'
+          - '!**.md'
+          - '!**.mdx'
 
   run_tests:
     name: Flutter ${{ matrix.flutter-version }} on ${{ matrix.device_model }} (${{ matrix.os_version }}) simulator

--- a/.github/workflows/test-ios-simulator.yaml
+++ b/.github/workflows/test-ios-simulator.yaml
@@ -3,18 +3,6 @@ name: test ios simulator
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'packages/patrol/**'
-      - 'packages/patrol_finders/**'
-      - 'packages/patrol_log/**'
-      - 'packages/patrol_cli/**'
-      - 'packages/adb/**'
-      - 'packages/patrol_gen/**'
-      - 'dev/e2e_app/**'
-      - 'schema.dart'
-      - 'gen_from_schema'
-      - '!**.md'
-      - '!**.mdx'
 
 
 concurrency:
@@ -22,8 +10,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol/**'
+              - 'packages/patrol_finders/**'
+              - 'packages/patrol_log/**'
+              - 'packages/patrol_cli/**'
+              - 'packages/adb/**'
+              - 'packages/patrol_gen/**'
+              - 'dev/e2e_app/**'
+              - 'schema.dart'
+              - 'gen_from_schema'
+              - '!**.md'
+              - '!**.mdx'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   run_tests:
     name: Flutter ${{ matrix.flutter-version }} on ${{ matrix.device_model }} (${{ matrix.os_version }}) simulator
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: macos-latest
     timeout-minutes: 30
     outputs:
@@ -203,3 +228,17 @@ jobs:
       ERROR_STATUS: ${{ needs.run_tests.outputs.ERROR_STATUS }}
       SLACK_MESSAGE_TITLE: ${{ needs.run_tests.outputs.SLACK_MESSAGE_TITLE }}
     secrets: inherit
+
+  test-ios-simulator-gate:
+    name: test ios simulator gate
+    needs: [changes, run_tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -12,39 +12,21 @@ concurrency:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/patrol/**'
-              - 'packages/patrol_finders/**'
-              - 'packages/patrol_log/**'
-              - 'packages/patrol_cli/**'
-              - 'packages/adb/**'
-              - 'packages/patrol_gen/**'
-              - 'dev/e2e_app/**'
-              - 'schema.dart'
-              - 'gen_from_schema'
-              - '!**.md'
-              - '!**.mdx'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/patrol/**'
+          - 'packages/patrol_finders/**'
+          - 'packages/patrol_log/**'
+          - 'packages/patrol_cli/**'
+          - 'packages/adb/**'
+          - 'packages/patrol_gen/**'
+          - 'dev/e2e_app/**'
+          - 'schema.dart'
+          - 'gen_from_schema'
+          - '!**.md'
+          - '!**.mdx'
 
   run_tests:
     name: Flutter ${{ matrix.flutter-version }} on ${{ matrix.device_model }}

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -5,26 +5,51 @@ on:
   schedule:
     - cron: '0 0 * * *'
   pull_request:
-    paths:
-      - 'packages/patrol/**'
-      - 'packages/patrol_finders/**'
-      - 'packages/patrol_log/**'
-      - 'packages/patrol_cli/**'
-      - 'packages/adb/**'
-      - 'packages/patrol_gen/**'
-      - 'dev/e2e_app/**'
-      - 'schema.dart'
-      - 'gen_from_schema'
-      - '!**.md'
-      - '!**.mdx'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol/**'
+              - 'packages/patrol_finders/**'
+              - 'packages/patrol_log/**'
+              - 'packages/patrol_cli/**'
+              - 'packages/adb/**'
+              - 'packages/patrol_gen/**'
+              - 'dev/e2e_app/**'
+              - 'schema.dart'
+              - 'gen_from_schema'
+              - '!**.md'
+              - '!**.mdx'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   run_tests:
     name: Flutter ${{ matrix.flutter-version }} on ${{ matrix.device_model }}
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: macos-latest
     timeout-minutes: 25
     outputs:
@@ -168,3 +193,17 @@ jobs:
       ERROR_STATUS: ${{ needs.run_tests.outputs.ERROR_STATUS }}
       SLACK_MESSAGE_TITLE: ${{ needs.run_tests.outputs.SLACK_MESSAGE_TITLE }}
     secrets: inherit
+
+  test-macos-gate:
+    name: test macos gate
+    needs: [changes, run_tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -14,19 +14,12 @@ jobs:
   changes:
     uses: ./.github/workflows/_relevant.yaml
     with:
+      quantifier: every
       filters: |
         relevant:
-          - 'packages/patrol/**'
-          - 'packages/patrol_finders/**'
-          - 'packages/patrol_log/**'
-          - 'packages/patrol_cli/**'
-          - 'packages/adb/**'
-          - 'packages/patrol_gen/**'
-          - 'dev/e2e_app/**'
-          - 'schema.dart'
-          - 'gen_from_schema'
-          - '!**.md'
-          - '!**.mdx'
+          - '{packages/patrol/**,packages/patrol_finders/**,packages/patrol_log/**,packages/patrol_cli/**,packages/adb/**,packages/patrol_gen/**,dev/e2e_app/**,schema.dart,gen_from_schema}'
+          - '!**/*.md'
+          - '!**/*.mdx'
 
   run_tests:
     name: Flutter ${{ matrix.flutter-version }} on ${{ matrix.device_model }}

--- a/.github/workflows/test-patrol-develop.yaml
+++ b/.github/workflows/test-patrol-develop.yaml
@@ -6,26 +6,51 @@ on:
   # checked out the base branch, so every run tested master instead of the PR.
   pull_request:
     types: [opened, synchronize]
-    paths:
-      - 'packages/patrol/**'
-      - 'packages/patrol_finders/**'
-      - 'packages/patrol_log/**'
-      - 'packages/patrol_cli/**'
-      - 'packages/adb/**'
-      - 'packages/patrol_gen/**'
-      - 'dev/e2e_app/**'
-      - 'schema.dart'
-      - 'gen_from_schema'
-      - '!**.md'
-      - '!**.mdx'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol/**'
+              - 'packages/patrol_finders/**'
+              - 'packages/patrol_log/**'
+              - 'packages/patrol_cli/**'
+              - 'packages/adb/**'
+              - 'packages/patrol_gen/**'
+              - 'dev/e2e_app/**'
+              - 'schema.dart'
+              - 'gen_from_schema'
+              - '!**.md'
+              - '!**.mdx'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   test-linux:
     name: Test `patrol develop` on Linux
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -76,6 +101,8 @@ jobs:
 
   test-macos:
     name: Test `patrol develop` on macOS
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     # macos-15 is on macOS 15.7, where simulator mDNS is broken and
     # `flutter attach` cannot discover the app. See flutter#166333.
     runs-on: macos-latest
@@ -119,3 +146,17 @@ jobs:
         run: |
           dart pub get
           dart patrol_develop_test.dart --ios 26.2
+
+  test-patrol-develop-gate:
+    name: test patrol develop gate
+    needs: [changes, test-linux, test-macos]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/test-patrol-develop.yaml
+++ b/.github/workflows/test-patrol-develop.yaml
@@ -13,39 +13,21 @@ concurrency:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/patrol/**'
-              - 'packages/patrol_finders/**'
-              - 'packages/patrol_log/**'
-              - 'packages/patrol_cli/**'
-              - 'packages/adb/**'
-              - 'packages/patrol_gen/**'
-              - 'dev/e2e_app/**'
-              - 'schema.dart'
-              - 'gen_from_schema'
-              - '!**.md'
-              - '!**.mdx'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/patrol/**'
+          - 'packages/patrol_finders/**'
+          - 'packages/patrol_log/**'
+          - 'packages/patrol_cli/**'
+          - 'packages/adb/**'
+          - 'packages/patrol_gen/**'
+          - 'dev/e2e_app/**'
+          - 'schema.dart'
+          - 'gen_from_schema'
+          - '!**.md'
+          - '!**.mdx'
 
   test-linux:
     name: Test `patrol develop` on Linux

--- a/.github/workflows/test-patrol-develop.yaml
+++ b/.github/workflows/test-patrol-develop.yaml
@@ -15,19 +15,12 @@ jobs:
   changes:
     uses: ./.github/workflows/_relevant.yaml
     with:
+      quantifier: every
       filters: |
         relevant:
-          - 'packages/patrol/**'
-          - 'packages/patrol_finders/**'
-          - 'packages/patrol_log/**'
-          - 'packages/patrol_cli/**'
-          - 'packages/adb/**'
-          - 'packages/patrol_gen/**'
-          - 'dev/e2e_app/**'
-          - 'schema.dart'
-          - 'gen_from_schema'
-          - '!**.md'
-          - '!**.mdx'
+          - '{packages/patrol/**,packages/patrol_finders/**,packages/patrol_log/**,packages/patrol_cli/**,packages/adb/**,packages/patrol_gen/**,dev/e2e_app/**,schema.dart,gen_from_schema}'
+          - '!**/*.md'
+          - '!**/*.mdx'
 
   test-linux:
     name: Test `patrol develop` on Linux

--- a/.github/workflows/test-web.yaml
+++ b/.github/workflows/test-web.yaml
@@ -10,37 +10,19 @@ concurrency:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/patrol/**'
-              - 'packages/patrol_finders/**'
-              - 'packages/patrol_log/**'
-              - 'packages/patrol_cli/**'
-              - 'packages/adb/**'
-              - 'packages/patrol_gen/**'
-              - 'dev/e2e_app/**'
-              - '!**.md'
-              - '!**.mdx'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/patrol/**'
+          - 'packages/patrol_finders/**'
+          - 'packages/patrol_log/**'
+          - 'packages/patrol_cli/**'
+          - 'packages/adb/**'
+          - 'packages/patrol_gen/**'
+          - 'dev/e2e_app/**'
+          - '!**.md'
+          - '!**.mdx'
 
   run_tests:
     name: Flutter ${{ matrix.flutter-version }} on Web

--- a/.github/workflows/test-web.yaml
+++ b/.github/workflows/test-web.yaml
@@ -3,26 +3,49 @@ name: test web
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'packages/patrol/**'
-      - 'packages/patrol_finders/**'
-      - 'packages/patrol_log/**'
-      - 'packages/patrol_cli/**'
-      - 'packages/adb/**'
-      - 'packages/patrol_gen/**'
-      - 'dev/e2e_app/**'
-      - 'packages/patrol/web_runner/**'
-      - '!**.md'
-      - '!**.mdx'
-      - 'dev/e2e_app/patrol_test/web/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol/**'
+              - 'packages/patrol_finders/**'
+              - 'packages/patrol_log/**'
+              - 'packages/patrol_cli/**'
+              - 'packages/adb/**'
+              - 'packages/patrol_gen/**'
+              - 'dev/e2e_app/**'
+              - '!**.md'
+              - '!**.mdx'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   run_tests:
     name: Flutter ${{ matrix.flutter-version }} on Web
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
   
@@ -76,3 +99,17 @@ jobs:
           name: playwright-report-${{ matrix.flutter-version }}
           path: dev/e2e_app/playwright-report/
           retention-days: 7
+
+  test-web-gate:
+    name: test web gate
+    needs: [changes, run_tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/test-web.yaml
+++ b/.github/workflows/test-web.yaml
@@ -12,17 +12,12 @@ jobs:
   changes:
     uses: ./.github/workflows/_relevant.yaml
     with:
+      quantifier: every
       filters: |
         relevant:
-          - 'packages/patrol/**'
-          - 'packages/patrol_finders/**'
-          - 'packages/patrol_log/**'
-          - 'packages/patrol_cli/**'
-          - 'packages/adb/**'
-          - 'packages/patrol_gen/**'
-          - 'dev/e2e_app/**'
-          - '!**.md'
-          - '!**.mdx'
+          - '{packages/patrol/**,packages/patrol_finders/**,packages/patrol_log/**,packages/patrol_cli/**,packages/adb/**,packages/patrol_gen/**,dev/e2e_app/**}'
+          - '!**/*.md'
+          - '!**/*.mdx'
 
   run_tests:
     name: Flutter ${{ matrix.flutter-version }} on Web

--- a/.github/workflows/verify_compatibility.yml
+++ b/.github/workflows/verify_compatibility.yml
@@ -8,12 +8,37 @@ on:
       - 'packages/patrol_cli/test/compatibility_checker/version_compatibility_test.dart'
   pull_request:
     branches: [ master ]
-    paths:
-      - 'packages/patrol_cli/lib/src/compatibility_checker/version_compatibility.dart'
-      - 'packages/patrol_cli/test/compatibility_checker/version_compatibility_test.dart'
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Filter paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'packages/patrol_cli/lib/src/compatibility_checker/version_compatibility.dart'
+              - 'packages/patrol_cli/test/compatibility_checker/version_compatibility_test.dart'
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          fi
+
   verify:
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     
     steps:
@@ -45,4 +70,18 @@ jobs:
           echo "$MODIFIED_TABLES"
           echo "Please run 'dart run lib/src/compatibility_checker/generate_compatibility_table.dart' and commit the changes."
           exit 1
-        fi 
+        fi
+
+  verify-compatibility-gate:
+    name: Verify Version Compatibility gate
+    needs: [changes, verify]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job did not pass: ${{ join(needs.*.result, ' ') }}"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped: ${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/verify_compatibility.yml
+++ b/.github/workflows/verify_compatibility.yml
@@ -11,30 +11,12 @@ on:
 
 jobs:
   changes:
-    name: changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      relevant: ${{ steps.decide.outputs.relevant }}
-    steps:
-      - name: Filter paths
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            relevant:
-              - 'packages/patrol_cli/lib/src/compatibility_checker/version_compatibility.dart'
-              - 'packages/patrol_cli/test/compatibility_checker/version_compatibility_test.dart'
-      - name: Decide whether to run
-        id: decide
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "relevant=${{ steps.filter.outputs.relevant }}" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/_relevant.yaml
+    with:
+      filters: |
+        relevant:
+          - 'packages/patrol_cli/lib/src/compatibility_checker/version_compatibility.dart'
+          - 'packages/patrol_cli/test/compatibility_checker/version_compatibility_test.dart'
 
   verify:
     needs: changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ In the PR description mention the issue that this PR resolves. If that issue doe
 
 Use `## Unreleased` title if you're not sure what should be next version number.
 
-Be aware that `test android emulator` and `test android emulator webview` workflows will fails due to insufficient permission of a contributor. Those will have to be re-run by someone with the write access in the repository.
+Be aware that `test android emulator` and `test android emulator webview` run their emulator.wtf job only for PRs whose branch lives in this repository. On a PR from a fork that job is skipped, so it does not fail and the PR is not blocked. Re-running does not change this, since the check is on the head repository, not on the actor who triggered the run. To exercise these workflows on a fork PR, a maintainer runs them from an in-repo branch.
 
 ## Running patrol_cli locally
 


### PR DESCRIPTION
Make CI checks enforceable as required status checks, without the path-filter "stuck pending" trap.

| Status | Workflows |
|---|---|
| **Mandatory** (gated, will block merge once set required) | patrol prepare · patrol_cli prepare · patrol_finders prepare · patrol_log prepare · patrol_devtools_extension prepare · patrol_gen prepare · patrol_mcp prepare · adb prepare · prepare e2e_app · check changelog · check skills · Verify Version Compatibility · test android emulator · test android emulator webview · test macos · test web · test patrol develop · test ios simulator |
| **Advisory** (run, never block) | patrol / patrol_finders / patrol_log check semver · patrol_mcp cli-compat · pana scores · `pub publish --dry-run` |
| **Never a PR gate** (scheduled only) | test flutter main · test flutter beta · test android device · test ios device · test locales android · test locales ios · test ios simulator webview |

**Problem**
- Failing workflows didn't block merges, so regressions slipped through.
- A required check filtered out by `on: paths` never reports, leaving the PR stuck "Expected — waiting for status". No branch-protection/ruleset setting treats a missing check as passed.

**Change**
- Each mandatory workflow drops `on: paths`, gains a change-detection job (reusable `_relevant.yaml`; the two emulator.wtf workflows use an inline `access` job) + a `<workflow> gate` job (`if: always()`) that fails only on real failure/cancel.
- Real jobs run under `if: needs.changes.outputs.relevant == 'true'`; skipped == success, so the gate stays green on unrelated PRs. Require the `* gate` names, not each matrix job.
- emulator.wtf (`pull_request_target`): the `access` job runs the secret job only for in-repo head branches (`head.repo == github.repository`); fork PRs skip and the gate passes.
- `pub publish --dry-run` set to `continue-on-error`: pub's bundled analyzer false-positives (exit 65); still reported, no longer blocking. pana stays advisory.
- `dorny/paths-filter` pinned to a commit SHA. Decision + rollout at the top of `.github/WORKFLOWS.md`.

**Watch out**
- Nothing is required yet. Rollout: (1) merge, (2) green test PR, (3) admin adds the `* gate` contexts as required.
- Confirm `dorny/paths-filter` is allowed by the org action policy, else `changes` jobs fail.

**Result**
- Static: actionlint + YAML parse clean on all changed files. CI unverified until a test PR.
