### PR TITLE
docs: explain which appId owns iOS system sheets

### DIFF
--- a/dev/e2e_app/ios/Runner/Info.plist
+++ b/dev/e2e_app/ios/Runner/Info.plist
@@ -37,6 +37,8 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_dartobservatory._tcp</string>
@@ -58,6 +60,8 @@
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This app needs access to photo library to select images</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/dev/e2e_app/lib/file_picker_screen.dart
+++ b/dev/e2e_app/lib/file_picker_screen.dart
@@ -1,0 +1,52 @@
+import 'package:e2e_app/keys.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+
+/// Exercises the native file picker, so tests can drive it with Patrol's
+/// native automation.
+class FilePickerScreen extends StatefulWidget {
+  const FilePickerScreen({super.key});
+
+  @override
+  State<FilePickerScreen> createState() => _FilePickerScreenState();
+}
+
+class _FilePickerScreenState extends State<FilePickerScreen> {
+  var _status = 'idle';
+
+  Future<void> _pickFile() async {
+    setState(() => _status = 'picking');
+
+    final result = await FilePicker.platform.pickFiles();
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _status = result == null
+          ? 'cancelled'
+          : 'picked: ${result.files.single.name}';
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('File picker')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(_status, key: K.filePickerStatusText),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              key: K.pickFileButton,
+              onPressed: _pickFile,
+              child: const Text('Pick file'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/dev/e2e_app/lib/keys.dart
+++ b/dev/e2e_app/lib/keys.dart
@@ -39,6 +39,11 @@ class Keys {
   static const textfieldsScreenButton = Key('textfieldsScreenButton');
   static const openExternalAppScreenButton = Key('openExternalAppScreenButton');
 
+  // file picker screen
+  static const filePickerScreenButton = Key('filePickerScreenButton');
+  static const filePickerStatusText = Key('filePickerStatusText');
+  static const pickFileButton = Key('pickFileButton');
+
   // text fields screen
   static const textField1 = Key('textField1');
   static const textField2 = Key('textField2');

--- a/dev/e2e_app/lib/main.dart
+++ b/dev/e2e_app/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:e2e_app/applink_screen.dart';
 import 'package:e2e_app/at_finder_screen.dart';
 import 'package:e2e_app/camera_screen.dart';
 import 'package:e2e_app/external_app_screen.dart';
+import 'package:e2e_app/file_picker_screen.dart';
 import 'package:e2e_app/keys.dart';
 import 'package:e2e_app/loading_screen.dart';
 import 'package:e2e_app/location_screen.dart';
@@ -320,6 +321,13 @@ class _ExampleHomePageState extends State<ExampleHomePage> {
               MaterialPageRoute<void>(builder: (_) => const TextfieldsScreen()),
             ),
             child: const Text('Open many textfields screen'),
+          ),
+          TextButton(
+            key: K.filePickerScreenButton,
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(builder: (_) => const FilePickerScreen()),
+            ),
+            child: const Text('Open file picker screen'),
           ),
           TextButton(
             key: K.openExternalAppScreenButton,

--- a/dev/e2e_app/patrol_test/native_tests/file_picker_test.dart
+++ b/dev/e2e_app/patrol_test/native_tests/file_picker_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+import 'common.dart';
+
+/// Puts a file in the app's Documents directory. Thanks to
+/// `UIFileSharingEnabled` and `LSSupportsOpeningDocumentsInPlace` in the
+/// Info.plist, it shows up in the native file picker under
+/// On My iPhone > Example, which gives the test a folder and a file to
+/// navigate to. The test body runs in the app process, so it writes to the
+/// app's own sandbox.
+Future<File> _createTestFile() async {
+  final documents = await getApplicationDocumentsDirectory();
+
+  return File('${documents.path}/patrol_test_file.txt')
+    ..writeAsStringSync('patrol');
+}
+
+void main() {
+  patrol('picks a file from the iOS file picker', ($) async {
+    await createApp($);
+
+    final file = await _createTestFile();
+    $.log('created ${file.path}, exists=${file.existsSync()}');
+
+    await $(#filePickerScreenButton).scrollTo().tap();
+    await $(#pickFileButton).tap();
+
+    // The picker opens on the Recents tab; go to Browse > On My iPhone >
+    // Example (the app's Documents folder) and pick the test file. The picker
+    // is a system view, but it lives in the app under test's view hierarchy,
+    // so it's driven with the default appId.
+    await $.platform.ios.tap(IOSSelector(label: 'Browse'));
+    await $.platform.ios.tap(IOSSelector(labelContains: 'On My iPhone'));
+    await $.platform.ios.tap(IOSSelector(labelContains: 'Example'));
+    await $.platform.ios.tap(IOSSelector(labelContains: 'patrol_test_file'));
+
+    await $.waitUntilVisible($('picked: patrol_test_file.txt'));
+  }, tags: ['ios', 'simulator']);
+}

--- a/dev/e2e_app/pubspec.lock
+++ b/dev/e2e_app/pubspec.lock
@@ -817,7 +817,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/dev/e2e_app/pubspec.yaml
+++ b/dev/e2e_app/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   image_picker: ^1.1.2
   meta: ^1.10.0
   package_info_plus: ^8.3.1
+  path_provider: ^2.1.5
   permission_handler: ^11.4.0
   timezone: ^0.9.2
   web: ^1.1.1

--- a/docs/documentation/native/usage.mdx
+++ b/docs/documentation/native/usage.mdx
@@ -102,6 +102,30 @@ await $.platform.ios.tap(
 
 </Warning>
 
+#### System sheets (file picker, share sheet)
+
+System sheets presented from your app - like the file picker opened by the
+[file_picker](https://pub.dev/packages/file_picker) plugin, or the share
+sheet - are rendered by a separate system process, but they belong to your
+app's view hierarchy. Interact with them using the default `appId` (your app
+under test):
+
+```dart
+// Open the file picker from your Flutter app first, then:
+await $.platform.ios.tap(IOSSelector(label: 'Browse'));
+await $.platform.ios.tap(IOSSelector(labelContains: 'On My iPhone'));
+await $.platform.ios.tap(IOSSelector(labelContains: 'my_file'));
+```
+
+Don't pass `com.apple.springboard` here - it owns system alerts (like
+permission dialogs), not these sheets. Also don't use process names that show
+up in element identifiers in the Patrol DevTools inspector (like
+`com.apple.FileProvider.LocalStorage`) - they are system extensions, not apps
+that can be automated.
+
+For a complete working example that navigates the file picker and picks a
+file, see [`file_picker_test.dart`] in the Patrol repository.
+
 ### Web-specific actions
 
 For Flutter Web apps, use `$.platform.web` to interact with browser elements and features:
@@ -286,3 +310,4 @@ To build SDK-specific companion packages on top of Patrol, see [extension packag
 
 [example_app]: https://github.com/leancodepl/patrol/tree/master/packages/patrol/example
 [extension_packages]: /documentation/native/extension-packages
+[`file_picker_test.dart`]: https://github.com/leancodepl/patrol/blob/master/dev/e2e_app/patrol_test/native_tests/file_picker_test.dart


### PR DESCRIPTION
# docs: explain which appId owns iOS system sheets + file picker e2e coverage

Related to #2790 (a follow-up PR adds a code-side fix for the unattachable-appId hang).

## Why

Users testing flows that open the iOS file picker (e.g. via the `file_picker` plugin) or the share sheet consistently target the wrong `appId`:

- `com.apple.springboard` — sees none of the picker's elements, so every selector fails with `viewNotExists`;
- `com.apple.FileProvider.LocalStorage` (visible in the picker's element identifiers in the DevTools inspector) — a file provider extension without an accessibility server, which XCTest cannot automate at all (queries stall inside XCTest and end in a client `TimeoutException`).

Verified on an iPhone 17 Pro / iOS 26.1 simulator (the reporter's setup): the picker's elements live in the **app under test's** view hierarchy, so the whole flow (Browse → On My iPhone → folder → file) works with the **default `appId`** — nothing extra to pass.

## Changes

- **Docs**: new **"System sheets (file picker, share sheet)"** subsection in `docs/documentation/native/usage.mdx` (under *iOS-specific actions*), with a working snippet, an explicit warning against `com.apple.springboard` and inspector process names, and a link to the e2e test below.
- **`dev/e2e_app`**: `patrol_test/native_tests/file_picker_test.dart` — an e2e test that opens the picker and drives the full flow with the default appId (Browse → On My iPhone → Example → file), asserting the picked file lands back in Flutter. It guards the documented behavior on CI. Supporting fixtures:
  - new `FilePickerScreen` (uses the already-present `file_picker` dependency),

## Verification

- The test passes on an iPhone 17 Pro / iOS 26.1 simulator with the local `patrol_cli` (`✅ Successful: 1, ❌ Failed: 0`) — on unmodified automator code, confirming the documented flow works on current `master`.
- `dart analyze` and `dart format` clean.

