### PR TITLE
Allow killing and relaunching the app between test phases

### DIFF
--- a/dev/e2e_app/patrol_test/restart_app_test.dart
+++ b/dev/e2e_app/patrol_test/restart_app_test.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+import 'common.dart';
+
+Future<File> _pidFile() async {
+  final directory = await getApplicationSupportDirectory();
+  return File('${directory.path}/patrol_restart_app_test.pid');
+}
+
+void main() {
+  patrol(
+    'restarts the app between phases',
+    phases([
+      PatrolPhase(($) async {
+        await createApp($);
+        await (await _pidFile()).writeAsString('$pid', flush: true);
+      }),
+      PatrolPhase(($) async {
+        await createApp($);
+        final file = await _pidFile();
+        final previousPid = int.parse(await file.readAsString());
+
+        expect(pid, isNot(previousPid));
+        await file.delete();
+      }),
+    ]),
+    tags: ['ios', 'simulator'],
+  );
+}

--- a/dev/e2e_app/patrol_test/restart_app_test.dart
+++ b/dev/e2e_app/patrol_test/restart_app_test.dart
@@ -26,6 +26,5 @@ void main() {
         await file.delete();
       }),
     ]),
-    tags: ['ios', 'simulator'],
   );
 }

--- a/docs/documentation/meta.json
+++ b/docs/documentation/meta.json
@@ -14,6 +14,7 @@
     "physical-ios-devices-setup",
     "finders",
     "native",
+    "phased-tests",
     "ci",
     "integrations",
     "other"

--- a/docs/documentation/native/advanced.mdx
+++ b/docs/documentation/native/advanced.mdx
@@ -149,6 +149,9 @@ void main() {
 }
 ```
 
+`openApp` here brings the **same process** back. To kill the app and keep testing
+in a **new** process, see [phased tests].
+
 You can run this test and view its results in many ways, using all sorts of
 different tools, platforms, and IDEs:
 
@@ -199,5 +202,6 @@ different tools, platforms, and IDEs:
 This is so awesome!
 
 [native automation setup]: /documentation
+[phased tests]: /documentation/phased-tests
 [fastlane scan]: https://docs.fastlane.tools/actions/scan
 [integration_test]: https://github.com/flutter/flutter/tree/master/packages/integration_test

--- a/docs/documentation/phased-tests.mdx
+++ b/docs/documentation/phased-tests.mdx
@@ -1,0 +1,97 @@
+---
+title: Phased tests
+---
+
+A Patrol test is normally one Dart callback in one app process. **Phased tests**
+split that callback into consecutive phases. When a phase finishes, the native
+runner **kills the app and starts a new process** for the next phase.
+
+Use this when you need to keep testing after a real process death: in-memory
+state is gone, `main()` runs again, and persisted files or plugins survive if
+the OS did not wipe them.
+
+## Basic usage
+
+Pass `phases([...])` as the test body instead of a single `($) async { ... }`
+callback:
+
+```dart title="patrol_test/restart_app_test.dart"
+import 'dart:io';
+
+import 'package:patrol/patrol.dart';
+
+void main() {
+  patrolTest(
+    'restarts the app between phases',
+    phases([
+      PatrolPhase(($) async {
+        await $.pumpWidgetAndSettle(const MyApp());
+        // First process: write whatever you need to survive the kill.
+      }),
+      PatrolPhase(($) async {
+        await $.pumpWidgetAndSettle(const MyApp());
+        // Second process: the previous Dart isolate is gone.
+      }),
+    ]),
+  );
+}
+```
+
+The test **passes only if Dart reports success after the last phase**.
+
+Each phase is a fresh Flutter app. Pump your root widget again at the start of
+every phase (the same `createApp` / `$.pumpWidgetAndSettle` you already use).
+
+A working example lives in
+[`restart_app_test.dart`](https://github.com/leancodepl/patrol/blob/master/dev/e2e_app/patrol_test/restart_app_test.dart)
+in the Patrol repository: phase 1 writes the current PID to a file, phase 2
+asserts a different PID.
+
+## How to launch the next process
+
+By default the next phase starts the same way as a normal Patrol launch (the
+app's launcher activity / default URL).
+
+To open the next process through a deep link, set `launch` on **that** phase:
+
+```dart
+patrolTest(
+  'cold-starts from a deep link after a kill',
+  phases([
+    PatrolPhase(($) async {
+      await $.pumpWidgetAndSettle(const MyApp());
+      // ...
+    }),
+    PatrolPhase(
+      ($) async {
+        await $.pumpWidgetAndSettle(const MyApp());
+        // Assert the route that the URL opened.
+      },
+      launch: PatrolAppLaunch.deepLink('https://example.com/path'),
+    ),
+  ]),
+);
+```
+
+`PatrolAppLaunch.normal()` is the default.
+
+`launch` is **ignored on the first phase**. That process is already started by
+the native runner before Dart runs. Put a deep link on phase 2 or later.
+
+## Requirements and limits
+
+<Warning>
+  **Android** phased tests need the self-instrumenting [`:patrolTest`] layout.
+  The older in-app `androidTest` runner lives inside the app it would kill, so
+  Patrol throws if a test asks to continue.
+</Warning>
+
+- **Android and iOS only.** macOS fails if a test returns a continuation.
+- **`patrol test` / `patrol build`, not `patrol develop`.** Hot Restart cannot
+  survive killing the app. Phased tests throw in develop mode.
+- **Web is not supported.**
+- A phased list must contain **at least one** phase. One phase is valid; it
+  behaves like a normal test (no kill).
+
+[native automation]: /documentation/native/usage
+[`:patrolTest`]: /documentation#android-setup

--- a/packages/patrol/CHANGELOG.md
+++ b/packages/patrol/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- Add `phases()` so a Patrol test can continue after the app is killed and
+  relaunched (normal start or a deep link). Requires the self-instrumenting
+  Android `:patrolTest` layout; unsupported in `patrol develop` and on macOS.
+  See [Phased tests](https://patrol.leancode.co/documentation/phased-tests).
+  (#1374)
 - Add the optional self-instrumenting Android `:patrolTest` layout, which runs
   JUnit outside the app process. The in-app `androidTest` layout remains
   supported.

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAppServiceClient.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolAppServiceClient.kt
@@ -53,6 +53,12 @@ class PatrolAppServiceClient {
         return client.runDartTest(Contracts.RunDartTestRequest(name))
     }
 
+    @Throws(PatrolAppServiceClientException::class)
+    fun runDartTest(name: String, phaseIndex: Long): Contracts.RunDartTestResponse {
+        Logger.i("PatrolAppServiceClient.runDartTest($name, phaseIndex=$phaseIndex)")
+        return client.runDartTest(Contracts.RunDartTestRequest(name, phaseIndex))
+    }
+
     fun close() {
         client.close()
     }

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
@@ -9,6 +9,7 @@ import static org.junit.Assume.*;
 
 import android.app.Instrumentation;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.runner.AndroidJUnitRunner;
@@ -219,15 +220,20 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
             forceStopApp(appId);
         }
 
-        Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
-
         PatrolServer patrolServer = new PatrolServer();
         patrolServer.start();
+
+        launchApp(appId, activityClassName);
+        patrolAppServiceClient = createAppServiceClient();
+    }
+
+    private void launchApp(String appId, String activityClassName) {
+        Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
 
         // Launcher intents support activities declared through aliases.
         Intent intent = instrumentation.getContext().getPackageManager()
                 .getLaunchIntentForPackage(appId);
-        
+
         if (intent == null && activityClassName != null) {
             intent = new Intent(Intent.ACTION_MAIN);
             intent.setClassName(appId, activityClassName);
@@ -236,11 +242,9 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
         if (intent == null) {
             throw new IllegalStateException("No launch intent found for " + appId);
         }
-        
+
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         instrumentation.getContext().startActivity(intent);
-
-        patrolAppServiceClient = createAppServiceClient();
     }
 
     public PatrolAppServiceClient createAppServiceClient() {
@@ -467,6 +471,32 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
         try {
             Logger.INSTANCE.i(TAG + "Requested execution");
             RunDartTestResponse response = patrolAppServiceClient.runDartTest(name);
+
+            while (response.getResult() == Contracts.RunDartTestResponseResult.continuation) {
+                if (!isSelfInstrumenting()) {
+                    throw new IllegalStateException(
+                            "Phased Patrol tests require the self-instrumenting "
+                                    + ":patrolTest Android layout"
+                    );
+                }
+
+                final Long nextPhaseIndex = response.getNextPhaseIndex();
+                if (nextPhaseIndex == null) {
+                    throw new IllegalStateException(
+                            "A phased Patrol test returned continuation without a next phase"
+                    );
+                }
+
+                closePatrolAppServiceClient();
+                PatrolServer.Companion.getAppReady().close();
+                forceStopApp(targetAppId);
+                openApp(targetAppId, response.getNextPhaseLaunchUrl());
+
+                waitForPatrolAppService();
+                patrolAppServiceClient = createAppServiceClient();
+                response = patrolAppServiceClient.runDartTest(name, nextPhaseIndex);
+            }
+
             if (response.getResult() == Contracts.RunDartTestResponseResult.failure) {
                 throw new AssertionError("Dart test failed: " + name + "\n" + response.getDetails());
             }
@@ -482,5 +512,26 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
             Logger.INSTANCE.e(TAG + e.getMessage(), e.getCause());
             throw new RuntimeException(e);
         }
+    }
+
+    private void openApp(String appId, String url) {
+        if (url == null || url.isEmpty()) {
+            launchApp(appId, null);
+            return;
+        }
+
+        Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        intent.setPackage(appId);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        instrumentation.getContext().startActivity(intent);
+    }
+
+    private void closePatrolAppServiceClient() {
+        if (patrolAppServiceClient == null) {
+            return;
+        }
+        patrolAppServiceClient.close();
+        patrolAppServiceClient = null;
     }
 }

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/PatrolJUnitRunner.java
@@ -492,7 +492,7 @@ public class PatrolJUnitRunner extends AndroidJUnitRunner {
                 forceStopApp(targetAppId);
                 openApp(targetAppId, response.getNextPhaseLaunchUrl());
 
-                waitForPatrolAppService();
+                awaitPatrolAppService();
                 patrolAppServiceClient = createAppServiceClient();
                 response = patrolAppServiceClient.runDartTest(name, nextPhaseIndex);
             }

--- a/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
+++ b/packages/patrol/android/src/main/kotlin/pl/leancode/patrol/contracts/Contracts.kt
@@ -15,6 +15,7 @@ class Contracts {
     success,
     skipped,
     failure,
+    continuation,
   }
 
   enum class KeyboardBehavior {
@@ -203,15 +204,28 @@ class Contracts {
   )
 
   data class RunDartTestRequest (
-    val name: String
-  )
+    val name: String,
+    val phaseIndex: Long? = null
+  ){
+    fun hasPhaseIndex(): Boolean {
+      return phaseIndex != null
+    }
+  }
 
   data class RunDartTestResponse (
     val result: RunDartTestResponseResult,
-    val details: String? = null
+    val details: String? = null,
+    val nextPhaseIndex: Long? = null,
+    val nextPhaseLaunchUrl: String? = null
   ){
     fun hasDetails(): Boolean {
       return details != null
+    }
+    fun hasNextPhaseIndex(): Boolean {
+      return nextPhaseIndex != null
+    }
+    fun hasNextPhaseLaunchUrl(): Boolean {
+      return nextPhaseLaunchUrl != null
     }
   }
 

--- a/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Contracts.swift
+++ b/packages/patrol/darwin/patrol/Sources/PatrolImpl/AutomatorServer/Contracts.swift
@@ -14,6 +14,7 @@ public enum RunDartTestResponseResult: String, Codable {
   case success = "success"
   case skipped = "skipped"
   case failure = "failure"
+  case continuation = "continuation"
 }
 
 public enum KeyboardBehavior: String, Codable {
@@ -203,11 +204,14 @@ public struct ListDartTestsResponse: Codable {
 
 public struct RunDartTestRequest: Codable {
   public var name: String
+  public var phaseIndex: Int?
 }
 
 public struct RunDartTestResponse: Codable {
   public var result: RunDartTestResponseResult
   public var details: String?
+  public var nextPhaseIndex: Int?
+  public var nextPhaseLaunchUrl: String?
 }
 
 public struct ConfigureRequest: Codable {

--- a/packages/patrol/darwin/patrol/Sources/PatrolImpl/ObjCPatrolAppServiceClient.swift
+++ b/packages/patrol/darwin/patrol/Sources/PatrolImpl/ObjCPatrolAppServiceClient.swift
@@ -2,14 +2,21 @@ import Foundation
 
 /// Simplified objective-c RunDartTestResponse model that we use in PatrolIntegrationTestRunner.h
 @objc(ObjCRunDartTestResponse) public class ObjCRunDartTestResponse: NSObject {
-  @objc public dynamic let passed: Bool
-  @objc public dynamic let skipped: Bool
+  @objc public dynamic let result: String
   @objc public dynamic let details: String?
+  @objc public dynamic let nextPhaseIndex: NSNumber?
+  @objc public dynamic let nextPhaseLaunchUrl: String?
 
-  @objc public init(passed: Bool, skipped: Bool, details: String?) {
-    self.passed = passed
-    self.skipped = skipped
+  @objc public init(
+    result: String,
+    details: String?,
+    nextPhaseIndex: NSNumber?,
+    nextPhaseLaunchUrl: String?
+  ) {
+    self.result = result
     self.details = details
+    self.nextPhaseIndex = nextPhaseIndex
+    self.nextPhaseLaunchUrl = nextPhaseLaunchUrl
   }
 }
 
@@ -78,16 +85,27 @@ import Foundation
   @objc public func runDartTest(
     name: String, completion: @escaping (ObjCRunDartTestResponse?, Error?) -> Void
   ) {
-    NSLog("PatrolAppServiceClient.runDartTest(\(name))")
+    runDartTest(name: name, phaseIndex: nil, completion: completion)
+  }
 
-    let request = RunDartTestRequest(name: name)
+  @objc public func runDartTest(
+    name: String,
+    phaseIndex: NSNumber?,
+    completion: @escaping (ObjCRunDartTestResponse?, Error?) -> Void
+  ) {
+    NSLog(
+      "PatrolAppServiceClient.runDartTest(\(name), phaseIndex=\(String(describing: phaseIndex)))"
+    )
+
+    let request = RunDartTestRequest(name: name, phaseIndex: phaseIndex?.intValue)
     client.runDartTest(request: request) { result in
       switch result {
       case .success(let result):
         let testResponse = ObjCRunDartTestResponse(
-          passed: result.result == .success,
-          skipped: result.result == .skipped,
-          details: result.details
+          result: result.result.rawValue,
+          details: result.details,
+          nextPhaseIndex: result.nextPhaseIndex.map(NSNumber.init(value:)),
+          nextPhaseLaunchUrl: result.nextPhaseLaunchUrl
         )
         completion(testResponse, nil)
       case .failure(let error):

--- a/packages/patrol/darwin/patrol/Sources/patrol/include/PatrolIntegrationTestIosRunner.h
+++ b/packages/patrol/darwin/patrol/Sources/patrol/include/PatrolIntegrationTestIosRunner.h
@@ -41,6 +41,9 @@
     return [[NSProcessInfo processInfo].environment[@"PATROL_DEVELOP"] isEqualToString:@"1"];                       \
   }                                                                                                                 \
   +(void)launchPatrolAppWithServer : (PatrolServer *)server {                                                       \
+    [self launchPatrolAppWithServer:server launchURL:nil];                                                          \
+  }                                                                                                                 \
+  +(void)launchPatrolAppWithServer : (PatrolServer *)server launchURL : (NSString *)launchURL {                     \
     server.appReady = NO;                                                                                           \
     XCUIApplication *app = [[XCUIApplication alloc] init];                                                          \
     NSMutableDictionary<NSString *, NSString *> *environment =                                                      \
@@ -48,7 +51,21 @@
     environment[@"PATROL_TEST_SERVER_PORT"] = [NSString stringWithFormat:@"%ld", (long)server.boundTestPort];       \
     environment[@"PATROL_APP_SERVER_PORT"] = [NSString stringWithFormat:@"%ld", (long)server.boundAppPort];         \
     app.launchEnvironment = environment;                                                                            \
-    [app launch];                                                                                                   \
+    if (launchURL == nil) {                                                                                         \
+      [app launch];                                                                                                 \
+    } else {                                                                                                        \
+      NSURL *url = [NSURL URLWithString:launchURL];                                                                 \
+      XCTAssertNotNil(url, @"Invalid phase launch URL: %@", launchURL);                                             \
+      if (url == nil) {                                                                                             \
+        return;                                                                                                     \
+      }                                                                                                             \
+      if (@available(iOS 16.4, *)) {                                                                                \
+        [app openURL:url];                                                                                          \
+      } else {                                                                                                      \
+        [app launch];                                                                                               \
+        [[XCUIDevice sharedDevice].system openURL:url];                                                             \
+      }                                                                                                             \
+    }                                                                                                               \
   }                                                                                                                 \
   +(BOOL)waitForPatrolAppReadyWithServer : (PatrolServer *)server {                                                 \
     NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:60.0];                                                  \
@@ -338,27 +355,49 @@
         }                                                                                                           \
                                                                                                                     \
         __block ObjCRunDartTestResponse *response = NULL;                                                           \
-        __block NSError *error;                                                                                     \
-        [appServiceClient                                                                                           \
-            runDartTestWithName:dartTestName                                                                        \
-                     completion:^(ObjCRunDartTestResponse *_Nullable r, NSError *_Nullable err) {                   \
-                       NSString *status;                                                                            \
-                       if (err != NULL) {                                                                           \
-                         error = err;                                                                               \
-                         status = @"CRASHED";                                                                       \
-                       } else {                                                                                     \
-                         response = r;                                                                              \
-                         status = response.passed ? @"PASSED" : @"FAILED";                                          \
-                       }                                                                                            \
-                       NSLog(@"runDartTest(\"%@\"): call finished, test result: %@", dartTestName, status);         \
-                     }];                                                                                            \
+        __block NSError *error = nil;                                                                               \
+        NSNumber *phaseIndex = nil;                                                                                 \
+        while (true) {                                                                                              \
+          response = NULL;                                                                                          \
+          error = nil;                                                                                              \
+          [appServiceClient                                                                                         \
+              runDartTestWithName:dartTestName                                                                      \
+                       phaseIndex:phaseIndex                                                                        \
+                       completion:^(ObjCRunDartTestResponse *_Nullable r, NSError *_Nullable err) {                 \
+                         if (err != NULL) {                                                                         \
+                           error = err;                                                                             \
+                         } else {                                                                                   \
+                           response = r;                                                                            \
+                         }                                                                                          \
+                         NSString *status = err != NULL ? @"CRASHED" : response.result.uppercaseString;             \
+                         NSLog(@"runDartTest(\"%@\"): call finished, test result: %@", dartTestName, status);       \
+                       }];                                                                                          \
                                                                                                                     \
-        while (!response && !error) {                                                                               \
-          [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];                        \
+          while (!response && !error) {                                                                             \
+            [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];                      \
+          }                                                                                                         \
+          if (error != nil || response == nil || ![response.result isEqualToString:@"continuation"]) {              \
+            break;                                                                                                  \
+          }                                                                                                         \
+                                                                                                                    \
+          phaseIndex = response.nextPhaseIndex;                                                                     \
+          if (phaseIndex == nil) {                                                                                  \
+            XCTFail(@"A phased Patrol test returned continuation without a next phase");                            \
+            return;                                                                                                 \
+          }                                                                                                         \
+          NSString *launchURL = response.nextPhaseLaunchUrl;                                                        \
+          XCUIApplication *app = [[XCUIApplication alloc] init];                                                    \
+          [app terminate];                                                                                          \
+          [__test_class launchPatrolAppWithServer:server launchURL:launchURL];                                      \
+          appReady = [__test_class waitForPatrolAppReadyWithServer:server];                                         \
+          XCTAssertTrue(appReady, @"Patrol app did not become ready on port %ld", (long)server.boundAppPort);       \
+          if (!appReady) {                                                                                          \
+            return;                                                                                                 \
+          }                                                                                                         \
         }                                                                                                           \
-        BOOL passed = response ? response.passed : NO;                                                              \
+        BOOL passed = response != nil && [response.result isEqualToString:@"success"];                              \
         NSString *details = response ? response.details : @"(no details - app likely crashed)";                     \
-        if (response && response.skipped) {                                                                         \
+        if (response && [response.result isEqualToString:@"skipped"]) {                                             \
           XCTSkip(@"%@", details);                                                                                  \
         }                                                                                                           \
         XCTAssertTrue(passed, @"%@", details);                                                                      \
@@ -417,6 +456,9 @@
   }                                                                                                                    \
                                                                                                                        \
   +(void)launchPatrolApp {                                                                                             \
+    [self launchPatrolAppWithURL:nil];                                                                                 \
+  }                                                                                                                    \
+  +(void)launchPatrolAppWithURL : (NSString *)launchURL {                                                              \
     _patrolStaticServer.appReady = NO;                                                                                 \
     XCUIApplication *app = [[XCUIApplication alloc] init];                                                             \
     NSMutableDictionary<NSString *, NSString *> *environment =                                                         \
@@ -426,7 +468,21 @@
     environment[@"PATROL_APP_SERVER_PORT"] =                                                                           \
         [NSString stringWithFormat:@"%ld", (long)_patrolStaticServer.boundAppPort];                                    \
     app.launchEnvironment = environment;                                                                               \
-    [app launch];                                                                                                      \
+    if (launchURL == nil) {                                                                                            \
+      [app launch];                                                                                                    \
+    } else {                                                                                                           \
+      NSURL *url = [NSURL URLWithString:launchURL];                                                                    \
+      XCTAssertNotNil(url, @"Invalid phase launch URL: %@", launchURL);                                                \
+      if (url == nil) {                                                                                                \
+        return;                                                                                                        \
+      }                                                                                                                \
+      if (@available(iOS 16.4, *)) {                                                                                   \
+        [app openURL:url];                                                                                             \
+      } else {                                                                                                         \
+        [app launch];                                                                                                  \
+        [[XCUIDevice sharedDevice].system openURL:url];                                                                \
+      }                                                                                                                \
+    }                                                                                                                  \
   }                                                                                                                    \
                                                                                                                        \
   +(void)resetPermissions {                                                                                            \
@@ -570,22 +626,51 @@
     }                                                                                                                  \
                                                                                                                        \
     __block ObjCRunDartTestResponse *response = NULL;                                                                  \
-    __block NSError *error;                                                                                            \
-    [_patrolStaticClient runDartTestWithName:dartTestName                                                              \
-                                  completion:^(ObjCRunDartTestResponse *_Nullable r, NSError *_Nullable e) {           \
-                                    if (e != NULL) {                                                                   \
-                                      error = e;                                                                       \
-                                    } else {                                                                           \
-                                      response = r;                                                                    \
-                                    }                                                                                  \
-                                  }];                                                                                  \
+    __block NSError *error = nil;                                                                                      \
+    NSNumber *phaseIndex = nil;                                                                                        \
+    while (true) {                                                                                                     \
+      response = NULL;                                                                                                 \
+      error = nil;                                                                                                     \
+      [_patrolStaticClient runDartTestWithName:dartTestName                                                            \
+                                    phaseIndex:phaseIndex                                                              \
+                                    completion:^(ObjCRunDartTestResponse *_Nullable r, NSError *_Nullable e) {         \
+                                      if (e != NULL) {                                                                 \
+                                        error = e;                                                                     \
+                                      } else {                                                                         \
+                                        response = r;                                                                  \
+                                      }                                                                                \
+                                    }];                                                                                \
                                                                                                                        \
-    while (!response && !error) {                                                                                      \
-      [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];                               \
+      while (!response && !error) {                                                                                    \
+        [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];                             \
+      }                                                                                                                \
+      if (error != nil || response == nil || ![response.result isEqualToString:@"continuation"]) {                     \
+        break;                                                                                                         \
+      }                                                                                                                \
+                                                                                                                       \
+      phaseIndex = response.nextPhaseIndex;                                                                            \
+      if (phaseIndex == nil) {                                                                                         \
+        XCTFail(@"A phased Patrol test returned continuation without a next phase");                                   \
+        return;                                                                                                        \
+      }                                                                                                                \
+      NSString *launchURL = response.nextPhaseLaunchUrl;                                                               \
+      XCUIApplication *app = [[XCUIApplication alloc] init];                                                           \
+      [app terminate];                                                                                                 \
+      [[self class] launchPatrolAppWithURL:launchURL];                                                                 \
+                                                                                                                       \
+      NSDate *phaseReadyDeadline = [NSDate dateWithTimeIntervalSinceNow:180.0];                                        \
+      while (!_patrolStaticServer.appReady) {                                                                          \
+        if ([[NSDate date] compare:phaseReadyDeadline] == NSOrderedDescending) {                                       \
+          XCTFail(@"App did not report PatrolAppService readiness on port %ld",                                        \
+                  (long)_patrolStaticServer.boundAppPort);                                                             \
+          return;                                                                                                      \
+        }                                                                                                              \
+        [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];                             \
+      }                                                                                                                \
     }                                                                                                                  \
-    BOOL passed = response ? response.passed : NO;                                                                     \
+    BOOL passed = response != nil && [response.result isEqualToString:@"success"];                                     \
     NSString *details = response ? response.details : @"(no details - app likely crashed)";                            \
-    if (response && response.skipped) {                                                                                \
+    if (response && [response.result isEqualToString:@"skipped"]) {                                                    \
       XCTSkip(@"%@", details);                                                                                         \
     }                                                                                                                  \
     XCTAssertTrue(passed, @"%@", details);                                                                             \

--- a/packages/patrol/darwin/patrol/Sources/patrol/include/PatrolIntegrationTestIosRunner.h
+++ b/packages/patrol/darwin/patrol/Sources/patrol/include/PatrolIntegrationTestIosRunner.h
@@ -59,6 +59,8 @@
       if (url == nil) {                                                                                             \
         return;                                                                                                     \
       }                                                                                                             \
+      /* iOS 16.4+: openURL cold-starts through the link. Older iOS must launch  \
+         first, then openURL — first paint is a normal start, not the deep link. */ \
       if (@available(iOS 16.4, *)) {                                                                                \
         [app openURL:url];                                                                                          \
       } else {                                                                                                      \
@@ -476,6 +478,8 @@
       if (url == nil) {                                                                                                \
         return;                                                                                                        \
       }                                                                                                                \
+      /* iOS 16.4+: openURL cold-starts through the link. Older iOS must launch       \
+         first, then openURL — first paint is a normal start, not the deep link. */    \
       if (@available(iOS 16.4, *)) {                                                                                   \
         [app openURL:url];                                                                                             \
       } else {                                                                                                         \

--- a/packages/patrol/darwin/patrol/Sources/patrol/include/PatrolIntegrationTestMacosRunner.h
+++ b/packages/patrol/darwin/patrol/Sources/patrol/include/PatrolIntegrationTestMacosRunner.h
@@ -131,7 +131,7 @@
                          status = @"CRASHED";                                                                 \
                        } else {                                                                               \
                          response = r;                                                                        \
-                         status = response.passed ? @"PASSED" : @"FAILED";                                    \
+                         status = response.result.uppercaseString;                                            \
                        }                                                                                      \
                        NSLog(@"runDartTest(\"%@\"): call finished, test result: %@", dartTestName, status);   \
                      }];                                                                                      \
@@ -140,9 +140,13 @@
         while (!response && !error) {                                                                         \
           [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];                  \
         }                                                                                                     \
-        BOOL passed = response ? response.passed : NO;                                                        \
+        if ([response.result isEqualToString:@"continuation"]) {                                              \
+          XCTFail(@"Phased Patrol tests are not supported on macOS");                                         \
+          return;                                                                                             \
+        }                                                                                                     \
+        BOOL passed = response != nil && [response.result isEqualToString:@"success"];                        \
         NSString *details = response ? response.details : @"(no details - app likely crashed)";               \
-        if (response && response.skipped) {                                                                   \
+        if (response && [response.result isEqualToString:@"skipped"]) {                                       \
           XCTSkip(@"%@", details);                                                                            \
         }                                                                                                     \
         XCTAssertTrue(passed, @"%@", details);                                                                \

--- a/packages/patrol/darwin/patrol/Sources/patrol/include/patrol.h
+++ b/packages/patrol/darwin/patrol/Sources/patrol/include/patrol.h
@@ -34,10 +34,14 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface ObjCRunDartTestResponse : NSObject
-@property(nonatomic, readonly) BOOL passed;
-@property(nonatomic, readonly) BOOL skipped;
+@property(nonatomic, readonly) NSString *result;
 @property(nonatomic, readonly, nullable) NSString *details;
-- (instancetype)initWithPassed:(BOOL)passed skipped:(BOOL)skipped details:(NSString *_Nullable)details;
+@property(nonatomic, readonly, nullable) NSNumber *nextPhaseIndex;
+@property(nonatomic, readonly, nullable) NSString *nextPhaseLaunchUrl;
+- (instancetype)initWithResult:(NSString *)result
+                       details:(NSString *_Nullable)details
+                nextPhaseIndex:(NSNumber *_Nullable)nextPhaseIndex
+            nextPhaseLaunchUrl:(NSString *_Nullable)nextPhaseLaunchUrl;
 @end
 
 @interface ObjCPatrolAppServiceClient : NSObject
@@ -46,6 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)listDartTestsWithCompletion:(void (^)(NSArray<NSDictionary *> *_Nullable tests,
                                               NSError *_Nullable error))completion;
 - (void)runDartTestWithName:(NSString *)name
+                 completion:(void (^)(ObjCRunDartTestResponse *_Nullable response, NSError *_Nullable error))completion;
+- (void)runDartTestWithName:(NSString *)name
+                 phaseIndex:(NSNumber *_Nullable)phaseIndex
                  completion:(void (^)(ObjCRunDartTestResponse *_Nullable response, NSError *_Nullable error))completion;
 @end
 

--- a/packages/patrol/lib/patrol.dart
+++ b/packages/patrol/lib/patrol.dart
@@ -11,6 +11,8 @@ export 'src/common.dart';
 export 'src/custom_finders/patrol_integration_tester.dart';
 export 'src/extensions/patrol_extension.dart';
 export 'src/native/native.dart';
+export 'src/phases.dart'
+    show PatrolAppLaunch, PatrolPhase, PatrolPhaseCallback, phases;
 export 'src/platform/android/android_automator.dart';
 export 'src/platform/android/android_automator_config.dart';
 export 'src/platform/contracts/contracts.dart'

--- a/packages/patrol/lib/src/binding.dart
+++ b/packages/patrol/lib/src/binding.dart
@@ -86,10 +86,9 @@ class PatrolBinding extends LiveTestWidgetsFlutterBinding {
           );
         }
 
-        final nameOfRequestedTest =
-            await patrolAppService.testExecutionRequested;
+        final requestedTest = await patrolAppService.testExecutionRequested;
 
-        if (nameOfRequestedTest == _currentDartTest) {
+        if (requestedTest.name == _currentDartTest) {
           if (const bool.fromEnvironment('COVERAGE_ENABLED')) {
             postEvent('waitForCoverageCollection', {
               'mainIsolateId': Service.getIsolateId(Isolate.current),

--- a/packages/patrol/lib/src/common.dart
+++ b/packages/patrol/lib/src/common.dart
@@ -7,6 +7,7 @@ import 'package:meta/meta.dart';
 import 'package:patrol/src/binding.dart';
 import 'package:patrol/src/global_state.dart' as global_state;
 import 'package:patrol/src/native/native_automator_config.dart';
+import 'package:patrol/src/phases.dart';
 import 'package:patrol/src/platform/contracts/contracts.dart';
 import 'package:patrol/src/platform/platform_automator.dart';
 import 'package:patrol_finders/patrol_finders.dart' as finders;
@@ -110,6 +111,8 @@ void patrolTest(
   LiveTestWidgetsFlutterBindingFramePolicy framePolicy =
       LiveTestWidgetsFlutterBindingFramePolicy.fullyLive,
 }) {
+  final phasedTest = patrolPhasesOf(callback);
+
   if (constants.testDiscoveryEnabled) {
     // Build-time discovery (host `flutter test`): only register the test so it
     // shows up in the group tree. Do NOT initialize PatrolBinding (Live binding,
@@ -179,19 +182,40 @@ void patrolTest(
         web: platformAutomator.web.configure,
       );
 
-      patrolLog.log(
-        TestEntry(
-          name: global_state.currentTestFullName,
-          status: TestEntryStatus.start,
-        ),
-      );
       final patrolTester = PatrolIntegrationTester(
         tester: widgetTester,
         config: config,
         platformAutomator: platformAutomator,
       );
+      var callbackToRun = callback;
+      var phaseIndex = 0;
+      if (phasedTest != null) {
+        if (constants.hotRestartEnabled) {
+          throw UnsupportedError(
+            'Phased Patrol tests are not supported in develop mode',
+          );
+        }
+        final request =
+            await patrolBinding.patrolAppService.testExecutionRequested;
+        phaseIndex = request.phaseIndex ?? 0;
+        callbackToRun = phasedTest.phaseAt(phaseIndex).callback;
+      }
+
+      if (phaseIndex == 0) {
+        patrolLog.log(
+          TestEntry(
+            name: global_state.currentTestFullName,
+            status: TestEntryStatus.start,
+          ),
+        );
+      }
+
       try {
-        await callback(patrolTester);
+        await callbackToRun(patrolTester);
+        final continuation = phasedTest?.continuationAfter(phaseIndex);
+        if (continuation != null) {
+          patrolBinding.patrolAppService.setContinuation(continuation);
+        }
       } catch (_) {
         // Capture the failing screen before teardown pumps the next frame.
         if (constants.screenshotOnFailureEnabled) {

--- a/packages/patrol/lib/src/phases.dart
+++ b/packages/patrol/lib/src/phases.dart
@@ -1,0 +1,111 @@
+import 'package:meta/meta.dart';
+import 'package:patrol/src/custom_finders/patrol_integration_tester.dart';
+
+/// A callback containing the Dart part of a Patrol test.
+typedef PatrolPhaseCallback = Future<void> Function(PatrolIntegrationTester $);
+
+/// One Dart part of a phased Patrol test.
+final class PatrolPhase {
+  /// Creates a phase with the way the app should be launched before it.
+  const PatrolPhase(
+    this.callback, {
+    this.launch = const PatrolAppLaunch.normal(),
+  });
+
+  /// The test code to execute during this phase.
+  final PatrolPhaseCallback callback;
+
+  /// How the app should be launched before this phase.
+  ///
+  /// This is ignored for the first phase, which starts normally.
+  final PatrolAppLaunch launch;
+}
+
+/// How Patrol launches the app before a phase.
+final class PatrolAppLaunch {
+  /// Launches the app using its launcher activity.
+  const PatrolAppLaunch.normal() : url = null;
+
+  /// Launches the app through [url].
+  const PatrolAppLaunch.deepLink(this.url) : assert(url != '');
+
+  /// The deep link URL, or `null` for a normal launch.
+  final String? url;
+}
+
+/// Metadata attached to the callback returned by [phases].
+@internal
+final class PatrolPhases {
+  PatrolPhases(List<PatrolPhase> phases) : phases = List.unmodifiable(phases);
+
+  /// The phases in declaration order.
+  final List<PatrolPhase> phases;
+
+  /// Returns the phase requested by the native runner.
+  PatrolPhase phaseAt(int index) {
+    if (index < 0 || index >= phases.length) {
+      throw RangeError.index(index, phases, 'index');
+    }
+    return phases[index];
+  }
+
+  /// Describes how to restart the app for the phase after [phaseIndex].
+  PatrolPhaseContinuation? continuationAfter(int phaseIndex) {
+    phaseAt(phaseIndex);
+    final nextPhaseIndex = phaseIndex + 1;
+    if (nextPhaseIndex >= phases.length) {
+      return null;
+    }
+
+    return PatrolPhaseContinuation(
+      nextPhaseIndex: nextPhaseIndex,
+      launchUrl: phases[nextPhaseIndex].launch.url,
+    );
+  }
+}
+
+/// Restart information returned after a Dart phase completes.
+@internal
+final class PatrolPhaseContinuation {
+  PatrolPhaseContinuation({
+    required this.nextPhaseIndex,
+    required this.launchUrl,
+  });
+
+  /// The next Dart phase.
+  final int nextPhaseIndex;
+
+  /// The deep link used to launch it, or `null` for a normal launch.
+  final String? launchUrl;
+}
+
+final _phasesByCallback = Expando<PatrolPhases>('Patrol phased test');
+
+/// Creates a phased body accepted by `patrolTest`.
+///
+/// `patrolTest` reads the phase metadata attached to the returned callback and
+/// runs only the Dart phase requested by the native runner. Calling the
+/// returned callback directly is unsupported.
+PatrolPhaseCallback phases(List<PatrolPhase> phases) {
+  if (phases.isEmpty) {
+    throw ArgumentError.value(
+      phases,
+      'phases',
+      'A phased test must contain at least one phase',
+    );
+  }
+  Future<void> callback(PatrolIntegrationTester $) {
+    throw UnsupportedError(
+      'A phased Patrol test body can only be executed by patrolTest',
+    );
+  }
+
+  _phasesByCallback[callback] = PatrolPhases(phases);
+  return callback;
+}
+
+/// Returns phased-test metadata attached to [callback], if any.
+@internal
+PatrolPhases? patrolPhasesOf(PatrolPhaseCallback callback) {
+  return _phasesByCallback[callback];
+}

--- a/packages/patrol/lib/src/phases.dart
+++ b/packages/patrol/lib/src/phases.dart
@@ -27,7 +27,7 @@ final class PatrolAppLaunch {
   const PatrolAppLaunch.normal() : url = null;
 
   /// Launches the app through [url].
-  const PatrolAppLaunch.deepLink(this.url) : assert(url != '');
+  const PatrolAppLaunch.deepLink(String this.url) : assert(url != '');
 
   /// The deep link URL, or `null` for a normal launch.
   final String? url;

--- a/packages/patrol/lib/src/platform/contracts/contracts.dart
+++ b/packages/patrol/lib/src/platform/contracts/contracts.dart
@@ -20,7 +20,8 @@ enum GroupEntryType {
 enum RunDartTestResponseResult {
   success('success'),
   skipped('skipped'),
-  failure('failure');
+  failure('failure'),
+  continuation('continuation');
 
   const RunDartTestResponseResult(this.value);
   final String value;
@@ -259,33 +260,46 @@ class ListDartTestsResponse with Equatable {
 
 @JsonSerializable()
 class RunDartTestRequest with Equatable {
-  const RunDartTestRequest({required this.name});
+  const RunDartTestRequest({required this.name, this.phaseIndex});
 
   factory RunDartTestRequest.fromJson(Map<String, dynamic> json) =>
       _$RunDartTestRequestFromJson(json);
 
   final String name;
+  final int? phaseIndex;
 
   Map<String, dynamic> toJson() => _$RunDartTestRequestToJson(this);
 
   @override
-  List<Object?> get props => [name];
+  List<Object?> get props => [name, phaseIndex];
 }
 
 @JsonSerializable()
 class RunDartTestResponse with Equatable {
-  const RunDartTestResponse({required this.result, this.details});
+  const RunDartTestResponse({
+    required this.result,
+    this.details,
+    this.nextPhaseIndex,
+    this.nextPhaseLaunchUrl,
+  });
 
   factory RunDartTestResponse.fromJson(Map<String, dynamic> json) =>
       _$RunDartTestResponseFromJson(json);
 
   final RunDartTestResponseResult result;
   final String? details;
+  final int? nextPhaseIndex;
+  final String? nextPhaseLaunchUrl;
 
   Map<String, dynamic> toJson() => _$RunDartTestResponseToJson(this);
 
   @override
-  List<Object?> get props => [result, details];
+  List<Object?> get props => [
+    result,
+    details,
+    nextPhaseIndex,
+    nextPhaseLaunchUrl,
+  ];
 }
 
 @JsonSerializable()

--- a/packages/patrol/lib/src/platform/contracts/contracts.g.dart
+++ b/packages/patrol/lib/src/platform/contracts/contracts.g.dart
@@ -42,15 +42,20 @@ Map<String, dynamic> _$ListDartTestsResponseToJson(
 ) => <String, dynamic>{'group': instance.group.toJson()};
 
 RunDartTestRequest _$RunDartTestRequestFromJson(Map<String, dynamic> json) =>
-    RunDartTestRequest(name: json['name'] as String);
+    RunDartTestRequest(
+      name: json['name'] as String,
+      phaseIndex: (json['phaseIndex'] as num?)?.toInt(),
+    );
 
 Map<String, dynamic> _$RunDartTestRequestToJson(RunDartTestRequest instance) =>
-    <String, dynamic>{'name': instance.name};
+    <String, dynamic>{'name': instance.name, 'phaseIndex': instance.phaseIndex};
 
 RunDartTestResponse _$RunDartTestResponseFromJson(Map<String, dynamic> json) =>
     RunDartTestResponse(
       result: $enumDecode(_$RunDartTestResponseResultEnumMap, json['result']),
       details: json['details'] as String?,
+      nextPhaseIndex: (json['nextPhaseIndex'] as num?)?.toInt(),
+      nextPhaseLaunchUrl: json['nextPhaseLaunchUrl'] as String?,
     );
 
 Map<String, dynamic> _$RunDartTestResponseToJson(
@@ -58,12 +63,15 @@ Map<String, dynamic> _$RunDartTestResponseToJson(
 ) => <String, dynamic>{
   'result': _$RunDartTestResponseResultEnumMap[instance.result]!,
   'details': instance.details,
+  'nextPhaseIndex': instance.nextPhaseIndex,
+  'nextPhaseLaunchUrl': instance.nextPhaseLaunchUrl,
 };
 
 const _$RunDartTestResponseResultEnumMap = {
   RunDartTestResponseResult.success: 'success',
   RunDartTestResponseResult.skipped: 'skipped',
   RunDartTestResponseResult.failure: 'failure',
+  RunDartTestResponseResult.continuation: 'continuation',
 };
 
 ConfigureRequest _$ConfigureRequestFromJson(Map<String, dynamic> json) =>

--- a/packages/patrol/lib/src/platform/mobile/patrol_app_service_io.dart
+++ b/packages/patrol/lib/src/platform/mobile/patrol_app_service_io.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:patrol/patrol.dart';
 import 'package:patrol/src/common.dart';
+import 'package:patrol/src/phases.dart';
 import 'package:patrol/src/platform/contracts/contracts.dart';
 import 'package:patrol/src/platform/contracts/patrol_app_service_server.dart';
 import 'package:patrol/src/platform/mobile/patrol_runtime_ports.dart';
@@ -16,10 +17,15 @@ import 'package:shelf/shelf_io.dart' as shelf_io;
 const _idleTimeout = Duration(hours: 2);
 
 class _TestExecutionResult {
-  const _TestExecutionResult({required this.passed, required this.details});
+  const _TestExecutionResult({
+    required this.passed,
+    required this.details,
+    required this.continuation,
+  });
 
   final bool passed;
   final String? details;
+  final PatrolPhaseContinuation? continuation;
 }
 
 /// Initializes the app service.
@@ -75,15 +81,17 @@ class PatrolAppService extends PatrolAppServiceServer {
   /// bundled Dart test file.
   final DartGroupEntry topLevelDartTestGroup;
 
-  /// A completer that completes with the name of the Dart test file that was
-  /// requested to execute by the native side.
-  final _testExecutionRequested = Completer<String>();
+  /// A completer that completes with the Dart test request made by the native
+  /// side.
+  final _testExecutionRequested = Completer<RunDartTestRequest>();
 
-  /// A future that completes with the name of the Dart test file that was
-  /// requested to execute by the native side.
-  Future<String> get testExecutionRequested => _testExecutionRequested.future;
+  /// A future that completes with the Dart test request made by the native
+  /// side.
+  Future<RunDartTestRequest> get testExecutionRequested =>
+      _testExecutionRequested.future;
 
   final _testExecutionCompleted = Completer<_TestExecutionResult>();
+  PatrolPhaseContinuation? _continuation;
 
   /// A future that completes when the Dart test file (whose execution was
   /// requested by the native side) completes.
@@ -94,6 +102,11 @@ class PatrolAppService extends PatrolAppServiceServer {
   }
 
   final _patrolLog = PatrolLogWriter();
+
+  /// Sets the native work that should follow the currently running Dart phase.
+  void setContinuation(PatrolPhaseContinuation continuation) {
+    _continuation = continuation;
+  }
 
   /// Marks [dartFileName] as completed with the given [passed] status.
   ///
@@ -110,15 +123,19 @@ class PatrolAppService extends PatrolAppServiceServer {
       'Tried to mark a test as completed, but no tests were requested to run',
     );
 
-    final requestedDartTestName = await testExecutionRequested;
+    final request = await testExecutionRequested;
     assert(
-      requestedDartTestName == dartFileName,
+      request.name == dartFileName,
       'Tried to mark test $dartFileName as completed, but the test '
-      'that was most recently requested to run was $requestedDartTestName',
+      'that was most recently requested to run was ${request.name}',
     );
 
     _testExecutionCompleted.complete(
-      _TestExecutionResult(passed: passed, details: details),
+      _TestExecutionResult(
+        passed: passed,
+        details: details,
+        continuation: passed ? _continuation : null,
+      ),
     );
   }
 
@@ -134,14 +151,14 @@ class PatrolAppService extends PatrolAppServiceServer {
   Future<bool> waitForExecutionRequest(String dartTest) async {
     print('PatrolAppService: registered "$dartTest"');
 
-    final requestedDartTest = await testExecutionRequested;
-    if (requestedDartTest != dartTest) {
+    final request = await testExecutionRequested;
+    if (request.name != dartTest) {
       // If the requested Dart test is not the one we're waiting for now, it
       // means that dartTest was already executed. Return false so that callers
       // can skip the already executed test.
 
       print(
-        'PatrolAppService: registered test "$dartTest" was not matched by requested test "$requestedDartTest"',
+        'PatrolAppService: registered test "$dartTest" was not matched by requested test "${request.name}"',
       );
 
       return false;
@@ -231,7 +248,7 @@ class PatrolAppService extends PatrolAppServiceServer {
       );
     }
 
-    _testExecutionRequested.complete(request.name);
+    _testExecutionRequested.complete(request);
 
     final testExecutionResult = await testExecutionCompleted;
 
@@ -242,17 +259,22 @@ class PatrolAppService extends PatrolAppServiceServer {
       testExecutionResult.details
           ?.split('\n')
           .forEach((e) => _patrolLog.log(ErrorEntry(message: e)));
-    } else {
+    } else if (testExecutionResult.continuation == null) {
       _patrolLog.log(
         TestEntry(name: request.name, status: TestEntryStatus.success),
       );
     }
 
+    final continuation = testExecutionResult.continuation;
     return RunDartTestResponse(
-      result: testExecutionResult.passed
-          ? RunDartTestResponseResult.success
-          : RunDartTestResponseResult.failure,
+      result: !testExecutionResult.passed
+          ? RunDartTestResponseResult.failure
+          : continuation != null
+          ? RunDartTestResponseResult.continuation
+          : RunDartTestResponseResult.success,
       details: testExecutionResult.details,
+      nextPhaseIndex: continuation?.nextPhaseIndex,
+      nextPhaseLaunchUrl: continuation?.launchUrl,
     );
   }
 }

--- a/packages/patrol/lib/src/platform/web/patrol_app_service_web.dart
+++ b/packages/patrol/lib/src/platform/web/patrol_app_service_web.dart
@@ -218,21 +218,29 @@ class PatrolAppService {
       result.details
           ?.split('\n')
           .forEach((e) => _patrolLog.log(ErrorEntry(message: e)));
-    } else if (result.continuation == null) {
-      _patrolLog.log(
-        TestEntry(name: request.name, status: TestEntryStatus.success),
+      return RunDartTestResponse(
+        result: RunDartTestResponseResult.failure,
+        details: result.details,
       );
     }
-    final continuation = result.continuation;
-    return RunDartTestResponse(
-      result: !result.passed
-          ? RunDartTestResponseResult.failure
-          : continuation != null
-          ? RunDartTestResponseResult.continuation
-          : RunDartTestResponseResult.success,
-      details: result.details,
-      nextPhaseIndex: continuation?.nextPhaseIndex,
-      nextPhaseLaunchUrl: continuation?.launchUrl,
+
+    // Playwright only fails on `failure`, and web has no process-kill loop.
+    if (result.continuation != null) {
+      const details = 'Phased Patrol tests are not supported on web';
+      _patrolLog
+        ..log(TestEntry(name: request.name, status: TestEntryStatus.failure))
+        ..log(ErrorEntry(message: details));
+      return const RunDartTestResponse(
+        result: RunDartTestResponseResult.failure,
+        details: details,
+      );
+    }
+
+    _patrolLog.log(
+      TestEntry(name: request.name, status: TestEntryStatus.success),
+    );
+    return const RunDartTestResponse(
+      result: RunDartTestResponseResult.success,
     );
   }
 }

--- a/packages/patrol/lib/src/platform/web/patrol_app_service_web.dart
+++ b/packages/patrol/lib/src/platform/web/patrol_app_service_web.dart
@@ -11,14 +11,20 @@ library;
 import 'dart:async';
 import 'dart:js_interop';
 
+import 'package:patrol/src/phases.dart';
 import 'package:patrol/src/platform/contracts/contracts.dart';
 import 'package:patrol_log/patrol_log.dart';
 
 class _TestExecutionResult {
-  const _TestExecutionResult({required this.passed, required this.details});
+  const _TestExecutionResult({
+    required this.passed,
+    required this.details,
+    required this.continuation,
+  });
 
   final bool passed;
   final String? details;
+  final PatrolPhaseContinuation? continuation;
 }
 
 @JS()
@@ -142,13 +148,14 @@ class PatrolAppService {
   /// bundled Dart test file.
   final DartGroupEntry topLevelDartTestGroup;
 
-  final _testExecutionRequested = Completer<String>();
+  final _testExecutionRequested = Completer<RunDartTestRequest>();
 
-  /// A future that completes with the name of the Dart test file that was
-  /// requested to execute.
-  Future<String> get testExecutionRequested => _testExecutionRequested.future;
+  /// A future that completes with the Dart test request.
+  Future<RunDartTestRequest> get testExecutionRequested =>
+      _testExecutionRequested.future;
 
   final _testExecutionCompleted = Completer<_TestExecutionResult>();
+  PatrolPhaseContinuation? _continuation;
 
   /// A future that completes when the Dart test file (whose execution was
   /// requested) completes.
@@ -159,6 +166,11 @@ class PatrolAppService {
 
   final _patrolLog = PatrolLogWriter();
 
+  /// Sets the native work that should follow the currently running Dart phase.
+  void setContinuation(PatrolPhaseContinuation continuation) {
+    _continuation = continuation;
+  }
+
   /// Marks [dartFileName] as completed with the given [passed] status.
   ///
   /// If an exception was thrown during the test, [details] should contain the
@@ -168,10 +180,14 @@ class PatrolAppService {
     required bool passed,
     required String? details,
   }) async {
-    final requestedDartTestName = await testExecutionRequested;
-    assert(requestedDartTestName == dartFileName);
+    final request = await testExecutionRequested;
+    assert(request.name == dartFileName);
     _testExecutionCompleted.complete(
-      _TestExecutionResult(passed: passed, details: details),
+      _TestExecutionResult(
+        passed: passed,
+        details: details,
+        continuation: passed ? _continuation : null,
+      ),
     );
   }
 
@@ -182,8 +198,8 @@ class PatrolAppService {
   /// It's used inside of `patrolTest` to halt execution of test body until
   /// [runDartTest] is called.
   Future<bool> waitForExecutionRequest(String dartTest) async {
-    final requestedDartTest = await testExecutionRequested;
-    return requestedDartTest == dartTest;
+    final request = await testExecutionRequested;
+    return request.name == dartTest;
   }
 
   /// Returns the list of Dart tests.
@@ -193,7 +209,7 @@ class PatrolAppService {
 
   /// Runs a Dart test with the given [request].
   Future<RunDartTestResponse> runDartTest(RunDartTestRequest request) async {
-    _testExecutionRequested.complete(request.name);
+    _testExecutionRequested.complete(request);
     final result = await testExecutionCompleted;
     if (!result.passed) {
       _patrolLog.log(
@@ -202,16 +218,21 @@ class PatrolAppService {
       result.details
           ?.split('\n')
           .forEach((e) => _patrolLog.log(ErrorEntry(message: e)));
-    } else {
+    } else if (result.continuation == null) {
       _patrolLog.log(
         TestEntry(name: request.name, status: TestEntryStatus.success),
       );
     }
+    final continuation = result.continuation;
     return RunDartTestResponse(
-      result: result.passed
-          ? RunDartTestResponseResult.success
-          : RunDartTestResponseResult.failure,
+      result: !result.passed
+          ? RunDartTestResponseResult.failure
+          : continuation != null
+          ? RunDartTestResponseResult.continuation
+          : RunDartTestResponseResult.success,
       details: result.details,
+      nextPhaseIndex: continuation?.nextPhaseIndex,
+      nextPhaseLaunchUrl: continuation?.launchUrl,
     );
   }
 }

--- a/packages/patrol/test/phases_test.dart
+++ b/packages/patrol/test/phases_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+import 'package:patrol/src/phases.dart' show patrolPhasesOf;
+import 'package:patrol/src/platform/contracts/contracts.dart';
+
+void main() {
+  group('phases()', () {
+    test('attaches an immutable phase definition to its callback', () {
+      final declaredPhases = <PatrolPhase>[
+        PatrolPhase((_) => Future.value()),
+        PatrolPhase(
+          (_) => Future.value(),
+          launch: const PatrolAppLaunch.deepLink('patrol://settings'),
+        ),
+      ];
+
+      final callback = phases(declaredPhases);
+      final definition = patrolPhasesOf(callback);
+
+      expect(definition, isNotNull);
+      expect(definition!.phases, hasLength(2));
+
+      final continuation = definition.continuationAfter(0);
+      expect(continuation, isNotNull);
+      expect(continuation!.nextPhaseIndex, 1);
+      expect(continuation.launchUrl, 'patrol://settings');
+      expect(definition.continuationAfter(1), isNull);
+
+      declaredPhases.clear();
+      expect(definition.phases, hasLength(2));
+      expect(
+        () => definition.phases.add(PatrolPhase((_) => Future.value())),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('rejects an empty phase list', () {
+      expect(() => phases([]), throwsArgumentError);
+    });
+  });
+
+  test('continuation response survives JSON serialization', () {
+    const response = RunDartTestResponse(
+      result: RunDartTestResponseResult.continuation,
+      nextPhaseIndex: 2,
+      nextPhaseLaunchUrl: 'patrol://settings',
+    );
+
+    expect(RunDartTestResponse.fromJson(response.toJson()), response);
+  });
+}

--- a/packages/patrol_devtools_extension/lib/api/contracts.dart
+++ b/packages/patrol_devtools_extension/lib/api/contracts.dart
@@ -19,7 +19,8 @@ enum GroupEntryType {
 enum RunDartTestResponseResult {
   success('success'),
   skipped('skipped'),
-  failure('failure');
+  failure('failure'),
+  continuation('continuation');
 
   const RunDartTestResponseResult(this.value);
   final String value;
@@ -258,33 +259,46 @@ class ListDartTestsResponse with Equatable {
 
 @JsonSerializable()
 class RunDartTestRequest with Equatable {
-  const RunDartTestRequest({required this.name});
+  const RunDartTestRequest({required this.name, this.phaseIndex});
 
   factory RunDartTestRequest.fromJson(Map<String, dynamic> json) =>
       _$RunDartTestRequestFromJson(json);
 
   final String name;
+  final int? phaseIndex;
 
   Map<String, dynamic> toJson() => _$RunDartTestRequestToJson(this);
 
   @override
-  List<Object?> get props => [name];
+  List<Object?> get props => [name, phaseIndex];
 }
 
 @JsonSerializable()
 class RunDartTestResponse with Equatable {
-  const RunDartTestResponse({required this.result, this.details});
+  const RunDartTestResponse({
+    required this.result,
+    this.details,
+    this.nextPhaseIndex,
+    this.nextPhaseLaunchUrl,
+  });
 
   factory RunDartTestResponse.fromJson(Map<String, dynamic> json) =>
       _$RunDartTestResponseFromJson(json);
 
   final RunDartTestResponseResult result;
   final String? details;
+  final int? nextPhaseIndex;
+  final String? nextPhaseLaunchUrl;
 
   Map<String, dynamic> toJson() => _$RunDartTestResponseToJson(this);
 
   @override
-  List<Object?> get props => [result, details];
+  List<Object?> get props => [
+    result,
+    details,
+    nextPhaseIndex,
+    nextPhaseLaunchUrl,
+  ];
 }
 
 @JsonSerializable()

--- a/packages/patrol_devtools_extension/lib/api/contracts.g.dart
+++ b/packages/patrol_devtools_extension/lib/api/contracts.g.dart
@@ -42,15 +42,20 @@ Map<String, dynamic> _$ListDartTestsResponseToJson(
 ) => <String, dynamic>{'group': instance.group.toJson()};
 
 RunDartTestRequest _$RunDartTestRequestFromJson(Map<String, dynamic> json) =>
-    RunDartTestRequest(name: json['name'] as String);
+    RunDartTestRequest(
+      name: json['name'] as String,
+      phaseIndex: (json['phaseIndex'] as num?)?.toInt(),
+    );
 
 Map<String, dynamic> _$RunDartTestRequestToJson(RunDartTestRequest instance) =>
-    <String, dynamic>{'name': instance.name};
+    <String, dynamic>{'name': instance.name, 'phaseIndex': instance.phaseIndex};
 
 RunDartTestResponse _$RunDartTestResponseFromJson(Map<String, dynamic> json) =>
     RunDartTestResponse(
       result: $enumDecode(_$RunDartTestResponseResultEnumMap, json['result']),
       details: json['details'] as String?,
+      nextPhaseIndex: (json['nextPhaseIndex'] as num?)?.toInt(),
+      nextPhaseLaunchUrl: json['nextPhaseLaunchUrl'] as String?,
     );
 
 Map<String, dynamic> _$RunDartTestResponseToJson(
@@ -58,12 +63,15 @@ Map<String, dynamic> _$RunDartTestResponseToJson(
 ) => <String, dynamic>{
   'result': _$RunDartTestResponseResultEnumMap[instance.result]!,
   'details': instance.details,
+  'nextPhaseIndex': instance.nextPhaseIndex,
+  'nextPhaseLaunchUrl': instance.nextPhaseLaunchUrl,
 };
 
 const _$RunDartTestResponseResultEnumMap = {
   RunDartTestResponseResult.success: 'success',
   RunDartTestResponseResult.skipped: 'skipped',
   RunDartTestResponseResult.failure: 'failure',
+  RunDartTestResponseResult.continuation: 'continuation',
 };
 
 ConfigureRequest _$ConfigureRequestFromJson(Map<String, dynamic> json) =>

--- a/schema.dart
+++ b/schema.dart
@@ -21,15 +21,18 @@ class ListDartTestsResponse {
   late DartGroupEntry group;
 }
 
-enum RunDartTestResponseResult { success, skipped, failure }
+enum RunDartTestResponseResult { success, skipped, failure, continuation }
 
 class RunDartTestRequest {
   late String name;
+  int? phaseIndex;
 }
 
 class RunDartTestResponse {
   late RunDartTestResponseResult result;
   String? details;
+  int? nextPhaseIndex;
+  String? nextPhaseLaunchUrl;
 }
 
 abstract class PatrolAppService<IOSClient, AndroidClient, DartServer> {


### PR DESCRIPTION
Until now, a Patrol test was one Dart callback in one app process. This PR lets a
test declare consecutive Dart phases. When one phase finishes, the native runner
kills the app and starts a new process for the next phase. Existing
single-callback tests are unchanged.
Stacked on https://github.com/leancodepl/patrol/pull/3280 — Android needs the
self-instrumenting test APK so the runner can outlive the app it kills.
Closes https://github.com/leancodepl/patrol/issues/1374
## Why
- **A test can continue after a real process death.** State that lived only in
  memory is gone. That is different from `openApp` / `openUrl` while the process
  is still alive.
- **Relaunch can be a normal start or a deep link.** Later phases can pass
  `launch: PatrolAppLaunch.deepLink(...)`.
## How it works
```dart
patrol(
  'restarts the app between phases',
  phases([
    PatrolPhase(($) async { /* first process */ }),
    PatrolPhase(($) async { /* after kill + relaunch */ }),
    PatrolPhase(
      ($) async { /* after kill + open via URL */ },
      launch: PatrolAppLaunch.deepLink('https://example.com/path'),
    ),
  ]),
);
```
- After a phase, Dart returns `continuation` with the next index and optional URL.
- Android and iOS loop: wait for the result → terminate →
  launch (launcher or `ACTION_VIEW` / `openURL`) → wait until the app is ready →
  run the next phase. The test passes only if Dart reports `success` after the
  last phase.

## Note for review
- Commits are split:
  1. **Dart + contract** — `phases()` / `PatrolPhase` / `PatrolAppLaunch`, and
     `continuation` / `phaseIndex` / next-launch URL on the app service.
  2. **Android** — continuation loop in the JUnit runner. Phased tests **throw**
     on the old in-app `androidTest` layout; they need `:patrolTest` from #3280.
  3. **iOS + example** — same loop in the iOS runner, plus the restart e2e.